### PR TITLE
Some printing cleanups

### DIFF
--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -31,6 +31,7 @@
 #include "libwacomint.h"
 #include <assert.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <gudev/gudev.h>
@@ -659,13 +660,16 @@ static void print_supported_leds (int fd, const WacomDevice *device)
 	const WacomStatusLEDs *status_leds;
 	int i;
 	char buf[256] = {0};
+	bool have_led = false;
 
 	status_leds = libwacom_get_status_leds(device, &num_leds);
 
-	for (i = 0; i < num_leds; i++)
+	for (i = 0; i < num_leds; i++) {
 		strcat(buf, leds_name[status_leds[i]]);
+		have_led = true;
+	}
 
-	dprintf(fd, "StatusLEDs=%s\n", buf);
+	dprintf(fd, "%sStatusLEDs=%s\n", have_led ? "" : "# ", buf);
 }
 
 static void print_button_flag_if(int fd, const WacomDevice *device, const char *label, int flag)
@@ -674,15 +678,17 @@ static void print_button_flag_if(int fd, const WacomDevice *device, const char *
 	char buf[nbuttons * 2 + 1];
 	int idx = 0;
 	char b;
+	bool have_flag = false;
 
 	for (b = 'A'; b < 'A' + nbuttons; b++) {
 		if (libwacom_get_button_flag(device, b) & flag) {
 			buf[idx++] = b;
 			buf[idx++] = ';';
+			have_flag = true;
 		}
 	}
 	buf[idx] = '\0';
-	dprintf(fd, "%s=%s\n", label, buf);
+	dprintf(fd, "%s%s=%s\n", have_flag ? "" : "# ", label, buf);
 }
 
 static void print_button_evdev_codes(int fd, const WacomDevice *device)

--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -803,6 +803,7 @@ libwacom_print_device_description(int fd, const WacomDevice *device)
 
 	dprintf(fd, "NumStrips=%d\n",	libwacom_get_num_strips(device));
 	dprintf(fd, "Buttons=%d\n",		libwacom_get_num_buttons(device));
+	dprintf(fd, "\n");
 
 	print_buttons_for_device(fd, device);
 }

--- a/tools/list-local-devices.c
+++ b/tools/list-local-devices.c
@@ -96,9 +96,12 @@ int main(int argc, char **argv)
 		char fname[PATH_MAX];
 
 		snprintf(fname, sizeof(fname), "/dev/input/%s", namelist[i]->d_name);
+
 		dev = libwacom_new_from_path(db, fname, WFALLBACK_NONE, NULL);
 		if (!dev)
 			continue;
+
+		dprintf(STDOUT_FILENO, "# Device node: %s\n", fname);
 		libwacom_print_device_description(STDOUT_FILENO, dev);
 		libwacom_destroy(dev);
 


### PR DESCRIPTION
This is on top of #96 

Some rework in printing devices so we only call `dprintf` once for each line (for some of them anyway) and we can prefix a `#` in front of empty led or button lines.