### PR TITLE
Ignore serial touchpads

### DIFF
--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -56,10 +56,22 @@ libwacom_get_device(const WacomDeviceDatabase *db, const char *match)
 }
 
 static gboolean
+is_tablet (GUdevDevice *device)
+{
+	return g_udev_device_get_property_as_boolean (device, "ID_INPUT_TABLET");
+}
+
+static gboolean
+is_touchpad (GUdevDevice *device)
+{
+	return g_udev_device_get_property_as_boolean (device, "ID_INPUT_TOUCHPAD");
+}
+
+
+static gboolean
 is_tablet_or_touchpad (GUdevDevice *device)
 {
-	return g_udev_device_get_property_as_boolean (device, "ID_INPUT_TABLET") ||
-		g_udev_device_get_property_as_boolean (device, "ID_INPUT_TOUCHPAD");
+	return is_touchpad (device) || is_tablet (device);
 }
 
 /* Overriding SUBSYSTEM isn't allowed in udev (works sometimes, but not
@@ -285,6 +297,9 @@ get_device_info (const char            *path,
 	*bus = bus_from_str (bus_str);
 
 	if (*bus == WBUSTYPE_SERIAL) {
+		if (is_touchpad (device))
+			goto out;
+
 		/* The serial bus uses 0:0 as the vid/pid */
 		*vendor_id = 0;
 		*product_id = 0;

--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -151,7 +151,8 @@ get_bus_vid_pid (GUdevDevice  *device,
 out:
 	if (splitted_product)
 		g_strfreev (splitted_product);
-	g_object_unref (parent);
+	if (parent)
+		g_object_unref (parent);
 	return retval;
 }
 


### PR DESCRIPTION
We don't have serial touchpad devices that we care about, but the current code ends up labeling any serial touchpad as supported device with vid/pid 0 - which in turn maps to our serial ISDV4 devices.

Fixes #100 

cc @daenney 