### PR TITLE
Tablet config for Elan 2415

### DIFF
--- a/data/elan-2514.tablet
+++ b/data/elan-2514.tablet
@@ -1,0 +1,14 @@
+# ELAN touchscreen/pen sensor present in the HP Spectre x360 Convertible 13-aw0xxx
+[Device]
+Name=ELAN 2514
+ModelName=
+DeviceMatch=i2c:04f3:29f5
+Class=ISDV4
+Width=12
+Height=7
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
Found in HP Spectre x360 13-aw0xxx series.

Changes modeled after #95, the tablet is now recognized in Gnome's settings (but the stylus isn't).

`xsetwacom --list` still shows no devices.