### PR TITLE
Make run-full-test.sh compatible with git rebase

### DIFF
--- a/run-full-test.sh
+++ b/run-full-test.sh
@@ -30,6 +30,7 @@ echo "####################################### running make distcheck"
 # previously. So let's only do this where we have a clean tree that we can
 # clone.
 if git diff --exit-code -s; then
+    unset GIT_WORK_TREE
     mkdir -p "$builddir/autotools/build"
     mkdir -p "$builddir/autotools/inst"
     pushd "$builddir/autotools" > /dev/null


### PR DESCRIPTION
The `git rebase` todo list allows you to specify scripts to be run as
part of the rebase process. This can be used e.g. to make sure that
the test suite still passes after any change to a commit in the history.

The `run-full-test.sh` script doesn't work properly when called by
`git rebase`. The script wants to perform a temporary checkout of the
repository for some of its tests, but this can fail with a "working
tree already exists" error. This is a result of the GIT_WORK_TREE
environment variable being already set by the `git rebase` command.
To work around this, we can just unset the variable since we do not
actually rely on its presence.

Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>