### PR TITLE
Device data for IPTS based Microsoft Surface Devices

### DIFF
--- a/data/surface-book.tablet
+++ b/data/surface-book.tablet
@@ -1,0 +1,14 @@
+# This is for the Microsoft Surface Book (1)
+
+[Device]
+Name=Microsoft Surface Book
+DeviceMatch=mei:1B96:005e
+Class=ISDV4
+Width=11
+Height=7
+IntegratedIn=Display;System;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0

--- a/data/surface-book2-13.tablet
+++ b/data/surface-book2-13.tablet
@@ -1,0 +1,14 @@
+# This is for the Microsoft Surface Book 2 13.5-inch model
+
+[Device]
+Name=Microsoft Surface Book 2 (13.5")
+DeviceMatch=mei:045E:0021
+Class=ISDV4
+Width=11
+Height=7
+IntegratedIn=Display;System;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0

--- a/data/surface-book2-15.tablet
+++ b/data/surface-book2-15.tablet
@@ -1,0 +1,14 @@
+# This is for the Microsoft Surface Book 2 15-inch model
+
+[Device]
+Name=Microsoft Surface Book 2 (15")
+DeviceMatch=mei:045E:0020
+Class=ISDV4
+Width=12
+Height=8
+IntegratedIn=Display;System;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0

--- a/data/surface-pro4.tablet
+++ b/data/surface-pro4.tablet
@@ -1,0 +1,14 @@
+# This is for the Microsoft Surface Pro 4
+
+[Device]
+Name=Microsoft Surface Pro 4
+DeviceMatch=mei:1B96:006A
+Class=ISDV4
+Width=10
+Height=6
+IntegratedIn=Display;System;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0

--- a/data/surface-pro5.tablet
+++ b/data/surface-pro5.tablet
@@ -1,0 +1,14 @@
+# This is for the Microsoft Surface Pro 5 (2017)
+
+[Device]
+Name=Microsoft Surface Pro 5
+DeviceMatch=mei:045E:001F
+Class=ISDV4
+Width=10
+Height=6
+IntegratedIn=Display;System;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0

--- a/data/surface-pro5.tablet
+++ b/data/surface-pro5.tablet
@@ -2,7 +2,7 @@
 
 [Device]
 Name=Microsoft Surface Pro 5
-DeviceMatch=mei:045E:001F
+DeviceMatch=mei:1B96:001F
 Class=ISDV4
 Width=10
 Height=6

--- a/data/surface-pro6.tablet
+++ b/data/surface-pro6.tablet
@@ -1,0 +1,14 @@
+# This is for the Microsoft Surface Pro 6
+
+[Device]
+Name=Microsoft Surface Pro 6
+DeviceMatch=mei:045E:001F
+Class=ISDV4
+Width=10
+Height=6
+IntegratedIn=Display;System;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
This PR depends on #92.

Adds support for:
- Surface Book 2 (13.5" model)
- Surface Pro 5 (also known as Surface Pro 2017)

See also the discussion in #89.