### PR TITLE
Several test suite updates

### DIFF
--- a/test/test-tablet-validity.c
+++ b/test/test-tablet-validity.c
@@ -169,6 +169,9 @@ test_vidpid(gconstpointer data)
 			g_assert_cmpint(libwacom_get_product_id(device), >=, 0);
 			break;
 		case WBUSTYPE_USB:
+			if (libwacom_get_vendor_id(device) == 0x056A)
+				g_assert_cmpint(libwacom_get_product_id(device), !=, 0x84); /* wireless dongle */
+			/* fall through */
 		case WBUSTYPE_BLUETOOTH:
 		case WBUSTYPE_I2C:
 			g_assert_cmpint(libwacom_get_vendor_id(device), >, 0);

--- a/test/test-tablet-validity.c
+++ b/test/test-tablet-validity.c
@@ -165,8 +165,8 @@ test_vidpid(gconstpointer data)
 
 	switch (libwacom_get_bustype(device)) {
 		case WBUSTYPE_SERIAL:
-			g_assert_cmpint(libwacom_get_vendor_id(device), ==, 0);
-			g_assert_cmpint(libwacom_get_product_id(device), ==, 0);
+			g_assert_cmpint(libwacom_get_vendor_id(device), >=, 0);
+			g_assert_cmpint(libwacom_get_product_id(device), >=, 0);
 			break;
 		case WBUSTYPE_USB:
 		case WBUSTYPE_BLUETOOTH:


### PR DESCRIPTION
* Supersedes pull requests #197 and #199 to add a test which checks for the wireless dongle.
* Allow matches to non-zero VID:PID for serial devices as mentioned in #199 
* Expand VID:PID checks to all defined matches