### PR TITLE
Add second PID for XP-Pen Star G640

### DIFF
--- a/data/xp-pen-g640.tablet
+++ b/data/xp-pen-g640.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=XP-Pen Star G640
 ModelName=
-DeviceMatch=usb:28bd:0094
+DeviceMatch=usb:28bd:0914;usb:28bd:0094
 Class=Bamboo
 Width=6
 Height=4

--- a/data/xp-pen-g640.tablet
+++ b/data/xp-pen-g640.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=XP-Pen Star G640
 ModelName=
-DeviceMatch=usb:28bd:0914
+DeviceMatch=usb:28bd:0094
 Class=Bamboo
 Width=6
 Height=4


### PR DESCRIPTION
The PID of my XP-Pen Star G640 is 0094, not 0914. My tablet only shows up in the Wacom Tablet settings if I make this change.