### PR TITLE
data: Add ISDv4 51F5 (Lenovo ThinkPad L13 Yoga)

### DIFF
--- a/data/isdv4-51f5.tablet
+++ b/data/isdv4-51f5.tablet
@@ -1,0 +1,16 @@
+# this is for the Wacom pen + touchscreen as found in the ThinkPad L13 Yoga
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/83
+
+[Device]
+Name=Wacom ISDv4 F1F5
+ModelName=
+DeviceMatch=usb:056a:51f5
+Class=ISDV4
+Width=12
+Height=7
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0

--- a/meson.build
+++ b/meson.build
@@ -249,6 +249,7 @@ data_files = [
 	'data/isdv4-51bf.tablet',
 	'data/isdv4-51c4.tablet',
 	'data/isdv4-51e2.tablet',
+	'data/isdv4-51f5.tablet',
 	'data/isdv4-51f6.tablet',
 	'data/isdv4-90.tablet',
 	'data/isdv4-93.tablet',


### PR DESCRIPTION
Ref: https://github.com/linuxwacom/wacom-hid-descriptors/issues/83
Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>