### PR TITLE
Add an API to retrieve the evdev codes for the HW keys

### DIFF
--- a/data/cintiq-22hd.tablet
+++ b/data/cintiq-22hd.tablet
@@ -57,3 +57,11 @@ Touchstrip=A
 Touchstrip2=J
 # Note: no physical LEDs to show mode
 StripsNumModes=4
+
+[Keys]
+# KEY_PROG3, KEY_PROG2, KEY_PROG1
+# The "menu" button is handled by the firmware to open up the monitor
+# controls and doesn't actually generate an event
+# Menu=0xca
+Wrench=0x95
+Info=0x94

--- a/data/cintiq-22hdt.tablet
+++ b/data/cintiq-22hdt.tablet
@@ -59,3 +59,11 @@ Touchstrip=A
 Touchstrip2=J
 # Note: no physical LEDs to show mode
 StripsNumModes=4
+
+[Keys]
+# KEY_PROG3, KEY_PROG2, KEY_PROG1
+# The "menu" button is handled by the firmware to open up the monitor
+# controls and doesn't actually generate an event
+# Menu=0xca
+Wrench=0x95
+Info=0x94

--- a/data/cintiq-24hd-touch.tablet
+++ b/data/cintiq-24hd-touch.tablet
@@ -66,3 +66,9 @@ Right=I;J;K;L;M;N;O;P
 
 Ring=A;B;C
 Ring2=I;J;K
+
+[Keys]
+# KEY_PROG3, KEY_PROG2, KEY_PROG1
+Info=0xca
+Keyboard=0x95
+Touch=0x94

--- a/data/cintiq-24hd.tablet
+++ b/data/cintiq-24hd.tablet
@@ -64,3 +64,9 @@ Right=I;J;K;L;M;N;O;P
 
 Ring=A;B;C
 Ring2=I;J;K
+
+[Keys]
+# KEY_PROG3, KEY_PROG2, KEY_PROG1
+Info=0xca
+Keyboard=0x95
+Wrench=0x94

--- a/data/cintiq-27hd.tablet
+++ b/data/cintiq-27hd.tablet
@@ -20,3 +20,9 @@ Touch=false
 Buttons=0
 Ring=false
 Ring2=false
+
+[Keys]
+# KEY_PROG3, KEY_PROG2, KEY_PROG1
+Wrench=0xca
+Keyboard=0x95
+Touch=0x94

--- a/data/cintiq-pro-13.tablet
+++ b/data/cintiq-pro-13.tablet
@@ -44,3 +44,10 @@ Reversible=false
 Touch=true
 Ring=false
 Buttons=0
+
+[Keys]
+# Display switch button handled in firmware
+Wrench=0x240    # KEY_BUTTONCONFIG
+Keyboard=0x278  # KEY_ONSCREEN_KEYBOARD
+Menu=0x243      # KEY_CONTROLPANEL
+# Touch switch button sends SW_MUTE_DEVICE

--- a/data/cintiq-pro-16.tablet
+++ b/data/cintiq-pro-16.tablet
@@ -44,3 +44,10 @@ Reversible=false
 Touch=true
 Ring=false
 Buttons=0
+
+[Keys]
+# Display switch button handled in firmware
+Wrench=0x240    # KEY_BUTTONCONFIG
+Keyboard=0x278  # KEY_ONSCREEN_KEYBOARD
+Menu=0x243      # KEY_CONTROLPANEL
+# Touch switch button sends SW_MUTE_DEVICE

--- a/data/cintiq-pro-24-p.tablet
+++ b/data/cintiq-pro-24-p.tablet
@@ -43,3 +43,10 @@ Reversible=false
 Touch=false
 Ring=false
 Buttons=0
+
+[Keys]
+# Display switch button handled in firmware
+Wrench=0x240    # KEY_BUTTONCONFIG
+Keyboard=0x278  # KEY_ONSCREEN_KEYBOARD
+Menu=0x243      # KEY_CONTROLPANEL
+# Touch switch button sends SW_MUTE_DEVICE

--- a/data/cintiq-pro-24-pt.tablet
+++ b/data/cintiq-pro-24-pt.tablet
@@ -44,3 +44,10 @@ Reversible=false
 Touch=true
 Ring=false
 Buttons=0
+
+[Keys]
+# Display switch button handled in firmware
+Wrench=0x240    # KEY_BUTTONCONFIG
+Keyboard=0x278  # KEY_ONSCREEN_KEYBOARD
+Menu=0x243      # KEY_CONTROLPANEL
+# Touch switch button sends SW_MUTE_DEVICE

--- a/data/cintiq-pro-32.tablet
+++ b/data/cintiq-pro-32.tablet
@@ -44,3 +44,10 @@ Reversible=false
 Touch=true
 Ring=false
 Buttons=0
+
+[Keys]
+# Display switch button handled in firmware
+Wrench=0x240    # KEY_BUTTONCONFIG
+Keyboard=0x278  # KEY_ONSCREEN_KEYBOARD
+Menu=0x243      # KEY_CONTROLPANEL
+# Touch switch button sends SW_MUTE_DEVICE

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -216,6 +216,18 @@ typedef enum {
 } WacomStatusLEDs;
 
 /**
+  Wacom Hardware key types. These are the buttons on the top right of the
+  tablets, with icons representing the type of key.
+ */
+typedef enum {
+	WACOM_KEY_TYPE_INFO = 1,
+	WACOM_KEY_TYPE_KEYBOARD,
+	WACOM_KEY_TYPE_WRENCH,
+	WACOM_KEY_TYPE_TOUCH,
+	WACOM_KEY_TYPE_MENU,
+} WacomKeyType;
+
+/**
  * Allocate a new structure for error reporting.
  *
  * @return A newly allocated error structure or NULL if the allocation
@@ -572,6 +584,15 @@ WacomButtonFlags libwacom_get_button_flag(const WacomDevice *device,
  */
 int libwacom_get_button_evdev_code(const WacomDevice *device,
 				   char               button);
+
+/**
+ * @param device The tablet to query
+ * @param type The key to return the evdev code for
+ * @return The evdev event code sent when the key is pressed or 0 if
+ * unknown.
+ */
+int libwacom_get_key_evdev_code(const WacomDevice *device,
+				WacomKeyType       type);
 
 /**
  * Get the WacomStylus for the given tool ID.

--- a/libwacom/libwacom.sym
+++ b/libwacom/libwacom.sym
@@ -71,3 +71,8 @@ global:
 local:
         *;
 };
+
+LIBWACOM_0.34 {
+global:
+    libwacom_get_key_evdev_code;
+} LIBWACOM_0.33;

--- a/libwacom/libwacomint.h
+++ b/libwacom/libwacomint.h
@@ -43,6 +43,8 @@
 #define GENERIC_DEVICE_MATCH "generic"
 #define WACOM_DEVICE_INTEGRATED_UNSET (WACOM_DEVICE_INTEGRATED_NONE - 1U)
 
+#define N_HW_KEYS (WACOM_KEY_TYPE_MENU - WACOM_KEY_TYPE_INFO + 1)
+
 enum WacomFeature {
 	FEATURE_STYLUS		= (1 << 0),
 	FEATURE_TOUCH		= (1 << 1),
@@ -92,6 +94,8 @@ struct _WacomDevice {
 	int num_buttons;
 	WacomButtonFlags *buttons;
 	int *button_codes;
+
+	int key_codes[N_HW_KEYS];
 
 	int num_leds;
 	WacomStatusLEDs *status_leds;

--- a/test/test-load.c
+++ b/test/test-load.c
@@ -171,6 +171,18 @@ int main(void)
 	assert(libwacom_get_button_evdev_code(device, 'C') == BTN_LEFT);
 	assert(libwacom_get_button_evdev_code(device, 'D') == BTN_RIGHT);
 	assert(strcmp(libwacom_get_model_name(device), "MTE-450") == 0);
+	assert(libwacom_get_key_evdev_code(device, WACOM_KEY_TYPE_INFO) == 0);
+	assert(libwacom_get_key_evdev_code(device, WACOM_KEY_TYPE_KEYBOARD) == 0);
+	assert(libwacom_get_key_evdev_code(device, WACOM_KEY_TYPE_WRENCH) == 0);
+	assert(libwacom_get_key_evdev_code(device, WACOM_KEY_TYPE_MENU) == 0);
+	libwacom_destroy(device);
+
+	device = libwacom_new_from_name(db, "Wacom Cintiq 24HD", NULL);
+	assert(device);
+	assert(libwacom_get_key_evdev_code(device, WACOM_KEY_TYPE_INFO) == KEY_PROG3);
+	assert(libwacom_get_key_evdev_code(device, WACOM_KEY_TYPE_KEYBOARD) == KEY_PROG2);
+	assert(libwacom_get_key_evdev_code(device, WACOM_KEY_TYPE_WRENCH) == KEY_PROG1);
+	assert(libwacom_get_key_evdev_code(device, WACOM_KEY_TYPE_MENU) == 0);
 	libwacom_destroy(device);
 
 	libwacom_database_destroy (db);


### PR DESCRIPTION
The Cintiqs have had hardware keys for a few generations now. These translate
to KEY_PROG1 and friends in the older tablets, newer tablets have them as
KEY_BUTTONCONFIG, etc.

To make it possible which labeled key sends which event code, add an API to
look this up. Since the HW buttons are of (intended) fixed functionality and
there are only 4 possible options, the type is an enum.

**Note: this is incomplete right now, we need to add the newer devices with the correct mappings**