### PR TITLE
Fix parsing of match strings when using musl

### DIFF
--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -147,14 +147,13 @@ make_match_string (const char *name, WacomBusType bus, int vendor_id, int produc
 static gboolean
 match_from_string(const char *str, WacomBusType *bus, int *vendor_id, int *product_id, char **name)
 {
-	int rc = 1;
-	char busstr[64], namestr[64];
+	int rc = 1, len = 0;
+	char busstr[64];
 
-	memset(namestr, 0, sizeof(namestr));
-
-	rc = sscanf(str, "%63[^:]:%x:%x:%63c", busstr, vendor_id, product_id, namestr);
-	if (rc == 4) {
-		*name = g_strdup(namestr);
+	rc = sscanf(str, "%63[^:]:%x:%x:%n", busstr, vendor_id, product_id, &len);
+	if (len > 0) {
+		/* Grumble grumble scanf handling of %n */
+		*name = g_strdup(str+len);
 	} else if (rc == 3) {
 		*name = NULL;
 	} else {


### PR DESCRIPTION
Several tests fail when running on a system with the musl libc library
with the error "Duplicate match of 'usb:256c:006e' on device 'Huion H420'".
The root cause appears to be musl's handling of '%63c' in our format string.
Specifically, unlike glibc which interprets this to mean "read up to 63
characters", musl interprets it as "read exactly 63 characters".

This commit tweaks our format string to extract the first three required
fields and probe (with ':%n') to see if more data follows. In such a case
we can directly strdup the remainder of the string.

Ref: https://github.com/linuxwacom/libwacom/issues/85
Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>