### PR TITLE
Don't double-free of the name during matching

### DIFF
--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -544,12 +544,12 @@ libwacom_new_from_path(const WacomDeviceDatabase *db, const char *path, WacomFal
 	libwacom_update_match(ret, match);
 	libwacom_match_destroy(match);
 
-	g_free (name);
-
 	if (device) {
 		/* if unset, use the kernel flags. Could be unset as well. */
 		if (ret->integration_flags == WACOM_DEVICE_INTEGRATED_UNSET)
 			ret->integration_flags = integration_flags;
+
+		g_free (name);
 
 		return ret;
 	}


### PR DESCRIPTION
The name is freed a few lines down as we fall through to the 'bail:' label.
The only exception is when we actually return the device, that's where we need
to free it manually.

This is just to shut up coverity, this code can only be triggered by supplying
an invalid WacomFallbackFlag.