### PR TITLE
tools: expand Huion consumer control quirk to include GAOMON

### DIFF
--- a/tools/65-libwacom.rules.in
+++ b/tools/65-libwacom.rules.in
@@ -3,8 +3,9 @@
 ACTION!="add|change", GOTO="libwacom_end"
 KERNEL!="event[0-9]*", GOTO="libwacom_end"
 
-# HUION consumer control devices are not tablets.
-ATTRS{name}=="HUION * Consumer Control", GOTO="libwacom_end"
+# HUION and GAOMON consumer and system control devices are not tablets.
+ATTRS{name}=="* Consumer Control", GOTO="libwacom_end"
+ATTRS{name}=="* System Control", GOTO="libwacom_end"
 
 # Match all serial wacom tablets with a serial ID starting with WACf
 ENV{ID_BUS}=="tty|pnp", ATTRS{id}=="WACf*", ENV{ID_INPUT}="1", ENV{ID_INPUT_TABLET}="1", GOTO="libwacom_end"


### PR DESCRIPTION
For instance, a GAOMON S56K device exposes "Tablet Monitor Consumer
Control" and "Tablet Monitor System Control" devices, both of which are
not tablet devices.

Instead of listing the Cartesian product of [HUION, TabletMonitor] &times; [Consumer Control, System Control] (as far as I can tell the udev syntax doesn't allow regex-like groupings?), I relaxed the matching to exclude all Consumer/System Control devices. I can write the Cartesian product directly if that's preferred, though.