### PR TITLE
data: Correct tablet name for ISDv4 51F6 (was: F1F6)

### DIFF
--- a/data/isdv4-51f6.tablet
+++ b/data/isdv4-51f6.tablet
@@ -2,7 +2,7 @@
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/78
 
 [Device]
-Name=Wacom ISDv4 F1F6
+Name=Wacom ISDv4 51F6
 ModelName=
 DeviceMatch=usb:056a:51f6
 Class=ISDV4


### PR DESCRIPTION
Signed-off-by: Jason Gerecke <jason.gereke@wacom.com>