### PR TITLE
travis: update to bionic (ubuntu 18.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: bionic
 language: c
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,9 +134,8 @@ jobs:
         - COVERITY_SCAN_BRANCH_PATTERN=".*"
         - COVERITY_URL="https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh"
         - secure: 'd0i9vJa6/lNDlCYMbKjNI77j1xnhw0ktBDAz0C10QbzIx17EsaYXOuAgO2ffWdIdGU7cP7yCH3gZGTRLnaPZfj7z1n7W81A8Hlosfc7AGcSW+EAo8T+CSxdFw1BfEPPWctsBP2y02INrOCno9k00pnW1shHlT7QzPxnHIsuPmHv21AbyUGbGk3nmvnfGg60dIYOLPdkZFNCGTNf6XtE0KVB0TLwS03/K8R1GnMtm5Qs0FXIDYMfASn1kKTPQOERYUIDABMCeYBfgHtiRvAzZkcxRnjVdoZvByDCfTeOtA3gS0bQ+nMt2UEHz2zzUS2egRGfAOafEqhvMrxEAdU9+HXNZIoPJfkLZWkUoe+3U/+Zj3NoIK/mpmtRFtHLyISp7kL/kQ9g8+cJPL5EI2RvIRM5cdf5Z47kI0Y0tQjceONz/7cHHCozZsrCLTjB4rlgWOxhbu+UL9C8vKYO1AX6rl1R/4J/WKc/ODztmNQem3u/GQEfHXyKVO+zrehAjtKb08wjQEGyMJYB7hxS3tDCb9/cCHkdi81Sx2WtF8mXp4TjCJafx7vyBo4VVlDuExvjodrZh/50KrzzZ+wGDE0tN42tJsuMGvJVTteNNk1pQ7r6XSlTOjbGsAQE+ri6Q8XBx63ES5Y1oN0bkA38KqhCfOrZIKXtx7QMLpPv2QKCaccg='
-      before_install:
-        - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
       before_script:
+        - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
         - curl -fs "$COVERITY_URL" > coverity.sh && sed -i 's/"$status_code" != "201"/"$status_code" -lt 200 -o "$status_code" -ge 300/' coverity.sh && chmod +x coverity.sh
       script:
         - ./autogen.sh --disable-silent-rules

--- a/meson.build
+++ b/meson.build
@@ -264,7 +264,10 @@ if get_option('tests').enabled()
 					     include_directories: [includes_src],
 					     c_args: tests_cflags,
 					     install: false)
-		test('test-deprecated', test_deprecated, suite: ['all'])
+		test('test-deprecated',
+		     test_deprecated,
+		     env:['LD_LIBRARY_PATH=@0@'.format(meson.build_root())],
+		     suite: ['all'])
 	endif
 endif
 


### PR DESCRIPTION
Let's use something 2 years old instead of 4 years old! Travis still defaults
to 16.04 and 20.04 is not (yet?) available.