### PR TITLE
meson_options: make the tests a feature too

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -491,7 +491,7 @@ if doxygen.found()
 endif
 ############# tests ############################
 
-if get_option('tests')
+if get_option('tests').enabled()
 	dep_libxml  = dependency('libxml-2.0')
 	dep_dl      = meson.get_compiler('c').find_library('dl')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,7 +7,7 @@ option('udev-dir',
        value: '',
        description: 'udev base directory [default=$prefix/lib/udev]')
 option('tests',
-       type: 'boolean',
-       value: true,
-       description: 'Build the tests [default=true]')
+       type: 'feature',
+       value: 'enabled',
+       description: 'Build the tests [default=enabled]')
 


### PR DESCRIPTION
Brings it in-line with the documentation feature (see 18722d3) so to disable
the tests, run meson -Dtests=disabled, as opposed to the previous
-Dtests=false.

No real reason other than cosmetics here.