### PR TITLE
tools: update rules to handle bind/unbind events

### DIFF
--- a/tools/65-libwacom.rules.in
+++ b/tools/65-libwacom.rules.in
@@ -1,6 +1,6 @@
 # udev rules for libwacom supported devices
 
-ACTION!="add|change", GOTO="libwacom_end"
+ACTION=="remove", GOTO="libwacom_end"
 KERNEL!="event[0-9]*", GOTO="libwacom_end"
 
 # HUION and GAOMON consumer and system control devices are not tablets.


### PR DESCRIPTION
Summary: we expect add, change or remove but kernel 4.12 added bind and
unbind. These events were previously discarded by udevd. Our rules should
handle any event *but* remove, so update as suggested in the announce email
linked below.

For a longer explanation, see the system 247rc2 announcement
https://lists.freedesktop.org/archives/systemd-devel/2020-November/045570.html