### PR TITLE
Add support for ELAN-2514 variant i2c:04f3:2af4

### DIFF
--- a/data/elan-2514.tablet
+++ b/data/elan-2514.tablet
@@ -1,8 +1,20 @@
-# ELAN touchscreen/pen sensor present in the HP Spectre x360 Convertible 13-aw0xxx
+# ELAN touchscreen/pen sensor
+
+# i2c:04f3:29f5
+#
+# HP Spectre x360 Convertible 13-aw0xxx
+
+# i2c:04f3:2af4
+#
+# HP Envy x360 Convertible 13-ay0xxx
+#
+# sysinfo.L1vXaj9Wcz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/110
+
 [Device]
 Name=ELAN 2514
 ModelName=
-DeviceMatch=i2c:04f3:29f5
+DeviceMatch=i2c:04f3:29f5;i2c:04f3:2af4;
 Class=ISDV4
 Width=12
 Height=7


### PR DESCRIPTION
HP Envy x360 Convertible 13-ay0xxx

sysinfo.L1vXaj9Wcz
https://github.com/linuxwacom/wacom-hid-descriptors/issues/110