### PR TITLE
Deprecate the WacomClass in the API

### DIFF
--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -781,7 +781,7 @@ libwacom_print_device_description(int fd, const WacomDevice *device)
 	WacomClass class;
 	const char *class_name;
 
-	class  = libwacom_get_class(device);
+	class  = device->cls;
 	switch(class) {
 		case WCLASS_UNKNOWN:	class_name = "Unknown";	break;
 		case WCLASS_INTUOS3:	class_name = "Intuos3";	break;

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -130,6 +130,9 @@ typedef enum {
 
 /**
  * Classes of devices.
+ *
+ * @deprecated This enum should no longer be used. The classes are not
+ * fine-grained or reliable enough to be useful.
  */
 typedef enum {
 	WCLASS_UNKNOWN,		/**< Unknown/unsupported device class */
@@ -363,7 +366,11 @@ int libwacom_compare(const WacomDevice *a, const WacomDevice *b, WacomCompareFla
 /**
  * @param device The tablet to query
  * @return The class of the device
+ *
+ * @deprecated This function should no longer be used. The classes are not
+ * fine-grained or reliable enough to be useful.
  */
+LIBWACOM_DEPRECATED
 WacomClass libwacom_get_class(const WacomDevice *device);
 
 /**

--- a/test/test-load.c
+++ b/test/test-load.c
@@ -109,7 +109,10 @@ test_intuos4(struct fixture *f, gconstpointer user_data)
 	g_assert_nonnull(device);
 
 	g_assert_cmpstr(libwacom_get_name(device), ==, "Wacom Intuos4 WL");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	g_assert_cmpint(libwacom_get_class(device), ==, WCLASS_INTUOS4);
+#pragma GCC diagnostic pop
 	g_assert_cmpint(libwacom_get_vendor_id(device), ==, 0x56a);
 	g_assert_cmpint(libwacom_get_product_id(device), ==, 0xbc);
 	g_assert_cmpint(libwacom_get_bustype(device), ==, WBUSTYPE_USB);

--- a/test/test-tablet-validity.c
+++ b/test/test-tablet-validity.c
@@ -129,8 +129,13 @@ static void
 test_class(gconstpointer data)
 {
 	WacomDevice *device = (WacomDevice*)data;
+	WacomClass cls;
 
-	switch (libwacom_get_class(device)) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+	cls = libwacom_get_class(device);
+#pragma GCC diagnostic pop
+	switch (cls) {
 		case WCLASS_BAMBOO:
 		case WCLASS_ISDV4:
 		case WCLASS_PEN_DISPLAYS:
@@ -319,6 +324,7 @@ _add_test(WacomDevice *device, GTestDataFunc func, const char *funcname)
 static void setup_tests(WacomDevice *device)
 {
 	const char *name;
+	WacomClass cls;
 
 	name = libwacom_get_name(device);
 	if (strcmp(name, "Generic") == 0)
@@ -334,16 +340,20 @@ static void setup_tests(WacomDevice *device)
 	add_test(device, test_rings);
 	add_test(device, test_strips);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+	cls = libwacom_get_class(device);
+#pragma GCC diagnostic pop
+
 	/* ISDv4 are built-in, they may be of varying size */
-	if (libwacom_get_class(device) != WCLASS_ISDV4 &&
-	    libwacom_get_class(device) != WCLASS_REMOTE)
+	if (cls != WCLASS_ISDV4 && cls != WCLASS_REMOTE)
 		add_test(device, test_dimensions);
 
 	/* FIXME: we force the generic pen for these, should add a test */
 	if (libwacom_has_stylus(device))
 		add_test(device, test_styli);
 
-	switch (libwacom_get_class(device)) {
+	switch (cls) {
 		case WCLASS_INTUOS:
 		case WCLASS_INTUOS2:
 		case WCLASS_INTUOS3:


### PR DESCRIPTION
To my knowledge, they are not used by anyone outside libwacom itself (which
uses it to set up default button mappings where EvdevCodes is missing) and
their usefulness has degraded over time anyway (any post-I5 device is now also
Intuos5) and the vast majority of devices now are ISDV4. So for any device
bought in the last few years, it's either Cintiq, Intuos5 or ISDV5.

And non-Wacom tablets are even harder to categorize.

Let's deprecate this so if there are any users, they get a compiler warning
about it at least.