### PR TITLE
data: Remove nonsense EMR stylus IDs

### DIFF
--- a/data/libwacom.stylus
+++ b/data/libwacom.stylus
@@ -56,13 +56,6 @@ HasEraser=false
 Axes=Tilt;Pressure;Distance;
 Type=Inking
 
-[0x012]
-Name=Inking Pen
-Buttons=0
-HasEraser=false
-Axes=Tilt;Pressure;Distance;
-Type=Inking
-
 # Regular pen has eraser
 [0x822]
 # Intuos and Intuos2
@@ -231,10 +224,6 @@ Buttons=2
 Axes=Tilt;Pressure;Distance;
 Type=General
 
-[0x022]
-Name=Pen
-HasEraser=true
-
 # Stroke pen has no eraser
 [0x832]
 #Intuos and Intuos2
@@ -242,12 +231,6 @@ Name=Stroke Pen
 Group=intuos
 HasEraser=false
 Buttons=0
-Axes=Tilt;Pressure;Distance;
-Type=Stroke
-
-[0x032]
-Name=Stroke Pen
-HasEraser=false
 Axes=Tilt;Pressure;Distance;
 Type=Stroke
 
@@ -296,10 +279,6 @@ IsEraser=true
 Buttons=1
 Axes=Tilt;Pressure;Distance;
 Type=Airbrush
-
-[0x0fa]
-Name=Eraser
-IsEraser=true
 
 [0x82b]
 # Intuos3 and Cintiq 21UX
@@ -443,12 +422,6 @@ Group=intuos2
 HasEraser=true
 Buttons=1
 Axes=Tilt;Pressure;Distance;Slider;
-Type=Airbrush
-
-[0x112]
-Name=Airbrush Pen
-HasEraser=true
-Axes=Tilt;Pressure;Distance;
 Type=Airbrush
 
 [0x913]


### PR DESCRIPTION
When the stylus database was initially populated from the kernel's list
of known stylus IDs, it brought over several nonsense IDs that should have
been removed from the kernel ages ago. All EMR styli should have an ID
with bit 0x800 set, and those which don't can be traced back to an almost-
prehistoric version of the kernel driver (commit 268175ce6f in the kernel's
history/history.git repository if you must know). That kernel commit only
used the low byte of the ID, and when the higher bytes were later used
the truncated versions were never removed.

Notably, bit 0x800 is *not* set for puck IDs, so don't assume that they
also need removal ;)

Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>