### PR TITLE
data: Add ISDv4 502A (Toshiba Portege X20W-D Convertible and Toshiba TruPen)

### DIFF
--- a/data/isdv4-502a.tablet
+++ b/data/isdv4-502a.tablet
@@ -1,0 +1,14 @@
+# Toshiba Portege X20W-D Convertible and Toshiba TruPen
+
+[Device]
+Name=Wacom ISDv4 50a2
+DeviceMatch=usb:056a:50a2
+Class=ISDV4
+Width=11
+Height=6
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
Add support for the Toshiba Portege X20W-D Convertible and Toshiba TruPen