### PR TITLE
Support Wacom Volito 4x5 (FT-0405, 056a:0060)

### DIFF
--- a/data/volito-4x5.tablet
+++ b/data/volito-4x5.tablet
@@ -1,0 +1,15 @@
+# Wacom
+# Volito 4x5
+# FT-0405
+
+[Device]
+Name=Wacom Volito 4x5
+ModelName=FT-0405
+DeviceMatch=usb:056a:0060
+Width=5
+Height=4
+Styli=0xffffd;
+
+[Features]
+Stylus=true
+Buttons=0


### PR DESCRIPTION
A pretty ancient and simple (it has a pen with no eraser and only one button) device but in the pre-libinput (or perhaps legacy-driver) days it worked perfectly - I was able to, out of the box, draw with varying pressure in the GIMP and the on-stylus button correctly worked as the right-mouse button. Getting it to work on a modern system took some work (in case anyone is interested, turns out that in order to both have the driver trigger button-1 events on contact with the tablet surface rather than as soon as the stylus came into proximity, and to get any pressure readings other than 1 once down, I had to change the threshold from the default 26 to 5 _exactly_ - no other value I have tried seems to have any effect) but in the end it does work too, and as a bonus it seems the generic no-eraser stylus definition suffices in spite of the Volito stylus (ID 0x2, in case anyone wants to know) only having one button - we simply never get any events from the second button.
