### PR TITLE
data: Add elan-264c (HP Envy x360 15-cp0xxx)

### DIFF
--- a/data/elan-264c.tablet
+++ b/data/elan-264c.tablet
@@ -1,0 +1,14 @@
+# ELAN touchscreen/pen sensor present in the HP Envy x360 Convertible 15-cp0XXX
+
+[Device]
+Name=ELAN 264C
+DeviceMatch=i2c:04f3:264c
+Class=ISDV4
+Width=14
+Height=8
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
This pull request allow displayed the elan-264c device from HP Envy x360 15-cp0xxx on Gnome Shell Wacom Tablet setting. 