### PR TITLE
Add entries for graphire4 6x8 tablet

### DIFF
--- a/data/graphire4-6x8.tablet
+++ b/data/graphire4-6x8.tablet
@@ -1,0 +1,33 @@
+# Wacom
+# Graphire4 6x8
+# CTE-640
+#
+# Button Map:
+# (A=1, B=2, C=3, ...)
+#
+#               AA  BB
+#      *----------------------*
+#      |                      |
+#      |                      |
+#      |                      |
+#      |        TABLET        |
+#      |                      |
+#      |                      |
+#      |                      |
+#      *----------------------*
+#
+[Device]
+Name=Wacom Graphire4 6x8
+DeviceMatch=usb:056a:0016
+Class=Graphire
+Width=8
+Height=6
+Layout=graphire4-6x8.svg
+
+[Features]
+Stylus=true
+Buttons=2
+
+[Buttons]
+Top=A;B
+EvdevCodes=0x116;0x115

--- a/data/layouts/graphire4-6x8.svg
+++ b/data/layouts/graphire4-6x8.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!--
+   Designed after data from http://www.wacom-asia.com/download/manuals/G4_QSG_EN.pdf
+   Size and positions of controls may not be accurate
+ -->
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
+   id="graphire4-4x5"
+   width="208"
+   height="204">
+  <title
+     id="title">Wacom Graphire4 4x5</title>
+  <g>
+    <rect
+       id="ButtonA"
+       class="A Button"
+       rx=".5"
+       ry=".5"
+       x="55"
+       y="24"
+       width="36"
+       height="10" />
+    <path
+       id="LeaderA"
+       class="A Leader"
+       d="M 73 36 l -23 23 l 0 10 m -5 0 l 10 0" />
+    <text
+       id="LabelA"
+       class="A Label"
+       x="50"
+       y="79"
+       style="text-anchor:middle;">A</text>
+  </g>
+  <rect
+     rx="1"
+     ry="1"
+     x="92"
+     y="25"
+     width="24"
+     height="9" />
+  <g>
+    <rect
+       id="ButtonB"
+       class="B Button"
+       rx=".5"
+       ry=".5"
+       x="117"
+       y="24"
+       width="36"
+       height="10" />
+    <path
+       id="LeaderB"
+       class="B Leader"
+       d="M 135 36 l 23 23 l 0 10 m -5 0 l 10 0" />
+    <text
+       id="LabelB"
+       class="B Label"
+       x="158"
+       y="79"
+       style="text-anchor:middle;">B</text>
+  </g>
+</svg>


### PR DESCRIPTION
This data was copied from the graphire4 4x5 tablet data file with the obvious changes made wrt USB ID and size.

I am unsure, however, if this is entirely correct. eg the data file says 2 buttons, but the mouse instrument has 3 buttons. Empirically the mouse left button seems to trigger same event as a stylus tap,  right button triggers same event as the bottom stylus button, and middle button triggers same event as top stylus button.  

The 2 buttons on the tablet itself though don't generate any button events under wayland. The wheel scroll on the tablet and mouse also don't generate anything.  So perhaps I'm missing some key data in this file ? 
