### PR TITLE
Support Wacom HID 48EC (Dell XPS13 7390 alternate)

### DIFF
--- a/data/isdv4-48ec.tablet
+++ b/data/isdv4-48ec.tablet
@@ -1,0 +1,15 @@
+# this is for the alternate Wacom pen + touchscreen as found in the Dell XPS 13 7390
+
+[Device]
+Name=Wacom HID 48EC
+ModelName=
+DeviceMatch=i2c:056a:48ec
+Class=ISDV4
+Width=11
+Height=7
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0

--- a/meson.build
+++ b/meson.build
@@ -230,6 +230,7 @@ data_files = [
 	'data/isdv4-10f.tablet',
 	'data/isdv4-12c.tablet',
 	'data/isdv4-48c9.tablet',
+	'data/isdv4-48ec.tablet',
 	'data/isdv4-48ed.tablet',
 	'data/isdv4-50b4.tablet',
 	'data/isdv4-50b6.tablet',


### PR DESCRIPTION
Wacom touchscreen from the 2019 Dell XPS 13 2-in-1 (7390). Listed in libinput as:

```
Device:           Wacom HID 48EC Pen
Kernel:           /dev/input/event11
Group:            5
Seat:             seat0, default
Size:             288x180mm
Capabilities:     tablet 
Tap-to-click:     n/a
Tap-and-drag:     n/a
Tap drag lock:    n/a
Left-handed:      n/a
Nat.scrolling:    n/a
Middle emulation: n/a
Calibration:      identity matrix
Scroll methods:   none
Click methods:    none
Disable-w-typing: n/a
Accel profiles:   none
Rotation:         n/a

Device:           Wacom HID 48EC Finger
Kernel:           /dev/input/event12
Group:            5
Seat:             seat0, default
Size:             288x180mm
Capabilities:     touch 
Tap-to-click:     n/a
Tap-and-drag:     n/a
Tap drag lock:    n/a
Left-handed:      n/a
Nat.scrolling:    n/a
Middle emulation: n/a
Calibration:      identity matrix
Scroll methods:   none
Click methods:    none
Disable-w-typing: n/a
Accel profiles:   n/a
Rotation:         n/a
```
Device works with libinput, but only single touch. 


**udevadm info output**
```
P: /devices/pci0000:00/0000:00:15.0/i2c_designware.0/i2c-15/i2c-434538344D4F4357:00/0018:056A:48EC.0006/input/input30/event12
N: input/event12
L: 0
S: input/by-path/pci-0000:00:15.0-platform-i2c_designware.0-event
E: DEVPATH=/devices/pci0000:00/0000:00:15.0/i2c_designware.0/i2c-15/i2c-434538344D4F4357:00/0018:056A:48EC.0006/input/input30/event12
E: DEVNAME=/dev/input/event12
E: MAJOR=13
E: MINOR=76
E: SUBSYSTEM=input
E: USEC_INITIALIZED=5582150
E: ID_INPUT=1
E: ID_INPUT_TOUCHSCREEN=1
E: ID_INPUT_WIDTH_MM=288
E: ID_INPUT_HEIGHT_MM=180
E: ID_PATH=pci-0000:00:15.0-platform-i2c_designware.0
E: ID_PATH_TAG=pci-0000_00_15_0-platform-i2c_designware_0
E: LIBINPUT_DEVICE_GROUP=18/56a/48ec:i2c-434538344D4F4357:00
E: LIBINPUT_FUZZ_35=4
E: LIBINPUT_FUZZ_36=4
E: DEVLINKS=/dev/input/by-path/pci-0000:00:15.0-platform-i2c_designware.0-event
```

I'm not 100% about the value for `Name:`. Dmesg and everywhere else lists TWO inputs with the same pci address: `Wacom HID 48EC Pen as /devices/pci0000:00/0000:00:15.0/i2c_designware.0/i2c-15/i2c-434538344D4F4357:00/0018:056A:48EC.0006/input/input29` and 
`input: Wacom HID 48EC Finger as /devices/pci0000:00/0000:00:15.0/i2c_designware.0/i2c-15/i2c-434538344D4F4357:00/0018:056A:48EC.0006/input/input30`
