### PR TITLE
data: add GAOMON S56K tablet definition

### DIFF
--- a/data/gaomon-s56k.tablet
+++ b/data/gaomon-s56k.tablet
@@ -1,0 +1,27 @@
+# GAOMON
+# S56K
+#
+# This tablet masquerades as a Huion (vendor 256c) tablet despite not being the
+# same manufacturer.
+#
+# The pen is visually identical to that from the Huion 420, so the Styli
+# parameter has been copied from it.
+#
+# The exposed device names are the same as in the Huion 420, with "Huion"
+# replaced by "Tablet Monitor".
+#
+
+[Device]
+Name=GAOMON S56K
+ModelName=
+DeviceMatch=usb:256c:006e:Tablet Monitor Pen;usb:256c:006e:Tablet Monitor Pad;
+Class=Bamboo
+Width=6
+Height=5
+IntegratedIn=
+Styli=0xffffd;
+
+[Features]
+Stylus=true
+Reversible=false
+Buttons=0


### PR DESCRIPTION
This PR adds a tablet definition for the [GAOMON S56K tablet](https://www.amazon.ca/GAOMON-Graphics-Drawing-Portable-Battery/dp/B01LL2QGXA) (thanks to @kiritofeng who let me prod it remotely).

If I understand the `Reversible` parameter correctly, this tablet isn't.

This tablet seems pretty weird to me... it masquerades as a Huion (vendor `256c`) despite not being the same manufacturer, and the pen is visually identical to my Huion 420's. Since it is, I just copied the `Styli` from the Huion 420 definition.

The device names in general just seem to have `s/Huion/Tablet Monitor/g` applied. I noticed `65-libwacom.rules` in systemd had:

```
# HUION consumer control devices are not tablets.                                                                       
ATTRS{name}=="HUION * Consumer Control", GOTO="libwacom_end"    
```

I'm not sure if that should be adjusted for this tablet, but thought I'd mention it. The devices this tablet exposes are:

```
/dev/input/event21:     Tablet Monitor Pad
/dev/input/event22:     Tablet Monitor Mouse
/dev/input/event23:     Tablet Monitor Keyboard
/dev/input/event24:     Tablet Monitor Consumer Control
/dev/input/event25:     Tablet Monitor System Control
```