### PR TITLE
data: Add ISDv4 515a (Lenovo ThinkPad L380 Yoga)

### DIFF
--- a/data/isdv4-515a.tablet
+++ b/data/isdv4-515a.tablet
@@ -1,0 +1,14 @@
+# this is for the Wacom pen + touchscreen as found in some versions of the Lenovo ThinkPad L380 Yoga
+
+[Device]
+Name=Wacom ISDv4 515a
+DeviceMatch=usb:056a:515a;
+Class=ISDV4
+Width=12
+Height=7
+IntegratedIn=Display;System;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
Added support for Wacom ISDv4 515a as found in Lenovo ThinkPad L380 Yoga