### PR TITLE
data: Add support for Wacom One Pen Display 13

### DIFF
--- a/data/wacom-one.tablet
+++ b/data/wacom-one.tablet
@@ -1,0 +1,20 @@
+# Wacom
+# Wacom One Pen Display 13
+# DTC133
+
+[Device]
+Name=Wacom One Pen Display 13
+ModelName=DTC133
+Class=PenDisplay
+DeviceMatch=usb:056a:03a6
+Width=11
+Height=6
+# No pad buttons, so no layout
+IntegratedIn=Display
+
+[Features]
+Stylus=true
+Reversible=false
+Touch=false
+Ring=false
+Buttons=0

--- a/meson.build
+++ b/meson.build
@@ -318,6 +318,7 @@ data_files = [
 	'data/one-by-wacom-s-p.tablet',
 	'data/one-by-wacom-s-p2.tablet',
 	'data/serial-wacf004.tablet',
+	'data/wacom-one.tablet',
 	'data/xp-pen-star03.tablet',
 ]
 


### PR DESCRIPTION
Add .tablet file and add it to meson.build.

Signed-off-by: Aaron Armstrong Skomra <aaron.skomra@wacom.com>