### PR TITLE
data: drop the '2' from the Intuos Pro 2 names

### DIFF
--- a/data/intuos-pro-2-l-wl.tablet
+++ b/data/intuos-pro-2-l-wl.tablet
@@ -43,7 +43,7 @@
 #
 
 [Device]
-Name=Wacom Intuos Pro 2 L WL
+Name=Wacom Intuos Pro L WL
 DeviceMatch=bluetooth:056a:0361
 Class=Intuos5
 Width=12

--- a/data/intuos-pro-2-l.tablet
+++ b/data/intuos-pro-2-l.tablet
@@ -43,7 +43,7 @@
 #
 
 [Device]
-Name=Wacom Intuos Pro 2 L
+Name=Wacom Intuos Pro L
 DeviceMatch=usb:056a:0358
 Class=Intuos5
 Width=12

--- a/data/intuos-pro-2-m-wl.tablet
+++ b/data/intuos-pro-2-m-wl.tablet
@@ -43,7 +43,7 @@
 #
 
 [Device]
-Name=Wacom Intuos Pro 2 M WL
+Name=Wacom Intuos Pro M WL
 DeviceMatch=bluetooth:056a:0360
 Class=Intuos5
 Width=9

--- a/data/intuos-pro-2-m.tablet
+++ b/data/intuos-pro-2-m.tablet
@@ -43,7 +43,7 @@
 #
 
 [Device]
-Name=Wacom Intuos Pro 2 M
+Name=Wacom Intuos Pro M
 DeviceMatch=usb:056a:0357
 Class=Intuos5
 Width=9


### PR DESCRIPTION
The device itself doesn't use a 2, so let's drop it here

Fixes #64

cc @tb2097