### PR TITLE
Add support for EDID information for integrated tablets

### DIFF
--- a/data/dell-canvas-27.tablet
+++ b/data/dell-canvas-27.tablet
@@ -29,6 +29,7 @@ Height=13
 # No pad buttons, so no layout
 Styli=0xffffd;
 IntegratedIn=Display
+EDIDMatch=DEL:*:*:Dell KV2718D;*:*:*:Dell KV2718D
 
 [Features]
 Stylus=true

--- a/data/wacom.example
+++ b/data/wacom.example
@@ -97,6 +97,42 @@ IntegratedIn=Display;System
 # Filename of the SVG representing this tablet. Only needed for tablets with
 # pad buttons.
 Layout=bamboo-16fg-m-pt.svg
+
+# EDID information if IntegratedIn is Display or System.
+# These are the 8 bytes in the EDID 1.4 struct comprising manufacturer ID,
+# product code and serial number. For reference, edid-decode output:
+# Extracted contents:
+# header:          00 ff ff ff ff ff ff 00
+# serial number:   10 ac 12 ab 4c 56 4a 30 16 16...
+#                  ^^^^^ ^^^^^ ^^^^^^^^^^^
+#                   Man   Prod   Serial
+#
+# The ProductName is separate in the EDID Other Monitor Descriptors as code
+# 0xFC.
+#
+# A match group is defined as string in the format: <Man>:<Prod>:<Name>:<Serial>.
+#
+# Manufacturer ID: a 3-byte string, e.g. DEL. These are three 5-bit chars from
+#                  the 15 least-significant bits of the first two bytes in the
+#                  EDID struct where 'A' == 1, 'B' == 2, etc. See the EDID
+#                  documentation. Example:
+#                  DEL == (4 << 10) | (5 << 5) | 12 == 0x10ac
+# Product code: a 4-character (16-bit) hex string in little endian order,
+#                 e.g. 12ab
+# Serial number: a 8-character (32-bit) hex string in little endian order,
+#                e.g. 4c564a30
+# Name: a string length 13 or less (shell globs supported)
+#
+# Any or all fields can be omitted using a literal '*'.
+#
+# The EDIDMatch contains one or more match groups, separated by
+# semicolons, e.g.
+# EDIDMatch=DEL:12ab:*:*;LEN:*:*:Lenovo Some Monitor;*:1234:01020304:*foo*:
+#
+# EDIDMatches are not exclusive, multiple tablets may have the same
+# EDIDMatch entries.
+EDIDMatch=DEL:12ab:*:*
+
 # Styli
 #
 # This is a list of stylus IDs supported by the tablet. Non-Wacom devices

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -32,6 +32,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 #if defined(__GNUC__) && ((__GNUC__ * 100 + __GNUC_MINOR__) >= 301)
 #define LIBWACOM_DEPRECATED  __attribute__((deprecated))
@@ -91,6 +92,8 @@ typedef struct _WacomStylus WacomStylus;
 typedef struct _WacomError WacomError;
 
 typedef struct _WacomDeviceDatabase WacomDeviceDatabase;
+
+typedef struct _WacomEDID WacomEDID;
 
 #define WACOM_STYLUS_FALLBACK_ID 0xfffff
 #define WACOM_ERASER_FALLBACK_ID 0xffffe
@@ -701,6 +704,74 @@ WacomBusType libwacom_match_get_bustype(const WacomMatch *match);
 uint32_t libwacom_match_get_product_id(const WacomMatch *match);
 uint32_t libwacom_match_get_vendor_id(const WacomMatch *match);
 const char* libwacom_match_get_match_string(const WacomMatch *match);
+
+/**
+ * Return true if the given EDID matches the device, false otherwise.
+ *
+ * Use libwacom_edid_set_manufacturer_id(), libwacom_edid_set_product_code()
+ * libwacom_edid_set_serial_number() and/or libwacom_edid_set_product_name()
+ * to fill in the information before matching. These can be omitted where
+ * the information is not available, e.g. it's possible to try to match on
+ * an EDID with only the manufacturer ID set.
+ *
+ * A WacomEDID with no information always returns false.
+ */
+bool libwacom_match_edid(WacomDevice *device,
+			 const WacomEDID *edid);
+
+/**
+ * Create a new WacomEDID struct to be used with libwacom_match_edid()
+ * When done with this struct, use libwacom_edid_destroy() to free associated
+ * memory.
+ */
+WacomEDID *libwacom_edid_new(void);
+
+/**
+ * Release the EDID struct and all associated memory.
+ */
+void libwacom_edid_destroy(WacomEDID *edid);
+
+/**
+ * Fill in the 3-character manufacturer id for this EDID.
+ *
+ * Where not set, a default "unset" value will be used during
+ * libwacom_match_edid(). This makes it possible to match on EDID with only
+ * partial information available.
+ *
+ * manufacturer_id must not be NULL and at least three bytes long. The
+ * string must be null-terminated.
+ */
+void libwacom_edid_set_manufacturer_id(WacomEDID *edid,
+				       const char *manufacturer_id);
+/**
+ * Fill in the 16-bit little endian product code for this EDID.
+ *
+ * Where not set, a default "unset" value will be used during
+ * libwacom_match_edid(). This makes it possible to match on EDID with only
+ * partial information available.
+ */
+void libwacom_edid_set_product_code(WacomEDID *edid,
+				    uint16_t product_code);
+/**
+ * Fill in the 32-bit little endian serial number for this EDID.
+ *
+ * Where not set, a default "unset" value will be used during
+ * libwacom_match_edid(). This makes it possible to match on EDID with only
+ * partial information available.
+ */
+void libwacom_edid_set_serial_number(WacomEDID *edid,
+				     uint32_t serial_number);
+/**
+ * Fill in the product name for this EDID.
+ *
+ * Where not set, a default "unset" value will be used during
+ * libwacom_match_edid(). This makes it possible to match on EDID with only
+ * partial information available.
+ *
+ * product_name must not be NULL
+ */
+void libwacom_edid_set_product_name(WacomEDID *edid,
+				    const char *product_name);
 
 /** @cond hide_from_doxygen */
 #endif /* _LIBWACOM_H_ */

--- a/libwacom/libwacom.sym
+++ b/libwacom/libwacom.sym
@@ -77,3 +77,13 @@ global:
     libwacom_stylus_get_eraser_type;
     libwacom_stylus_get_paired_ids;
 } LIBWACOM_0.33;
+
+LIBWACOM_1.6 {
+    libwacom_match_edid;
+    libwacom_edid_destroy;
+    libwacom_edid_new;
+    libwacom_edid_set_manufacturer_id;
+    libwacom_edid_set_product_code;
+    libwacom_edid_set_product_name;
+    libwacom_edid_set_serial_number;
+} LIBWACOM_1.4;

--- a/libwacom/libwacomint.h
+++ b/libwacom/libwacomint.h
@@ -34,6 +34,7 @@
 #include "libwacom.h"
 #include <stdint.h>
 #include <glib.h>
+#include <string.h>
 
 #define LIBWACOM_EXPORT __attribute__ ((visibility("default")))
 
@@ -63,6 +64,27 @@ struct _WacomMatch {
 	uint32_t product_id;
 };
 
+typedef enum {
+	WACOM_EDID_FLAG_NONE			= 0,
+	WACOM_EDID_FLAG_GLOB_MANUFACTURER	= (1 << 1),
+	WACOM_EDID_FLAG_GLOB_NAME		= (1 << 2),
+	WACOM_EDID_FLAG_GLOB_PRODUCT_CODE	= (1 << 3),
+	WACOM_EDID_FLAG_GLOB_SERIAL_NUMBER	= (1 << 4),
+
+	WACOM_EDID_FLAG_HAS_MANUFACTURER	= (1 << 10),
+	WACOM_EDID_FLAG_HAS_NAME		= (1 << 11),
+	WACOM_EDID_FLAG_HAS_PRODUCT_CODE	= (1 << 12),
+	WACOM_EDID_FLAG_HAS_SERIAL_NUMBER	= (1 << 13),
+} WacomEDIDFlags;
+
+struct _WacomEDID {
+	uint16_t product_code;
+	uint32_t serial_number;
+	char manufacturer_id[4]; /* 3 chars + null byte */
+	char product_name[14]; /* EDID: 13 bytes max + null byte */
+	uint32_t flags;
+};
+
 /* WARNING: When adding new members to this struct
  * make sure to update libwacom_copy() and
  * libwacom_print_device_description() ! */
@@ -82,6 +104,9 @@ struct _WacomDevice {
 	int num_strips;
 	uint32_t features;
 	uint32_t integration_flags;
+
+	WacomEDID *edid;
+	int num_edid;
 
 	int strips_num_modes;
 	int ring_num_modes;

--- a/test/test-load.c
+++ b/test/test-load.c
@@ -238,6 +238,51 @@ test_bamboopen(struct fixture *f, gconstpointer user_data)
 	g_assert_cmpint(libwacom_get_button_evdev_code(device, 'C'), ==, BTN_LEFT);
 	g_assert_cmpint(libwacom_get_button_evdev_code(device, 'D'), ==, BTN_RIGHT);
 	g_assert_cmpstr(libwacom_get_model_name(device), ==, "MTE-450");
+
+	for (unsigned int i = 1; i < 16; i++) {
+		WacomEDID *edid = libwacom_edid_new();
+
+		if (i & 0x1)
+			libwacom_edid_set_manufacturer_id(edid, "DEL");
+		if (i & 0x2)
+			libwacom_edid_set_product_name(edid, "KV2718D");
+		if (i & 0x4)
+			libwacom_edid_set_product_code(edid, 0x11);
+		if (i & 0x8)
+			libwacom_edid_set_serial_number(edid, 0x11);
+
+		g_assert_false(libwacom_match_edid(device, edid));
+		libwacom_edid_destroy(edid);
+	}
+
+	libwacom_destroy(device);
+}
+
+static void
+test_dellcanvas(struct fixture *f, gconstpointer user_data)
+{
+	WacomDevice *device = libwacom_new_from_name(f->db, "Dell Canvas 27", NULL);
+
+	g_assert_nonnull(device);
+	g_assert_true(libwacom_get_integration_flags(device) & WACOM_DEVICE_INTEGRATED_DISPLAY);
+	g_assert_false(libwacom_get_integration_flags(device) & WACOM_DEVICE_INTEGRATED_SYSTEM);
+
+	for (unsigned int i = 1; i < 16; i++) {
+		WacomEDID *edid = libwacom_edid_new();
+
+		if (i & 0x1)
+			libwacom_edid_set_manufacturer_id(edid, "DEL");
+		if (i & 0x2)
+			libwacom_edid_set_product_name(edid, "Dell KV2718D");
+		if (i & 0x4)
+			libwacom_edid_set_product_code(edid, 0x11);
+		if (i & 0x8)
+			libwacom_edid_set_serial_number(edid, 0x11);
+
+		g_assert_true(libwacom_match_edid(device, edid));
+		libwacom_edid_destroy(edid);
+	}
+
 	libwacom_destroy(device);
 }
 
@@ -285,6 +330,9 @@ int main(int argc, char **argv)
 		   fixture_teardown);
 	g_test_add("/load/056a:0065", struct fixture, NULL,
 		   fixture_setup, test_bamboopen,
+		   fixture_teardown);
+	g_test_add("/load/056a:4200", struct fixture, NULL,
+		   fixture_setup, test_dellcanvas,
 		   fixture_teardown);
 	g_test_add("/load/056a:WACf004", struct fixture, NULL,
 		   fixture_setup, test_wacf004,


### PR DESCRIPTION
Provide just enough data about the monitor we're integrated in to take the
guesswork out of the game for anyone who needs to map the tablet to the right
monitor.

Fixes #47 

cc @garnacho, @bentiss 