### PR TITLE
libwacom.c :: compare_matches: fix nested loop

### DIFF
--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -364,7 +364,7 @@ compare_matches(const WacomDevice *a, const WacomDevice *b)
 
 	for (match_a = ma; *match_a; match_a++) {
 		int found = 0;
-		for (match_b = mb; !found && *mb; mb++) {
+		for (match_b = mb; !found && *match_b; match_b++) {
 			if (strcmp((*match_a)->match, (*match_b)->match) == 0)
 				found = 1;
 		}


### PR DESCRIPTION
The nested loop of this comparison function looked malformed, 
as it was always comparing only against the first match by incrementing and comparing to the wrong variable.

So I decided to propose this change.