### PR TITLE
Support loading tablet/stylus files from /etc/libwacom

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,49 @@ jobs:
             builddir/meson-logs/testlog*.txt
             builddir/meson-logs/meson-log.txt
 
+  ####
+  # /etc/ loading check
+  etcdir:
+    needs: meson
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        command:
+          # A variety of ways to split the database across the two locations
+          # we load from.
+          - sudo mv /usr/share/libwacom/intuos*.tablet /etc/libwacom
+          - sudo mv /usr/share/libwacom/*.tablet /etc/libwacom
+          - sudo mv /usr/share/libwacom/*.stylus /etc/libwacom
+          # split the libwacom.stylus file into to two files to check for
+          # accumlated loading
+          - sudo csplit data/libwacom.stylus '/^\[0x822\]/' && sudo mv xx00 /etc/libwacom/first.stylus && sudo mv xx01 /usr/share/libwacom/libwacom.stylus
+
+    steps:
+      - uses: actions/checkout@v2
+      # install python so we get pip for meson
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.8'
+      # keep this in sync with the meson job above. We just do it as
+      # one step here, it's not supposed to fail if the above succeeded.
+      # Exception: everything is run as sudo because we install to /etc
+      # and thus need the pip bits available as root
+      - name: Prep install
+        run: |
+          sudo python -m pip install --upgrade pip meson ninja
+          sudo apt update && sudo apt install -yq --no-install-suggests --no-install-recommends $UBUNTU_PACKAGES
+          sudo python -m pip install --upgrade libevdev pyudev pytest
+      - run: meson builddir --prefix=/usr && sudo ninja -C builddir install
+      - name: list devices with database in /usr
+        run: ./builddir/list-devices > devicelist.default.txt
+      - run: sudo mkdir /etc/libwacom
+      - name: split the databases between /usr/share and /etc
+        run: ${{matrix.command}}
+      - name: list devices with database in /etc and /usr
+        run: ./builddir/list-devices > devicelist.modified.txt
+      - name: compare device database
+        run: diff -u8 devicelist.default.txt devicelist.modified.txt
+
   ###
   #
   # tarball verification

--- a/libwacom/Makefile.am
+++ b/libwacom/Makefile.am
@@ -2,6 +2,7 @@ lib_LTLIBRARIES=libwacom.la
 
 AM_CPPFLAGS = \
 	      -DDATADIR="\"$(datadir)/libwacom\"" \
+	      -DETCDIR="\"$(sysconfdir)/libwacom\"" \
 	      -DG_LOG_DOMAIN="\"$(PACKAGE)\"" \
 	      -I$(top_srcdir)/include \
 	      -fvisibility=hidden

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -926,33 +926,33 @@ load_from_datadir(WacomDeviceDatabase *db, const char *datadir)
 LIBWACOM_EXPORT WacomDeviceDatabase *
 libwacom_database_new_for_path (const char *datadir)
 {
-    WacomDeviceDatabase *db;
+	WacomDeviceDatabase *db;
 
-    db = g_new0 (WacomDeviceDatabase, 1);
-    db->device_ht = g_hash_table_new_full (g_str_hash,
-					   g_str_equal,
-					   g_free,
-					   (GDestroyNotify) libwacom_destroy);
-    db->stylus_ht = g_hash_table_new_full (g_direct_hash,
-					   g_direct_equal,
-					   NULL,
-					   (GDestroyNotify) stylus_destroy);
+	db = g_new0 (WacomDeviceDatabase, 1);
+	db->device_ht = g_hash_table_new_full (g_str_hash,
+					       g_str_equal,
+					       g_free,
+					       (GDestroyNotify) libwacom_destroy);
+	db->stylus_ht = g_hash_table_new_full (g_direct_hash,
+					       g_direct_equal,
+					       NULL,
+					       (GDestroyNotify) stylus_destroy);
 
-    if (!load_from_datadir(db, datadir))
-	    goto error;
+	if (!load_from_datadir(db, datadir))
+		goto error;
 
-    /* If we couldn't load _anything_ then something's wrong */
-    if (g_hash_table_size (db->stylus_ht) == 0 ||
-	g_hash_table_size (db->device_ht) == 0)
-	    goto error;
+	/* If we couldn't load _anything_ then something's wrong */
+	if (g_hash_table_size (db->stylus_ht) == 0 ||
+	    g_hash_table_size (db->device_ht) == 0)
+		goto error;
 
-    libwacom_setup_paired_attributes(db);
+	libwacom_setup_paired_attributes(db);
 
-    return db;
+	return db;
 
 error:
-    libwacom_database_destroy(db);
-    return NULL;
+	libwacom_database_destroy(db);
+	return NULL;
 }
 
 LIBWACOM_EXPORT WacomDeviceDatabase *

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -849,7 +849,7 @@ load_tablet_files(WacomDeviceDatabase *db, const char *datadir)
     bool success = false;
 
     n = scandir(datadir, &files, scandir_tablet_filter, alphasort);
-    if (n <= 0)
+    if (n < 0)
 	    return false;
 
     nfiles = n;
@@ -908,7 +908,7 @@ load_stylus_files(WacomDeviceDatabase *db, const char *datadir)
     bool success = false;
 
     n = scandir(datadir, &files, scandir_stylus_filter, alphasort);
-    if (n <= 0)
+    if (n < 0)
 	    return false;
 
     nfiles = n;

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -843,7 +843,7 @@ load_tablet_files(WacomDeviceDatabase *db, const char *datadir)
 
 	dir = opendir(datadir);
 	if (!dir)
-		return false;
+		return errno == ENOENT; /* non-existing directory is ok */
 
 	while ((file = readdir(dir))) {
 		WacomDevice *d;
@@ -899,7 +899,7 @@ load_stylus_files(WacomDeviceDatabase *db, const char *datadir)
 
 	dir = opendir(datadir);
 	if (!dir)
-		return false;
+		return errno == ENOENT; /* non-existing directory is ok */
 
 	while ((file = readdir(dir))) {
 		char *path;
@@ -966,9 +966,12 @@ libwacom_database_new_for_path (const char *datadir)
 LIBWACOM_EXPORT WacomDeviceDatabase *
 libwacom_database_new (void)
 {
-	const char *datadir = DATADIR;
+	const char *datadir[] = {
+		DATADIR,
+		ETCDIR,
+	};
 
-	return database_new_for_paths (1, &datadir);
+	return database_new_for_paths (2, datadir);
 }
 
 LIBWACOM_EXPORT void

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -930,6 +930,11 @@ load_stylus_files(WacomDeviceDatabase *db, const char *datadir)
     return success;
 }
 
+static bool
+load_from_datadir(WacomDeviceDatabase *db, const char *datadir)
+{
+	return load_stylus_files(db, datadir) && load_tablet_files(db, datadir);
+}
 
 LIBWACOM_EXPORT WacomDeviceDatabase *
 libwacom_database_new_for_path (const char *datadir)
@@ -946,8 +951,8 @@ libwacom_database_new_for_path (const char *datadir)
 					   NULL,
 					   (GDestroyNotify) stylus_destroy);
 
-    if (!load_stylus_files(db, datadir) || !load_tablet_files(db, datadir))
-	goto error;
+    if (!load_from_datadir(db, datadir))
+	    goto error;
 
     /* If we couldn't load _anything_ then something's wrong */
     if (g_hash_table_size (db->stylus_ht) == 0 ||

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -807,38 +807,31 @@ out:
 	return device;
 }
 
-static int
-scandir_tablet_filter(const struct dirent *entry)
+static bool
+has_suffix(const char *name, const char *suffix)
 {
-	const char *name = entry->d_name;
-	int len, suffix_len;
+	size_t len = strlen(name);
+	size_t suffix_len = strlen(suffix);
 
 	if (!name || name[0] == '.')
 		return 0;
 
-	len = strlen(name);
-	suffix_len = strlen(TABLET_SUFFIX);
 	if (len <= suffix_len)
-		return 0;
+		return false;
 
-	return streq(&name[len - suffix_len], TABLET_SUFFIX);
+	return streq(&name[len - suffix_len], suffix);
+}
+
+static int
+scandir_tablet_filter(const struct dirent *entry)
+{
+	return has_suffix(entry->d_name, TABLET_SUFFIX);
 }
 
 static int
 scandir_stylus_filter(const struct dirent *entry)
 {
-	const char *name = entry->d_name;
-	int len, suffix_len;
-
-	if (!name || name[0] == '.')
-		return 0;
-
-	len = strlen(name);
-	suffix_len = strlen(STYLUS_SUFFIX);
-	if (len <= suffix_len)
-		return 0;
-
-	return streq(&name[len - suffix_len], STYLUS_SUFFIX);
+	return has_suffix(entry->d_name, STYLUS_SUFFIX);
 }
 
 static bool

--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,7 @@ project('libwacom', 'c',
 	meson_version: '>= 0.50.0')
 
 dir_data    = join_paths(get_option('prefix'), get_option('datadir'), 'libwacom')
+dir_etc     = join_paths(get_option('prefix'), get_option('sysconfdir'), 'libwacom')
 dir_man1    = join_paths(get_option('prefix'), get_option('mandir'), 'man1')
 dir_src     = join_paths(meson.source_root(), 'libwacom')
 dir_test    = join_paths(meson.source_root(), 'test')
@@ -85,6 +86,7 @@ lib_libwacom = shared_library('wacom',
 			      c_args: [
 				'-DG_LOG_DOMAIN="@0@"'.format(meson.project_name()),
 				'-DDATADIR="@0@"'.format(dir_data),
+				'-DETCDIR="@0@"'.format(dir_etc),
 			      ],
 			      install: true)
 dep_libwacom = declare_dependency(link_with: lib_libwacom)

--- a/test/test-dbverify.c
+++ b/test/test-dbverify.c
@@ -43,32 +43,31 @@
 static WacomDeviceDatabase *db_old;
 static WacomDeviceDatabase *db_new;
 
-static int
-scandir_filter(const struct dirent *entry)
-{
-	return strncmp(entry->d_name, ".", 1);
-}
-
 static void
-rmtmpdir(const char *dir)
+rmtmpdir(const char *tmpdir)
 {
-	int nfiles;
-	struct dirent **files;
-	char *path = NULL;
+	DIR *dir;
+	struct dirent *file;
 
-	nfiles = scandir(dir, &files, scandir_filter, alphasort);
-	while(nfiles--)
-	{
-		g_assert(asprintf(&path, "%s/%s", dir, files[nfiles]->d_name) != -1);
+	dir = opendir(tmpdir);
+	if (!dir)
+		return;
+
+	while ((file = readdir(dir))) {
+		char *path = NULL;
+
+		if (file->d_name[0] == '.')
+			continue;
+
+		g_assert(asprintf(&path, "%s/%s", tmpdir, file->d_name) != -1);
 		g_assert(path);
 		g_assert(remove(path) != -1);
-		free(files[nfiles]);
 		free(path);
-		path = NULL;
 	}
 
-	free(files);
-	g_assert(remove(dir) != -1);
+	closedir(dir);
+
+	g_assert(remove(tmpdir) != -1);
 }
 
 static void


### PR DESCRIPTION
To add a new .tablet file, a user would have to add that file to /usr/share.
This location may be read-only on some systems, and any file there will
conflict with files provided by the distribution package. In the best case,
the user's file will be overwritten on update, in the worst case a file name
change leaves both files in place, causing conflicts.

The traditional approach is to have distribution-provided files in /usr and
host-specific packages in /etc, so let's do the same here: add /etc/libwacom
as default lookup path for .tablet and .stylus files.

The CI is a bit quirky again because afaict github workflows don't do templates. So it's some duplication but the basic summary is:
- build and install everthing with prefix `/usr`
- generate a list of supported devices with the `./builddir/list-devices` tool
- move some tablet files over to `/etc/libwacom`
- generate a list of supported devices with the `./builddir/list-devices` tool
- compare the two lists, they must be identical

Fixes #327 