### PR TITLE
data: Fix ISDv4 5044

### DIFF
--- a/data/isdv4-5044.tablet
+++ b/data/isdv4-5044.tablet
@@ -8,7 +8,7 @@ Name=Wacom ISDv4 5044
 ModelName=
 DeviceMatch=usb:056a:5044
 Class=ISDV4
-Width=10
+Width=11
 Height=6
 IntegratedIn=Display;System
 


### PR DESCRIPTION
Fix the incorrect width. Sensor is 27648 units wide with a resolution
of 2540 lpi.

Ref: https://github.com/linuxwacom/wacom-hid-descriptors/issues/88