### PR TITLE
data: move the git and svg checks to a separate scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ stamp-h1
 *.la
 *.swp
 *.trs
+*.log
 .deps
 .libs
 test-driver

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ before_script:
 script:
   - if [[ x"$TRAVIS_EVENT_TYPE" = "xcron" ]]; then export DO_COVERITY="YES"; fi
   - if [[ x"$BUILDTYPE" = "xcoverity" && x"$DO_COVERITY" = "xYES" ]]; then bash ./coverity.sh; fi
-  - if [[ x"$BUILDTYPE" != "xcoverity" ]]; then make && make check; fi
+  - if [[ x"$BUILDTYPE" != "xcoverity" ]]; then make && make check || (cat **/test-suite.log && false); fi

--- a/configure.ac
+++ b/configure.ac
@@ -21,9 +21,6 @@ AC_PROG_LIBTOOL
 AC_PROG_CC
 AC_PROG_INSTALL
 PKG_PROG_PKG_CONFIG
-AC_PATH_PROG(SED, sed)
-AC_PATH_PROG(GREP, grep)
-AC_PATH_PROGS(GIT, git false) # fail any git command if we can't find git
 
 AC_CHECK_PROG(HAVE_DOXYGEN, [doxygen], [yes], [no])
 AM_CONDITIONAL(HAVE_DOXYGEN, test "x$HAVE_DOXYGEN" = xyes)

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -10,19 +10,7 @@ EXTRA_DIST = wacom.example
 
 SUBDIRS = layouts
 
-check:
-	@for file in $(tablet_files); do \
-		svg=`$(GREP) 'Layout=' "$(top_srcdir)/data/$$file" | $(SED) -e "s/Layout=//"`; \
-		test -z "$$svg" || \
-		test -e "$(top_srcdir)/data/layouts/$$svg" || ( \
-			echo "ERROR: File $$file references nonexistent $$svg" && test); \
-		rc="$$(($$rc + $$?))"; \
-	done && test 0 -eq $$rc;
-	@(export GIT_DIR="$(top_srcdir)/.git"; \
-	 if $(GIT) ls-files >& /dev/null; then \
-		for file in $(tablet_files) $(stylus_files); do \
-			$(GIT) ls-files --error-unmatch "data/$$file" &> /dev/null || ( \
-			echo "ERROR: File $$file is not in git" && test); \
-		rc="$$(($$rc + $$?))"; \
-		done && test 0 -eq $$rc; \
-	fi)
+noinst_SCRIPTS = check-files-in-git.sh check-svg-exists.sh
+
+AM_TESTS_ENVIRONMENT=top_srcdir="$(abs_top_srcdir)"; export top_srcdir;
+TESTS = $(noinst_SCRIPTS)

--- a/data/check-files-in-git.sh
+++ b/data/check-files-in-git.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Usage: check-files-in-git.sh /path/to/libwacom/
+
+if [ -z "$top_srcdir" ]; then
+    top_srcdir="$1"
+fi
+if [ -z "$top_srcdir" ]; then
+    echo "Usage: `basename $0` /path/to/libwacom"
+    exit 1
+fi
+
+export GIT_DIR="$top_srcdir/.git";
+if ! git ls-files >& /dev/null; then
+    echo "Not a git tree. Skipping"
+    exit 77
+fi
+
+pushd "$top_srcdir" > /dev/null
+for file in data/*.tablet data/*.stylus data/layouts/*.svg; do
+    git ls-files --error-unmatch "$file" &> /dev/null || (
+        echo "ERROR: File $file is not in git" && test);
+    rc="$(($rc + $?))";
+done
+popd > /dev/null
+exit $rc

--- a/data/check-svg-exists.sh
+++ b/data/check-svg-exists.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Usage: check-svg-exists.sh /path/to/libwacom/
+
+if [ -z "$top_srcdir" ]; then
+    top_srcdir="$1"
+fi
+if [ -z "$top_srcdir" ]; then
+    echo "Usage: `basename $0` /path/to/libwacom"
+    exit 1
+fi
+
+pushd "$top_srcdir" > /dev/null
+for file in data/*.tablet; do
+        svg=`grep 'Layout=' "$file" | sed -e "s/Layout=//"`;
+        test -z "$svg" ||
+        test -e "data/layouts/$svg" ||
+            (echo "ERROR: File '$file' references nonexistent '$svg'" && test);
+        rc="$(($rc + $?))";
+done
+
+for file in data/layouts/*.svg; do
+    grep -q "`basename $file`" $top_srcdir/data/*.tablet ||
+        (echo "ERROR: Layout $file is not referenced" && test);
+    rc="$(($rc + $?))";
+done
+
+exit $rc

--- a/data/layouts/Makefile.am
+++ b/data/layouts/Makefile.am
@@ -3,18 +3,3 @@ layouts = $(shell find $(top_srcdir)/data/layouts -name "*.svg" -printf "%P\n")
 dist_libwacomlayouts_DATA =  $(layouts)
 
 EXTRA_DIST = README
-
-check:
-	@for file in $(layouts); do \
-		$(GREP) -q "$$file" $(top_srcdir)/data/*.tablet || (\
-			echo "ERROR: Layout $$file is not referenced" && test); \
-		rc="$$(($$rc + $$?))"; \
-	done && test 0 -eq $$rc;
-	@(export GIT_DIR="$(top_srcdir)/.git"; \
-	if $(GIT) ls-files >& /dev/null; then \
-		for file in $(layouts); do \
-			$(GIT) ls-files --error-unmatch "data/layouts/$$file" &> /dev/null || ( \
-			echo "ERROR: File $$file is not in git" && test); \
-		rc="$$(($$rc + $$?))"; \
-		done && test 0 -eq $$rc; \
-	fi)


### PR DESCRIPTION
Easier to test, comment, write, and review when it's in a separate file.

The automake integration is a bit odd. We can't pass arguments to scripts but
the only sane way for that script is to take the top_srcdir as argument
(otherwise it'd have to be a configure.in script). We can't do that, but we
can set it in the environment for the tests so that's the next best thing.

This also drops the custom lookups for git, grep and sed. Just make sure it's
in your PATH. Where git ls-files fails, the test is skipped which should make
anyone curious. This also covers the case where git is not available, so
that's not a hard failure.