### PR TITLE
Document the signed-ness mismatch between vendor ids

### DIFF
--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -376,6 +376,10 @@ const char* libwacom_get_layout_filename(const WacomDevice *device);
 /**
  * @param device The tablet to query
  * @return The numeric vendor ID for this device
+ *
+ * @bug The return value is a signed int but libwacom_match_get_vendor_id()
+ * returns an unsigned int. This may cause compiler warnings, but the
+ * effective range for vendor IDs is 16-bit only anyway.
  */
 int libwacom_get_vendor_id(const WacomDevice *device);
 
@@ -412,6 +416,10 @@ const WacomMatch* libwacom_get_paired_device(const WacomDevice *device);
 /**
  * @param device The tablet to query
  * @return The numeric product ID for this device
+ *
+ * @bug The return value is a signed int but libwacom_match_get_product_id()
+ * returns an unsigned int. This may cause compiler warning, but the
+ * effective range for product IDs is 16-bit only anyway.
  */
 int libwacom_get_product_id(const WacomDevice *device);
 

--- a/test/test-load.c
+++ b/test/test-load.c
@@ -49,9 +49,9 @@ static void check_multiple_match(WacomDevice *device)
 		nmatches++;
 		if (libwacom_match_get_bustype(*match) == libwacom_get_bustype(device))
 			found_bus = 1;
-		if (libwacom_match_get_vendor_id(*match) == libwacom_get_vendor_id(device))
+		if ((int)libwacom_match_get_vendor_id(*match) == libwacom_get_vendor_id(device))
 			found_vendor_id = 1;
-		if (libwacom_match_get_product_id(*match) == libwacom_get_product_id(device))
+		if ((int)libwacom_match_get_product_id(*match) == libwacom_get_product_id(device))
 			found_product_id = 1;
 	}
 


### PR DESCRIPTION
The vendor and product ids are all signed integers except in the
libwacom_match code where they are uint32_t. We can't change that
without API changes (not ABI though), so let's just document it and move on.