### PR TITLE
meson: make docs configurable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -460,7 +460,8 @@ install_man(configure_file(input: 'tools/libwacom-list-local-devices.man',
 			   copy: true))
 
 ############### docs ###########################
-doxygen = find_program('doxygen', required: false)
+docs_feature = get_option('documentation')
+doxygen = find_program('doxygen', required: docs_feature)
 if doxygen.found()
 	src_doxygen = [
 		join_paths(dir_src, 'libwacom.h'),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,7 @@
+option('documentation',
+       type: 'feature',
+       value: 'auto',
+       description: 'Build doxygen documentation [default=auto]')
 option('udev-dir',
        type: 'string',
        value: '',


### PR DESCRIPTION
Nice to have for distributions, which needs to have predicable build.

Signed-off-by: David Heidelberg <david@ixit.cz>