### PR TITLE
data: intuos-s-p3: Add EvdevCodes to description to support buttons

### DIFF
--- a/data/intuos-s-p3.tablet
+++ b/data/intuos-s-p3.tablet
@@ -35,3 +35,4 @@ Buttons=4
 
 [Buttons]
 Top=A;B;C;D
+EvdevCodes=0x100;0x101;0x102;0x103


### PR DESCRIPTION
Without the EvdevCodes specified, the buttons of the tablet are not
taking effect. This is visible with e.g. the gnome-control-center wacom
tablet configuration panel.

After adding the EvdevCodes, the buttons presses are properly detected
and can be bound to specific actions.

Signed-off-by: Paul Kocialkowski <contact@paulk.fr>