### PR TITLE
Unbreak tests on FreeBSD

### DIFF
--- a/data/check-data-in-meson.build.sh
+++ b/data/check-data-in-meson.build.sh
@@ -1,7 +1,9 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 pushd "$1" > /dev/null
-diff -u1 <(grep -o 'data/.*\.tablet' meson.build) <(ls -v data/*.tablet)
-diff -u1 <(grep -o 'data/.*\.stylus' meson.build) <(ls -v data/*.stylus)
-diff -u1 <(grep -o 'data/layouts/.*\.svg' meson.build) <(ls -v data/layouts/*.svg)
+diff -u1 <(grep -o 'data/.*\.tablet' meson.build) <(printf '%s\n' data/*.tablet | sort -V)
+diff -u1 <(grep -o 'data/.*\.stylus' meson.build) <(printf '%s\n' data/*.stylus | sort -V)
+diff -u1 <(grep -o 'data/layouts/.*\.svg' meson.build) <(printf '%s\n' data/layouts/*.svg | sort -V)
 popd > /dev/null

--- a/data/check-files-in-git.sh
+++ b/data/check-files-in-git.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage: check-files-in-git.sh /path/to/libwacom/
 

--- a/data/check-svg-exists.sh
+++ b/data/check-svg-exists.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Usage: check-svg-exists.sh /path/to/libwacom/
 

--- a/run-full-test.sh
+++ b/run-full-test.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 date=`date +"%Y-%m-%d-%H.%M.%S"`
 builddir="build.$date"


### PR DESCRIPTION
<details><summary>Tests output</summary>

```
$ cc --version
FreeBSD clang version 10.0.0 (git@github.com:llvm/llvm-project.git 90c78073f73eac58f4f8b4772a896dc8aac023bc)
Target: x86_64-unknown-freebsd13.0
Thread model: posix
InstalledDir: /usr/bin

$ meson _build
$ ninja -C _build test
ninja: Entering directory `_build'
[0/1] Running all tests.
 1/10 libwacom:all / files-in-git             OK       0.81 s
 2/10 libwacom:all / svg-layout-exists        OK       1.06 s
 3/10 libwacom:all / data-files-in-meson.build  OK       0.25 s
 4/10 libwacom:all+valgrind / test-load       OK       0.14 s
 5/10 libwacom:all+valgrind / test-dbverify   OK       0.25 s
 6/10 libwacom:all+valgrind / test-tablet-validity  OK       0.15 s
 7/10 libwacom:all+valgrind / test-stylus-validity  OK       0.05 s
 8/10 libwacom:all+valgrind / test-svg-validity  OK       0.18 s
 9/10 libwacom:all / test-deprecated          OK       0.01 s
10/10 libwacom:all / test-ltversion           OK       0.03 s

Ok:                   10
Expected Fail:         0
Fail:                  0
Unexpected Pass:       0
Skipped:               0
Timeout:               0
```
</details>
