### PR TITLE
Cintiq Pro 24 naming consistency with xsetwacom

### DIFF
--- a/data/cintiq-pro-24-p.tablet
+++ b/data/cintiq-pro-24-p.tablet
@@ -27,7 +27,7 @@
 #
 
 [Device]
-Name=Wacom Cintiq Pro 24 P
+Name=Wacom Cintiq Pro 24
 Class=Cintiq
 DeviceMatch=usb:056a:037c
 Width=20

--- a/data/cintiq-pro-24-pt.tablet
+++ b/data/cintiq-pro-24-pt.tablet
@@ -27,7 +27,7 @@
 #
 
 [Device]
-Name=Wacom Cintiq Pro 24 PT
+Name=Wacom Cintiq Pro 24
 Class=Cintiq
 DeviceMatch=usb:056a:0351
 PairedID=usb:056a:0355


### PR DESCRIPTION
Fix for [[#68]]; ExpressKeys/Express Keys issue can be skipped due to possible legacy support issues.