### PR TITLE
data: Add ELAN 29B6 & 29A1 (ASUS ZenBook Pro Duo UX581GV)

### DIFF
--- a/data/elan-29a1.tablet
+++ b/data/elan-29a1.tablet
@@ -1,0 +1,18 @@
+# ELAN touchscreen/pen sensor present in the ASUS ZenBook Pro Duo UX581GV
+# this is the secondary / bottom touchscreen
+# 345mm x 99mm
+# 13.59in x 3.9in
+
+[Device]
+Name=ELAN 29A1
+ModelName=
+DeviceMatch=i2c:04F3:29A1
+Class=ISDV4
+Width=14
+Height=4
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0

--- a/data/elan-29b6.tablet
+++ b/data/elan-29b6.tablet
@@ -1,0 +1,18 @@
+# ELAN touchscreen/pen sensor present in the ASUS ZenBook Pro Duo UX581GV
+# this is the main / top touchscreen
+# 345mm x 194mm
+# 13.59in x 7.64in
+
+[Device]
+Name=ELAN 29B6
+ModelName=
+DeviceMatch=i2c:04F3:29B6
+Class=ISDV4
+Width=14
+Height=8
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0

--- a/meson.build
+++ b/meson.build
@@ -159,6 +159,8 @@ data_files = [
 	'data/ek-remote.tablet',
 	'data/elan-22e2.tablet',
 	'data/elan-24db.tablet',
+	'data/elan-29a1.tablet',
+	'data/elan-29b6.tablet',
 	'data/elan-264c.tablet',
 	'data/elan-2072.tablet',
 	'data/elan-2537.tablet',


### PR DESCRIPTION
the [ASUS ZenBook Pro Duo UX581GV](https://www.asus.com/Laptops/ZenBook-Pro-Duo-UX581GV/Tech-Specs/) has two internal screens - 
- top/main oled screen (345mm x 194mm → 13.59in x 7.64in)  ELAN 29B6
- bottom/secondary TFT screen (345mm x 99mm → 13.59in x 3.9in) ELAN 29A1
both with touch and pen support.