### PR TITLE
Add support for ELAN 2628

### DIFF
--- a/data/elan-2628.tablet
+++ b/data/elan-2628.tablet
@@ -1,0 +1,14 @@
+# ELAN touchscreen/pen sensor present in the HP envy x360 Convertible 13-ag0xxx
+[Device]
+Name=ELAN 2628
+ModelName=
+DeviceMatch=i2c:04f3:2628
+Class=ISDV4
+Width=12
+Height=7
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0

--- a/meson.build
+++ b/meson.build
@@ -162,6 +162,7 @@ data_files = [
 	'data/elan-2072.tablet',
 	'data/elan-2537.tablet',
 	'data/elan-2627.tablet',
+	'data/elan-2628.tablet',
 	'data/elan-5515.tablet',
 	'data/generic.tablet',
 	'data/graphire2-4x5.tablet',


### PR DESCRIPTION
Hi!
This tablet is also found on some HP Envy x360 ag0xxxx (including mine). This commit is basically just a copy of  #95 (thanks @daenney !) modified to match this device. 