### PR TITLE
Fix the version number for the new API

### DIFF
--- a/libwacom/libwacom.sym
+++ b/libwacom/libwacom.sym
@@ -72,7 +72,7 @@ local:
         *;
 };
 
-LIBWACOM_1.2 {
+LIBWACOM_1.4 {
 global:
     libwacom_stylus_get_eraser_type;
     libwacom_stylus_get_paired_ids;


### PR DESCRIPTION
The version number is technically meaningless since it's just a string. But we
try to keep it in sync with the version the API was introduced in.