### PR TITLE
Allow for the tests to be "relocatable"

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -6,19 +6,19 @@ AM_CPPFLAGS=-I$(top_srcdir)/libwacom -DTOPSRCDIR="\"$(abs_top_srcdir)\""
 
 test_load_SOURCES = test-load.c
 test_load_LDADD=$(top_builddir)/libwacom/libwacom.la
-test_load_LDFLAGS = -static
+test_load_LDFLAGS = -no-install
 test_dbverify_SOURCES = test-dbverify.c
 test_dbverify_LDADD=$(top_builddir)/libwacom/libwacom.la
-test_dbverify_LDFLAGS = -static
+test_dbverify_LDFLAGS = -no-install
 test_tablet_validity_SOURCES = test-tablet-validity.c
 test_tablet_validity_LDADD=$(top_builddir)/libwacom/libwacom.la
-test_tablet_validity_LDFLAGS = -static
+test_tablet_validity_LDFLAGS = -no-install
 
 if HAVE_LIBXML
 noinst_PROGRAMS += test-tablet-svg-validity
 test_tablet_svg_validity_SOURCES = test-tablet-svg-validity.c
 test_tablet_svg_validity_LDADD = $(top_builddir)/libwacom/libwacom.la $(LIBXML_LIBS)
-test_tablet_svg_validity_LDFLAGS = -static
+test_tablet_svg_validity_LDFLAGS = -no-install
 test_tablet_svg_validity_CFLAGS = $(LIBXML_CFLAGS)
 endif
 

--- a/test/test-dbverify.c
+++ b/test/test-dbverify.c
@@ -182,10 +182,15 @@ compare_written_database(WacomDeviceDatabase *db)
 int main(int argc, char **argv)
 {
 	WacomDeviceDatabase *db;
+	const char *datadir;
 
-	db = libwacom_database_new_for_path(TOPSRCDIR"/data");
+	datadir = getenv("LIBWACOM_DATA_DIR");
+	if (!datadir)
+		datadir = TOPSRCDIR"/data";
+
+	db = libwacom_database_new_for_path(datadir);
 	if (!db)
-		printf("Failed to load data from %s", TOPSRCDIR"/data");
+		printf("Failed to load data from %s", datadir);
 	assert(db);
 
 

--- a/test/test-load.c
+++ b/test/test-load.c
@@ -31,6 +31,7 @@
 #include "input-event-codes.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "libwacom.h"
 #include <assert.h>
@@ -64,10 +65,15 @@ int main(int argc, char **argv)
 	WacomDevice *device;
 	const WacomMatch *match;
 	const char *str;
+	const char *datadir;
 
-	db = libwacom_database_new_for_path(TOPSRCDIR"/data");
+	datadir = getenv("LIBWACOM_DATA_DIR");
+	if (!datadir)
+		datadir = TOPSRCDIR"/data";
+
+	db = libwacom_database_new_for_path(datadir);
 	if (!db)
-		printf("Failed to load data from %s", TOPSRCDIR"/data");
+		printf("Failed to load data from %s", datadir);
 	assert(db);
 
 	device = libwacom_new_from_usbid(db, 0, 0, NULL);

--- a/test/test-tablet-validity.c
+++ b/test/test-tablet-validity.c
@@ -258,10 +258,15 @@ int main(int argc, char **argv)
 {
 	WacomDeviceDatabase *db;
 	WacomDevice **device, **devices;
+	const char *datadir;
 
-	db = libwacom_database_new_for_path(TOPSRCDIR"/data");
+	datadir = getenv("LIBWACOM_DATA_DIR");
+	if (!datadir)
+		datadir = TOPSRCDIR"/data";
+
+	db = libwacom_database_new_for_path(datadir);
 	if (!db)
-		printf("Failed to load data from %s", TOPSRCDIR"/data");
+		printf("Failed to load data from %s", datadir);
 	assert(db);
 
 	devices = libwacom_list_devices_from_database(db, NULL);


### PR DESCRIPTION
Add parsing of the `LIBWACOM_DATA_DIR` variable to override our test path. So during normal `make check` we do the same thing as before, but we can also test an installed version of libwacom with the same tests, e.g. `LIBWACOM_DATA_DIR=/usr/share/libwacom make check`. This should make it easier to spot missing files or general path mixups.

Note: first commit is #77 