### PR TITLE
data: Add ISDv4 2D1F:001E (Samsung Notebook 9 Pro)

### DIFF
--- a/data/isdv4-2d1f-001e.tablet
+++ b/data/isdv4-2d1f-001e.tablet
@@ -1,0 +1,15 @@
+# EMR (?) sensor used by the Samsung 940X5N (Samsung Notebook 9 Pro)
+# Wacom-alternate VID
+
+[Device]
+Name=Wacom ISDv4 1E
+ModelName=
+DeviceMatch=i2c:2d1f:001e
+Class=ISDV4
+Width=13
+Height=7
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Buttons=0

--- a/meson.build
+++ b/meson.build
@@ -224,6 +224,7 @@ data_files = [
 	'data/intuos-s-p3-wl.tablet',
 	'data/intuos-s-pt.tablet',
 	'data/intuos-s-pt2.tablet',
+	'data/isdv4-2d1f-001e.tablet',
 	'data/isdv4-2d1f-002e.tablet',
 	'data/isdv4-10d.tablet',
 	'data/isdv4-10e.tablet',


### PR DESCRIPTION
Ref: https://github.com/linuxwacom/wacom-hid-descriptors/issues/82
Ref: https://github.com/linuxwacom/xf86-input-wacom/issues/97
Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>