### PR TITLE
Prevent librsvg from bailing at the sight of uninitialized data

### DIFF
--- a/tools/show-svg-image.c
+++ b/tools/show-svg-image.c
@@ -209,6 +209,8 @@ update_tablet (Tablet *tablet)
 	gchar       *file_data, *escaped_file_data, *data;
 	gsize        file_len;
 
+	error = NULL;
+
 	if (tablet->handle)
 		g_object_unref (tablet->handle);
 


### PR DESCRIPTION
Leaving 'error' uninitalized causes the librsvg to believe that Something
Bad (TM) has already happened and prevents it from working.

(lt-show-svg-image:18442): librsvg-CRITICAL **: 14:34:08.414: rsvg_handle_write: assertion 'error == NULL || *error == NULL' failed

Fixes: https://github.com/linuxwacom/libwacom/issues/103
Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>