### PR TITLE
data: Add ISDv4 51BE (Lenovo X1 Yoga 4th)

### DIFF
--- a/data/isdv4-51be.tablet
+++ b/data/isdv4-51be.tablet
@@ -1,0 +1,15 @@
+# this is for the Wacom pen + touchscreen as found in the Lenovo X1 Yoga 4th-gen
+
+[Device]
+Name=Wacom ISDv4 51BE
+ModelName=
+DeviceMatch=usb:056a:51be
+Class=ISDV4
+Width=12
+Height=7
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0

--- a/meson.build
+++ b/meson.build
@@ -237,6 +237,7 @@ data_files = [
 	'data/isdv4-50f1.tablet',
 	'data/isdv4-50f8.tablet',
 	'data/isdv4-50fd.tablet',
+	'data/isdv4-51be.tablet',
 	'data/isdv4-51bf.tablet',
 	'data/isdv4-51e2.tablet',
 	'data/isdv4-90.tablet',


### PR DESCRIPTION
Second known PID for this tablet PC model.

Ref: https://github.com/linuxwacom/wacom-hid-descriptors/issues/61
Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>