### PR TITLE
data: fix button codes for the 6100WL

### DIFF
--- a/data/intuos-m-p3-wl.tablet
+++ b/data/intuos-m-p3-wl.tablet
@@ -35,3 +35,4 @@ Buttons=4
 
 [Buttons]
 Top=A;B;C;D
+EvdevCodes=0x100;0x101;0x102;0x103

--- a/data/intuos-m-p3.tablet
+++ b/data/intuos-m-p3.tablet
@@ -35,3 +35,4 @@ Buttons=4
 
 [Buttons]
 Top=A;B;C;D
+EvdevCodes=0x100;0x101;0x102;0x103


### PR DESCRIPTION
The buttons do not send 0x110-0x114, as already commented in the file:

    Buttons are no loger RIGHT, LEFT, FORWARD, and BACKWARD.
    The buttons are now reported as numbered buttons as with
    the Intuos Pro series.

The heuristics in set_button_codes_from_heuristics() default to the
LEFT/RIGHT/...  buttons for Class=Bamboo though, so let's set the codes
explicitly.

Fixes #5 

cc @martinhath, it was faster to quickly fix this here than making you go through another fix/push/review cycle.