### PR TITLE
elan-264c: add both pens with and without eraser support

### DIFF
--- a/data/elan-264c.tablet
+++ b/data/elan-264c.tablet
@@ -1,13 +1,15 @@
 # ELAN touchscreen/pen sensor present in the HP Envy x360 Convertible 15-cp0XXX
 
 [Device]
-Name=ELAN 264C
-ModelName=
+Name=ELAN touchscreen/pen sensor
+ModelName=ELAN-264C
 DeviceMatch=i2c:04f3:264c
 Class=ISDV4
 Width=14
 Height=8
 IntegratedIn=Display;System
+# This device supports both pens with eraser and without eraser
+Styli=0xffffd;0xffffe;0xfffff;
 
 [Features]
 Stylus=true


### PR DESCRIPTION
This update improves the support of styli and use a more generic name.