### PR TITLE
meson.build: ignore Makefile.in when installing data

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -94,10 +94,12 @@ install_subdir('data',
 	       install_dir: dir_data,
 	       strip_directory: true,
 	       exclude_files: ['wacom.example',
-		       	       'check-files-in-git.sh',
+			       'check-files-in-git.sh',
 			       'check-svg-exists.sh',
 			       'Makefile.am',
+			       'Makefile.in',
 			       'layouts/Makefile.am',
+			       'layouts/Makefile.in',
 			       'layouts/README'])
 
 test('files-in-git',


### PR DESCRIPTION
A tarball generated with autotools has a generated Makefile.in in every
directory we have a Makefile.am. Using install_subdir() we end up installing
that file unless we explicitly exclude it. This doesn't happen when building
from git (unless the git tree is dirty from a previous autotools setup).

And sneak a "space before tab" whitespace change in while we're in that
vincinity.