### PR TITLE
data: Add Huion 420

### DIFF
--- a/data/huion-420.tablet
+++ b/data/huion-420.tablet
@@ -1,0 +1,18 @@
+# HUION
+# H420
+#
+
+[Device]
+Name=Huion 420
+ModelName=
+DeviceMatch=usb:256c:006e:HUION 420 Pen;usb:256c:006e:HUION 420 Pad;
+Class=Bamboo
+Width=4
+Height=2
+IntegratedIn=
+Styli=0xffffd;
+
+[Features]
+Stylus=true
+Reversible=true
+Buttons=0


### PR DESCRIPTION
I've omitted a layout SVG, since this tablet has no buttons or anything but the active area. Hopefully that's alright, if not I can make one. `Styli` was copied over from the H420 definition.