### PR TITLE
data: Add "Styli=@isdv4-aes;" to new AES devices

### DIFF
--- a/data/isdv4-4838.tablet
+++ b/data/isdv4-4838.tablet
@@ -14,6 +14,7 @@ Class=ISDV4
 Width=10
 Height=7
 IntegratedIn=Display;System
+Styli=@isdv4-aes;
 
 [Features]
 Stylus=true

--- a/data/isdv4-4851.tablet
+++ b/data/isdv4-4851.tablet
@@ -14,6 +14,7 @@ Class=ISDV4
 Width=10
 Height=7
 IntegratedIn=Display;System
+Styli=@isdv4-aes;
 
 [Features]
 Stylus=true

--- a/data/isdv4-4957.tablet
+++ b/data/isdv4-4957.tablet
@@ -14,6 +14,7 @@ Class=ISDV4
 Width=12
 Height=7
 IntegratedIn=Display;System
+Styli=@isdv4-aes;
 
 [Features]
 Stylus=true


### PR DESCRIPTION
The wacom-hid-descriptors script to autogenerate tablet definitions from
sysinfo data was not updated to add a Styli line in its output after
libwacom began supporting AES styli. Autogenerated definitions added after
the addition of AES support need manual updating.

The autogeneration script has since been updated to add the Styli lines.

Signed-off-by: Jason Gerecke <jason.gerecke@wacom.com>