### PR TITLE
add support for surface go

### DIFF
--- a/data/surface-go.tablet
+++ b/data/surface-go.tablet
@@ -1,0 +1,14 @@
+# This is for the Microsoft Surface Go
+
+[Device]
+Name=Microsoft Surface Go
+DeviceMatch=i2c:04F3:261A
+Class=ISDV4
+Width=8
+Height=5
+IntegratedIn=Display;System;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
this adds support for surface go and the integrated device is displayed inside gnome settings