### PR TITLE
Tablet config for ELAN 2627

### DIFF
--- a/data/elan-2627.tablet
+++ b/data/elan-2627.tablet
@@ -1,0 +1,15 @@
+# ELAN touchscreen/pen sensor present in the HP envy x360 Convertible 13-ag0xxx
+[Device]
+Name=ELAN 2627
+ModelName=
+DeviceMatch=i2c:04f3:2627
+Class=ISDV4
+Width=12
+Height=7
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0
+


### PR DESCRIPTION
This model is found in the HP Envy x360 ag0xxxx series.

I have a few questions though:
* Width and height, couldn't really find them specified by HP so I just used a ruler and rounded up to the closest amount of inches. Does that make sense or should I round down to 11 and 6 instead?
* The device class is giving me trouble. `PenDisplay` seems the most appropriate but if I use that the Pen doesn't work at all. Switching to Intuos4 makes the pen work but the tracking is bonkers slow, the pointer lags behind the pen a great deal, almost a second and its location is off. I also tried `Class=ISDV4` which seems to get me the same result as `Class=Intuos4`. Which one should I pick?
* Touching the screen (with my finger) seems to result in multiple events. So for example when I touch the header bar of an app it goes full-screen b/c Gnome apparently believes I double-clicked it. I'm not sure if this has anything to do with libwacom or if I should raise this with the libinput folks

When I run `libwacom-list-local-devices` I get 2, contrary to what I would expect:
```
[Device]
Name=ELAN 2627
DeviceMatch=i2c:04f3:2627;
Class=PenDisplay
Width=12
Height=7
IntegratedIn=Display;System;
Styli=0xfffff;0xffffe;

[Features]
Reversible=false
Stylus=true
Ring=false
Ring2=false
Touch=true
TouchSwitch=false
StatusLEDs=
NumStrips=0
Buttons=0
---------------------------------------------------------------
[Device]
Name=Wacom Serial Tablet WACf004
DeviceMatch=serial:0000:0000;
Class=ISDV4
Width=0
Height=0
IntegratedIn=Display;System;
Styli=0xfffff;0xffffe;

[Features]
Reversible=false
Stylus=true
Ring=false
Ring2=false
Touch=false
TouchSwitch=false
StatusLEDs=
NumStrips=0
Buttons=0
---------------------------------------------------------------
```
Is the `Wacom Serial Tablet WACf004` device supposed to be there?

Despite adding this config devices didn't show up properly for X11, I had to add this snippet:

```
Section "InputClass"
    Identifier "Elan driver override"
    MatchUSBID "04f3:*"
    MatchDevicePath "/dev/input/event*"
    MatchIsTablet "true"
    Driver "wacom"
EndSection
```

I get this from `xinput`:
```
⎡ Virtual core pointer                          id=2    [master pointer  (3)]
⎜   ↳ Virtual core XTEST pointer                id=4    [slave  pointer  (2)]
⎜   ↳ ELAN0732:00 04F3:2627 stylus              id=11   [slave  pointer  (2)]
⎜   ↳ ELAN0732:00 04F3:2627                     id=12   [slave  pointer  (2)]
⎜   ↳ SynPS/2 Synaptics TouchPad                id=14   [slave  pointer  (2)]
⎜   ↳ ELAN0732:00 04F3:2627 eraser              id=17   [slave  pointer  (2)]
⎣ Virtual core keyboard                         id=3    [master keyboard (2)]
    ↳ Virtual core XTEST keyboard               id=5    [slave  keyboard (3)]
    ↳ Power Button                              id=6    [slave  keyboard (3)]
    ↳ Video Bus                                 id=7    [slave  keyboard (3)]
    ↳ Power Button                              id=8    [slave  keyboard (3)]
    ↳ HP Wide Vision HD Camera: HP Wi           id=9    [slave  keyboard (3)]
    ↳ HP IR Camera: HP IR Camera                id=10   [slave  keyboard (3)]
    ↳ AT Translated Set 2 keyboard              id=13   [slave  keyboard (3)]
    ↳ HP WMI hotkeys                            id=15   [slave  keyboard (3)]
    ↳ HP Wireless hotkeys                       id=16   [slave  keyboard (3)]
```

And `xsetwacom --list devices`:
```
ELAN0732:00 04F3:2627 stylus            id: 11  type: STYLUS    
ELAN0732:00 04F3:2627 eraser            id: 17  type: ERASER  
```

I took a look at the different properties for the devices xinput lists.

### Class=PenDisplay
* ELAN0732:00 04F3:2627 (id=12)
```
Device 'ELAN0732:00 04F3:2627':
        Device Enabled (145):   1
        Coordinate Transformation Matrix (147): 1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000
        libinput Calibration Matrix (311):      1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000
        libinput Calibration Matrix Default (312):      1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000
        libinput Send Events Modes Available (267):     1, 0
        libinput Send Events Mode Enabled (268):        0, 0
        libinput Send Events Mode Enabled Default (269):        0, 0
        Device Node (270):      "/dev/input/event6"
        Device Product ID (271):        1267, 9767
```
* ELAN0732:00 04F3:2627 stylus (id=11)
```
Device 'ELAN0732:00 04F3:2627 stylus':
        Device Enabled (145):   1
        Coordinate Transformation Matrix (147): 1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000
        Device Accel Profile (273):     0
        Device Accel Constant Deceleration (274):       1.000000
        Device Accel Adaptive Deceleration (275):       1.000000
        Device Accel Velocity Scaling (276):    10.000000
        Device Node (270):      "/dev/input/event7"
        Wacom Tablet Area (283):        0, 0, 18460, 10400
        Wacom Rotation (284):   0
        Wacom Pressurecurve (285):      0, 0, 100, 100
        Wacom Serial IDs (286): 9767, 0, 2, 0, 0
        Wacom Serial ID binding (287):  0
        Wacom Pressure Threshold (288): 26
        Wacom Sample and Suppress (289):        2, 4
        Wacom Enable Touch (290):       0
        Wacom Hover Click (291):        1
        Wacom Enable Touch Gesture (292):       0
        Wacom Touch Gesture Parameters (293):   0, 0, 250
        Wacom Tool Type (294):  "STYLUS" (272)
        Wacom Button Actions (295):     "Wacom button action 0" (296), "Wacom button action 1" (297), "Wacom button action 2" (298), "None" (0), "None" (0), "None" (0), "None" (0), "Wacom button action 3" (299)
        Wacom button action 0 (296):    1572865
        Wacom button action 1 (297):    1572866
        Wacom button action 2 (298):    1572867
        Wacom button action 3 (299):    1572872
        Wacom Pressure Recalibration (300):     1
        Wacom Panscroll Threshold (301):        819
        Device Product ID (271):        1267, 9767
        Wacom Debug Levels (302):       0, 0
```

* ELAN0732:00 04F3:2627 eraser (id=17)
```
Device 'ELAN0732:00 04F3:2627 eraser':
        Device Enabled (145):   1
        Coordinate Transformation Matrix (147): 1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000
        Device Accel Profile (273):     0
        Device Accel Constant Deceleration (274):       1.000000
        Device Accel Adaptive Deceleration (275):       1.000000
        Device Accel Velocity Scaling (276):    10.000000
        Device Node (270):      "/dev/input/event7"
        Wacom Tablet Area (283):        0, 0, 18460, 10400
        Wacom Rotation (284):   0
        Wacom Pressurecurve (285):      0, 0, 100, 100
        Wacom Serial IDs (286): 9767, 0, 10, 0, 0
        Wacom Serial ID binding (287):  0
        Wacom Pressure Threshold (288): 26
        Wacom Sample and Suppress (289):        2, 4
        Wacom Enable Touch (290):       0
        Wacom Enable Touch Gesture (292):       0
        Wacom Touch Gesture Parameters (293):   0, 0, 250
        Wacom Tool Type (294):  "ERASER" (340)
        Wacom Button Actions (295):     "Wacom button action 0" (296), "Wacom button action 1" (297), "Wacom button action 2" (298), "None" (0), "None" (0), "None" (0), "None" (0), "Wacom button action 3" (299)
        Wacom button action 0 (296):    1572865
        Wacom button action 1 (297):    1572866
        Wacom button action 2 (298):    1572867
        Wacom button action 3 (299):    1572872
        Wacom Pressure Recalibration (300):     1
        Wacom Panscroll Threshold (301):        819
        Device Product ID (271):        1267, 9767
        Wacom Debug Levels (302):       0, 0
```

Stylus and eraser appear to be the same, which I suppose is expected. I'm a bit puzzled by the other device, `id=12`.

### Class=Intuos4
* ELAN0732:00 04F3:2627 (id=12)
```
Device 'ELAN0732:00 04F3:2627':
        Device Enabled (145):   1
        Coordinate Transformation Matrix (147): 1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000
        libinput Calibration Matrix (311):      1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000
        libinput Calibration Matrix Default (312):      1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000
        libinput Send Events Modes Available (267):     1, 0
        libinput Send Events Mode Enabled (268):        0, 0
        libinput Send Events Mode Enabled Default (269):        0, 0
        Device Node (270):      "/dev/input/event6"
        Device Product ID (271):        1267, 9767
```
* ELAN0732:00 04F3:2627 stylus (id=11)
```
Device 'ELAN0732:00 04F3:2627':
        Device Enabled (145):   1
        Coordinate Transformation Matrix (147): 1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000
        libinput Calibration Matrix (311):      1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000
        libinput Calibration Matrix Default (312):      1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000
        libinput Send Events Modes Available (267):     1, 0
        libinput Send Events Mode Enabled (268):        0, 0
        libinput Send Events Mode Enabled Default (269):        0, 0
        Device Node (270):      "/dev/input/event6"
        Device Product ID (271):        1267, 9767
daenney@s-monocerotis ~> cat xinput-stylus-2.txt 
Device 'ELAN0732:00 04F3:2627 stylus':
        Device Enabled (145):   1
        Coordinate Transformation Matrix (147): 1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000
        Device Accel Profile (273):     0
        Device Accel Constant Deceleration (274):       1.000000
        Device Accel Adaptive Deceleration (275):       1.000000
        Device Accel Velocity Scaling (276):    10.000000
        Device Node (270):      "/dev/input/event7"
        Wacom Tablet Area (283):        0, 0, 18460, 10400
        Wacom Rotation (284):   0
        Wacom Pressurecurve (285):      0, 0, 100, 100
        Wacom Serial IDs (286): 9767, 1, 2, 1, 2
        Wacom Serial ID binding (287):  0
        Wacom Pressure Threshold (288): 26
        Wacom Sample and Suppress (289):        2, 4
        Wacom Enable Touch (290):       0
        Wacom Hover Click (291):        1
        Wacom Enable Touch Gesture (292):       0
        Wacom Touch Gesture Parameters (293):   0, 0, 250
        Wacom Tool Type (294):  "STYLUS" (272)
        Wacom Button Actions (295):     "Wacom button action 0" (296), "Wacom button action 1" (297), "Wacom button action 2" (298), "None" (0), "None" (0), "None" (0), "None" (0), "Wacom button action 3" (299)
        Wacom button action 0 (296):    1572865
        Wacom button action 1 (297):    1572866
        Wacom button action 2 (298):    1572867
        Wacom button action 3 (299):    1572872
        Wacom Pressure Recalibration (300):     1
        Wacom Panscroll Threshold (301):        819
        Device Product ID (271):        1267, 9767
        Wacom Debug Levels (302):       0, 0
```

* ELAN0732:00 04F3:2627 eraser (id=17)
```
Device 'ELAN0732:00 04F3:2627 eraser':
        Device Enabled (145):   1
        Coordinate Transformation Matrix (147): 1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000
        Device Accel Profile (273):     0
        Device Accel Constant Deceleration (274):       1.000000
        Device Accel Adaptive Deceleration (275):       1.000000
        Device Accel Velocity Scaling (276):    10.000000
        Device Node (270):      "/dev/input/event7"
        Wacom Tablet Area (283):        0, 0, 18460, 10400
        Wacom Rotation (284):   0
        Wacom Pressurecurve (285):      0, 0, 100, 100
        Wacom Serial IDs (286): 9767, 0, 10, 0, 0
        Wacom Serial ID binding (287):  0
        Wacom Pressure Threshold (288): 26
        Wacom Sample and Suppress (289):        2, 4
        Wacom Enable Touch (290):       0
        Wacom Enable Touch Gesture (292):       0
        Wacom Touch Gesture Parameters (293):   0, 0, 250
        Wacom Tool Type (294):  "ERASER" (340)
        Wacom Button Actions (295):     "Wacom button action 0" (296), "Wacom button action 1" (297), "Wacom button action 2" (298), "None" (0), "None" (0), "None" (0), "None" (0), "Wacom button action 3" (299)
        Wacom button action 0 (296):    1572865
        Wacom button action 1 (297):    1572866
        Wacom button action 2 (298):    1572867
        Wacom button action 3 (299):    1572872
        Wacom Pressure Recalibration (300):     1
        Wacom Panscroll Threshold (301):        819
        Device Product ID (271):        1267, 9767
        Wacom Debug Levels (302):       0, 0
```

The only difference appears to be a change in Wacom Serial IDs on the stylus:
```diff
12c12
<       Wacom Serial IDs (286): 9767, 0, 2, 0, 0
---
>       Wacom Serial IDs (286): 9767, 1, 2, 1, 2
```

I get a similar diff on the stylus between PenDisplay and ISDV4:
```diff
12c12
<       Wacom Serial IDs (286): 9767, 0, 2, 0, 0
---
>       Wacom Serial IDs (286): 9767, 1, 0, 1, 0
```