### PR TITLE
Unbreak -Werror on FreeBSD

### DIFF
--- a/tools/list-compatible-styli.c
+++ b/tools/list-compatible-styli.c
@@ -32,6 +32,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#include <libgen.h>
 #include <unistd.h>
 #include "libwacom.h"
 

--- a/tools/list-devices.c
+++ b/tools/list-devices.c
@@ -32,6 +32,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#include <libgen.h>
 #include <unistd.h>
 #include "libwacom.h"
 


### PR DESCRIPTION
See [error log](https://github.com/linuxwacom/libwacom/files/4639598/libwacom-1.3.log) caused by the following flags
https://github.com/linuxwacom/libwacom/blob/fbf519f76e235e4f465ae2f91066415f49c74318/.travis.yml#L22