### PR TITLE
data: fix typo in Huion H420 SVG title

### DIFF
--- a/data/layouts/huion-h420.svg
+++ b/data/layouts/huion-h420.svg
@@ -9,7 +9,7 @@
    width="355"
    height="250">
   <title
-     id="title">Huion H410</title>
+     id="title">Huion H420</title>
   <g>
     <circle
        r="7.5"


### PR DESCRIPTION
Noticed this minor typo while looking for layout examples. As far as I can find, the H410 is not an existing device, and most likely a typo.