### PR TITLE
Data: Add ELAN 2514 variant i2c:04F3:29CF (HP ENVY x360 Convertable 15-dr1xxx)

### DIFF
--- a/data/elan-2514-alt2.tablet
+++ b/data/elan-2514-alt2.tablet
@@ -1,7 +1,4 @@
 # ELAN touchscreen/pen sensor present in the HP Envy x360 Converti0ble 15-dr1xxx
-# Width and Height are rounded up to the nearest inch.  Real measurements are:
-# Width: 13 5/8"
-# Height: 7 5/8"
 #
 # Sysinfo:
 # sysinfo.uFNKtCProZ
@@ -10,7 +7,7 @@
 [Device]
 Name=ELAN 2514
 ModelName=
-DeviceMatch=i2c:04f3:29CF
+DeviceMatch=i2c:04f3:29cf
 Class=ISDV4
 Width=14
 Height=8

--- a/data/elan-2514-alt2.tablet
+++ b/data/elan-2514-alt2.tablet
@@ -1,0 +1,22 @@
+# ELAN touchscreen/pen sensor present in the HP Envy x360 Converti0ble 15-dr1xxx
+# Width and Height are rounded up to the nearest inch.  Real measurements are:
+# Width: 13 5/8"
+# Height: 7 5/8"
+#
+# Sysinfo:
+# sysinfo.uFNKtCProZ
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/102
+
+[Device]
+Name=ELAN 2514
+ModelName=
+DeviceMatch=i2c:04f3:29CF
+Class=ISDV4
+Width=14
+Height=8
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
This is based on #286 with a similar file-name structure.  I also contributed the sysinfo as an issue on wacom-hid-descriptors.

Let me know if there are any changes needed.