### PR TITLE
When loading devices for a vid/pid, fall back to bluetooth and i2c

### DIFF
--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -570,6 +570,10 @@ libwacom_new_from_usbid(const WacomDeviceDatabase *db, int vendor_id, int produc
 	}
 
 	device = libwacom_new(db, NULL, vendor_id, product_id, WBUSTYPE_USB, error);
+	if (!device)
+		device = libwacom_new(db, NULL, vendor_id, product_id, WBUSTYPE_I2C, error);
+	if (!device)
+		device = libwacom_new(db, NULL, vendor_id, product_id, WBUSTYPE_BLUETOOTH, error);
 
 	if (device)
 		return libwacom_copy(device);

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -301,6 +301,9 @@ WacomDevice* libwacom_new_from_path(const WacomDeviceDatabase *db, const char *p
  * In case of error, NULL is returned and the error is set to the
  * appropriate value.
  *
+ * @note The term "usbid" is misleading, this function will return
+ * devices with matching ids on the USB, Bluetooth or i2c bus.
+ *
  * @param db A device database
  * @param vendor_id The vendor ID of the device
  * @param product_id The product ID of the device

--- a/test/test-load.c
+++ b/test/test-load.c
@@ -241,6 +241,22 @@ test_bamboopen(struct fixture *f, gconstpointer user_data)
 	libwacom_destroy(device);
 }
 
+static void
+test_isdv4_4800(struct fixture *f, gconstpointer user_data)
+{
+	WacomDevice *device = libwacom_new_from_usbid(f->db, 0x56a, 0x4800, NULL);
+	g_assert_nonnull(device);
+
+	g_assert_true(libwacom_get_integration_flags(device) & WACOM_DEVICE_INTEGRATED_DISPLAY);
+	g_assert_true(libwacom_get_integration_flags(device) & WACOM_DEVICE_INTEGRATED_SYSTEM);
+	g_assert_null(libwacom_get_model_name(device));
+	g_assert_cmpint(libwacom_get_vendor_id(device), ==, 0x56a);
+	g_assert_cmpint(libwacom_get_product_id(device), ==, 0x4800);
+	g_assert_cmpint(libwacom_get_num_buttons(device), ==, 0);
+
+	libwacom_destroy(device);
+}
+
 int main(int argc, char **argv)
 {
 	g_test_init(&argc, &argv, NULL);
@@ -272,6 +288,9 @@ int main(int argc, char **argv)
 		   fixture_teardown);
 	g_test_add("/load/056a:WACf004", struct fixture, NULL,
 		   fixture_setup, test_wacf004,
+		   fixture_teardown);
+	g_test_add("/load/056a:4800", struct fixture, NULL,
+		   fixture_setup, test_isdv4_4800,
 		   fixture_teardown);
 
 	return g_test_run();


### PR DESCRIPTION
The term 'usbid' here is misleading in the API and it's not worth adding
separate functions (or a new generic function) for the other busses. Where the
vid/pid matches, return the device for any bus (except the vid/pid-less serial
bus).