### PR TITLE
Add support for Intel Management Engine bus

### DIFF
--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -112,6 +112,8 @@ bus_from_str (const char *str)
 		return WBUSTYPE_BLUETOOTH;
 	if (strcmp (str, "i2c") == 0)
 		return WBUSTYPE_I2C;
+	if (strcmp (str, "mei") == 0)
+		return WBUSTYPE_MEI;
 	return WBUSTYPE_UNKNOWN;
 }
 
@@ -130,6 +132,8 @@ bus_to_str (WacomBusType bus)
 		return "bluetooth";
 	case WBUSTYPE_I2C:
 		return "i2c";
+	case WBUSTYPE_MEI:
+		return "mei";
 	}
 	g_assert_not_reached ();
 }

--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -144,6 +144,10 @@ get_bus_vid_pid (GUdevDevice  *device,
 		*bus = WBUSTYPE_I2C;
 		retval = TRUE;
 		break;
+	case 68:
+		*bus = WBUSTYPE_MEI;
+		retval = TRUE;
+		break;
 	}
 
 out:
@@ -737,6 +741,7 @@ static void print_match(int fd, const WacomMatch *match)
 		case WBUSTYPE_USB:		bus_name = "usb";	break;
 		case WBUSTYPE_SERIAL:		bus_name = "serial";	break;
 		case WBUSTYPE_I2C:		bus_name = "i2c";	break;
+		case WBUSTYPE_MEI:		bus_name = "mei";	break;
 		case WBUSTYPE_UNKNOWN:		bus_name = "unknown";	break;
 		default:			g_assert_not_reached(); break;
 	}

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -116,6 +116,7 @@ typedef enum {
 	WBUSTYPE_SERIAL,	/**< Serial tablet */
 	WBUSTYPE_BLUETOOTH,	/**< Bluetooth tablet */
 	WBUSTYPE_I2C,		/**< I2C tablet */
+	WBUSTYPE_MEI,		/**< MEI */
 } WacomBusType;
 
 /**


### PR DESCRIPTION
Add support for devices connected via the Intel Management Engine (MEI).
This is required to support IPTS based devices, such as (among others)
the Microsoft Surface Books, Surface Pro 5 and 6, and Surface Laptops.

As per the previous discussion in #89. 