### PR TITLE
travis CI: drop root: sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 dist: bionic
 language: c
 


### PR DESCRIPTION
deprecated and has no effect, as the travis CI helpfully points out