### PR TITLE
tools: print the device node for list-local-devices

### DIFF
--- a/tools/list-local-devices.c
+++ b/tools/list-local-devices.c
@@ -96,9 +96,12 @@ int main(int argc, char **argv)
 		char fname[PATH_MAX];
 
 		snprintf(fname, sizeof(fname), "/dev/input/%s", namelist[i]->d_name);
+
 		dev = libwacom_new_from_path(db, fname, WFALLBACK_NONE, NULL);
 		if (!dev)
 			continue;
+
+		dprintf(STDOUT_FILENO, "# Device node: %s\n", fname);
 		libwacom_print_device_description(STDOUT_FILENO, dev);
 		libwacom_destroy(dev);
 


### PR DESCRIPTION
Makes it easier to identify where an entry comes from.

Related #95