### PR TITLE
Change 6100WL class from Bamboo

### DIFF
--- a/data/intuos-m-p3-wl.tablet
+++ b/data/intuos-m-p3-wl.tablet
@@ -21,7 +21,7 @@
 Name=Wacom Intuos BT M
 ModelName=CTL-6100WL
 DeviceMatch=usb:056a:0378;bluetooth:056a:0379
-Class=Bamboo
+Class=Intuos3
 Width=9
 Height=5
 Layout=intuos-m-p3.svg

--- a/data/intuos-m-p3-wl.tablet
+++ b/data/intuos-m-p3-wl.tablet
@@ -21,7 +21,6 @@
 Name=Wacom Intuos BT M
 ModelName=CTL-6100WL
 DeviceMatch=usb:056a:0378;bluetooth:056a:0379
-Class=Intuos3
 Width=9
 Height=5
 Layout=intuos-m-p3.svg
@@ -35,3 +34,4 @@ Buttons=4
 
 [Buttons]
 Top=A;B;C;D
+EvdevCodes=0x100;0x101;0x102;0x103

--- a/data/intuos-m-p3.tablet
+++ b/data/intuos-m-p3.tablet
@@ -21,7 +21,6 @@
 Name=Wacom Intuos M
 ModelName=CTL-6100
 DeviceMatch=usb:056a:0375
-Class=Bamboo
 Width=9
 Height=5
 Layout=intuos-m-p3.svg
@@ -35,3 +34,4 @@ Buttons=4
 
 [Buttons]
 Top=A;B;C;D
+EvdevCodes=0x100;0x101;0x102;0x103


### PR DESCRIPTION
The buttons does not send `0x110-0x114`, as already commented in the file:

> Buttons are no loger RIGHT, LEFT, FORWARD, and BACKWARD.
> The buttons are now reported as numbered buttons as with
> the Intuos Pro series.

This can be checked with `libinput record`, which, on my system, outputs
```
  events:
  - evdev:
    - [  0,      0,   1, 256,       1] # EV_KEY / BTN_0                     1
  - evdev:
    - [  0,      0,   3,  40,      15] # EV_ABS / ABS_MISC                 15 (+15)
    - [  0,      0,   0,   0,       0] # ------------ SYN_REPORT (0) ---------- +0ms
  - evdev:
    - [  0, 135988,   1, 256,       0] # EV_KEY / BTN_0                     0
    - [  0, 135988,   3,  40,       0] # EV_ABS / ABS_MISC                  0 (-15)
    - [  0, 135988,   0,   0,       0] # ------------ SYN_REPORT (0) ---------- +135ms
```

where `BTN_0 == 0x100` is the evdev code sent. 

When the class is `Bamboo` the [heuristic here](https://github.com/linuxwacom/libwacom/blob/master/libwacom/libwacom-database.c#L474) set the button code to `BTN_LEFT == 0x110`.

Applying this commit made `libinput debug-events` output events when the buttons are clicked, vs. before when nothing happened.

I'm not sure if `Intuos3` is really the right class to use here, but it seems to work well. 