### PR TITLE
Add HP ZBook Studio x360 G5 Wacom AES sensor 48d6

### DIFF
--- a/data/isdv4-48d6.tablet
+++ b/data/isdv4-48d6.tablet
@@ -1,0 +1,16 @@
+# Active electrostatic (AES) sensor used by the HP ZBook Studio x360 G5
+
+[Device]
+Name=Wacom ISDv4 48d6
+ModelName=
+DeviceMatch=i2c:056a:48d6
+Class=ISDV4
+Width=14
+Height=8
+IntegratedIn=Display;System
+Styli=@isdv4-aes;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
Add AES sensor used by the HP ZBook Studio x360 G5.

Tested with the HP Rechargeable Active Pen G3 (0x826B). Aside: I noticed that this stylus is listed in #178 without a name; is there some info I could provide to document it better?

For reference, I've attached [record_1589605219.tar.gz](https://github.com/linuxwacom/libwacom/files/4637982/record_1589605219.tar.gz) produced by [the caputure.sh script](https://gist.githubusercontent.com/jigpu/b7b47e4bede584cec8562f666fd84af4/raw/af36c0a0fc2c019750472443369915ad7ea97737/capture.sh).
