### PR TITLE
data: Add Lenovo X1 Yoga 3 Generation (ISDv4 5148)

### DIFF
--- a/data/isdv4-5148.tablet
+++ b/data/isdv4-5148.tablet
@@ -8,6 +8,7 @@ Class=ISDV4
 Width=12
 Height=7
 IntegratedIn=Display;System
+Styli=@isdv4-aes;
 
 [Features]
 Stylus=true

--- a/data/isdv4-5148.tablet
+++ b/data/isdv4-5148.tablet
@@ -1,0 +1,15 @@
+# this is for the Wacom pen + touchscreen as found in the Lenovo ThinkPad X1 Yoga (3rd-gen)
+
+[Device]
+Name=Wacom ISDv4 5148
+ModelName=
+DeviceMatch=usb:056a:5148
+Class=ISDV4
+Width=12
+Height=7
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0

--- a/data/isdv4-5148.tablet
+++ b/data/isdv4-5148.tablet
@@ -1,4 +1,7 @@
 # this is for the Wacom pen + touchscreen as found in the Lenovo ThinkPad X1 Yoga (3rd-gen)
+#
+# sysinfo.4xQ82uOLCD
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/117
 
 [Device]
 Name=Wacom ISDv4 5148


### PR DESCRIPTION
Hi,

I was able to get the tablet to be recognized but the buttons on the stylus don't seem to be working as configured in the settings application. The bottom button, closest to the tip, does nothing when pressed. The top button, when pressed acts as a back button. 

Note: I have also opened a issue in linuxwacom/wacom-hid-descriptors with the system information: https://github.com/linuxwacom/wacom-hid-descriptors/issues/117