### PR TITLE
Unbreak autotools build on BSDs

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,9 +1,9 @@
 libwacomtabletdir = $(datadir)/libwacom
-tablet_files = $(shell find $(top_srcdir)/data -name "*.tablet" -printf "%P\n")
+tablet_files = $(shell cd $(top_srcdir)/data; printf '%s\n' *.tablet)
 dist_libwacomtablet_DATA =  $(tablet_files)
 
 libwacomstylusdir = $(datadir)/libwacom
-stylus_files = $(shell find $(top_srcdir)/data -name "*.stylus" -printf "%P\n")
+stylus_files = $(shell cd $(top_srcdir)/data; printf '%s\n' *.stylus)
 dist_libwacomstylus_DATA = $(stylus_files)
 
 EXTRA_DIST = \

--- a/data/layouts/Makefile.am
+++ b/data/layouts/Makefile.am
@@ -1,5 +1,5 @@
 libwacomlayoutsdir = $(datadir)/libwacom/layouts
-layouts = $(shell find $(top_srcdir)/data/layouts -name "*.svg" -printf "%P\n")
+layouts = $(shell cd $(top_srcdir)/data/layouts; printf '%s\n' *.svg)
 dist_libwacomlayouts_DATA =  $(layouts)
 
 EXTRA_DIST = README


### PR DESCRIPTION
See find(1) manpage on [DragonFly](https://www.dragonflybsd.org/cgi/web-man?command=find&section=1), [FreeBSD](https://man.freebsd.org/find/1), [NetBSD](https://netbsd.gw.com/cgi-bin/man-cgi?find+1+NetBSD-current) [OpenBSD](https://man.openbsd.org/find.1). While build doesn't actually fail despite errors some files end up not being installed e.g., https://github.com/freebsd/freebsd-ports/commit/eea904e27f1b