### PR TITLE
Added .tablet and .svg for the Huion HS-610

### DIFF
--- a/data/huion-hs610.tablet
+++ b/data/huion-hs610.tablet
@@ -1,0 +1,50 @@
+# HUION
+# HS610
+#
+# Button Map:
+#      *-----------------------------------*
+#      |                                   |
+#  A|B |                                   |
+#  C|D |                                   |
+#  E|F |                                   |
+#      |                                   |
+#   M  |              TABLET               |
+#      |                                   |
+#  G|H |                                   |
+#  I|J |                                   |
+#  K|L |                                   |
+#      |                                   |
+#      *-----------------------------------*
+#
+# Touch Ring Map:
+# (A=1st ring, B=2nd ring, ...)
+#
+#    *-----------------------*
+#    |                       |
+#  M |        TABLET         |
+#    |                       |
+#    *-----------------------*
+#
+
+[Device]
+Name=HUION Huion Tablet
+ModelName=HS610
+DeviceMatch=usb:256c:006d
+Class=Bamboo
+Width=10
+Height=6
+IntegratedIn=
+Layout=huion-hs610.svg
+Styli=0xffffd;
+
+[Features]
+Stylus=true
+Reversible=true
+Touch=false
+Buttons=13
+Ring=true
+
+[Buttons]
+Left=A;B;C;D;E;F;G;H;I;J;K;L;M
+EvdevCodes=0x100;0x101;0x102;0x103;0x104;0x105;0x106;0x107;0x108;0x109;0x130;0x131;0x132
+Ring=M

--- a/data/huion-hs610.tablet
+++ b/data/huion-hs610.tablet
@@ -29,7 +29,7 @@
 [Device]
 Name=HUION Huion Tablet
 ModelName=HS610
-DeviceMatch=usb:256c:006d
+DeviceMatch=usb:256c:006d:HUION Huion Tablet Pen;usb:256c:006d:HUION Huion Tablet Pad;
 Class=Bamboo
 Width=10
 Height=6

--- a/data/layouts/huion-hs610.svg
+++ b/data/layouts/huion-hs610.svg
@@ -219,17 +219,17 @@
 	d="M 31 135 l 3 -1.5 l 0 1 a 7.5 7.5 0 0 0 5 -1 a 6.5 6.5 0 0 1 -5 2 l 0 1 z" />
   <circle
 	id="ButtonM"
-	class="M Button"
+	class="M ModeSwitch Button"
 	cx="34"
 	cy="121"
 	r="9.5" />
   <path
 	id="LeaderM"
-	class="M Leader"
+	class="M ModeSwitch Leader"
 	d="M 56 121 L 60 121" />
   <text
 	id="LabelM"
-	class="M Label"
+	class="M ModeSwitch Label"
 	x="62"
 	y="121"
 	style="text-anchor:start;">M</text>

--- a/data/layouts/huion-hs610.svg
+++ b/data/layouts/huion-hs610.svg
@@ -1,0 +1,239 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg
+   width="360.0"
+   height="240.0"
+   style="color:#000000;font-size:8px;fill:none;stroke:#7f7f7f;stroke-width:0.25"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg">
+  <title
+     id="title">HUION Huion Tablet</title>
+     
+	
+	
+	
+  <path
+     id="ButtonA"
+     class="A Button"
+     d="M 16.0 32.5 H 32.0 v 12.0 H 16.0 c -0.5 0.0 -1.0 -0.5 -1.0 -1.0 v -10.0 c 0.0 -0.5 0.5 -1.0 1.0 -1.0 z" />
+  <path
+     id="LeaderA"
+     class="A Leader"
+     d="M 8.5 41.5 H 13.5" />
+  <text
+     id="LabelA"
+     class="A Label"
+     x="7.0"
+     y="41.5"
+     style="text-anchor:end">A</text>
+  <path
+     id="ButtonB"
+     class="B Button"
+     d="M 49.0 32.5 H 33.0 v 12.0 h 16.0 c 0.5 0.0 1.0 -0.5 1.0 -1.0 v -10.0 c 0.0 -0.5 -0.5 -1.0 -1.0 -1.0 z" />
+  <path
+     id="LeaderB"
+     class="B Leader"
+     d="M 56.5 41.5 H 51.5" />
+  <text
+     id="LabelB"
+     class="B Label"
+     x="57.0"
+     y="41.5"
+     style="text-anchor:start">B</text>
+  <path
+     id="ButtonC"
+     class="C Button"
+     d="M 16.0 57.0 H 32.0 v 12.0 H 16.0 c -0.5 0 -1 -0.5 -1 -1 v -10 c 0 -0.5 0.5 -1 1 -1 z" />
+  <path
+     id="LeaderC"
+     class="C Leader"
+     d="M 8.5 65.5 H 13.5" />
+  <text
+     id="LabelC"
+     class="C Label"
+     x="7.0"
+     y="65.5"
+     style="text-anchor:end">C</text>
+  <path
+     id="ButtonD"
+     class="D Button"
+     d="M 49.0 57.0 H 33.0 v 12.0 h 16.0 c 0.5 0.0 1.0 -0.5 1.0 -1.0 v -10.0 c 0.0 -0.5 -0.5 -1.0 -1.0 -1.0 z" />
+  <path
+     id="LeaderD"
+     class="D Leader"
+     d="M 56.5 65.5 H 51.5" />
+  <text
+     id="LabelD"
+     class="D Label"
+     x="57.0"
+     y="65.5"
+     style="text-anchor:start">D</text>
+  <path
+     id="ButtonE"
+     class="E Button"
+     d="m 16.0 81.0 h 16.0 v 12.0 H 16.0 c -0.5 0.0 -1.0 -0.5 -1.0 -1.0 v -10.0 c 0.0 -0.5 0.5 -1.0 1.0 -1.0 z" />
+  <path
+     id="LeaderE"
+     class="E Leader"
+     d="M 8.5 89.5 H 13.5" />
+  <text
+     id="LabelE"
+     class="E Label"
+     x="7.0"
+     y="89.5"
+     style="text-anchor:end">E</text>
+  <path
+     id="ButtonF"
+     class="F Button"
+     d="M 49.0 81.0 H 33.0 v 12.0 h 16.0 c 0.5 0.0 1.0 -0.5 1.0 -1.0 v -10.0 c 0.0 -0.5 -0.5 -1.0 -1.0 -1.0 z" />
+  <path
+     id="LeaderF"
+     class="F Leader"
+     d="M 56.5 89.5 H 51.5" />
+  <text
+     id="LabelF"
+     class="F Label"
+     x="57.0"
+     y="89.5"
+     style="text-anchor:start">F</text>
+  <path
+     id="ButtonG"
+     class="G Button"
+     d="m 16.0 148.0 h 16.0 v 12.0 H 16.0 c -0.5 0.0 -1.0 -0.5 -1.0 -1.0 v -10.0 c 0.0 -0.5 0.5 -1.0 1.0 -1.0 z" />
+  <path
+     id="LeaderG"
+     class="G Leader"
+     d="M 8.5 156.5 H 13.5" />
+  <text
+     id="LabelG"
+     class="G Label"
+     x="7.0"
+     y="156.5"
+     style="text-anchor:end">G</text>
+  <path
+     id="ButtonH"
+     class="H Button"
+     d="M 49.0 148.0 H 33.0 v 12.0 h 16.0 c 0.5 0.0 1.0 -0.5 1.0 -1.0 v -10.0 c 0.0 -0.5 -0.5 -1.0 -1.0 -1.0 z" />
+  <path
+     id="LeaderH"
+     class="H Leader"
+     d="M 56.5 156.5 H 51.5" />
+  <text
+     id="LabelH"
+     class="H Label"
+     x="57.0"
+     y="156.5"
+     style="text-anchor:start">H</text>
+  <path
+     id="ButtonI"
+     class="I Button"
+     d="m 16.0 172.0 h 16.0 v 12.0 H 16.0 c -0.5 0.0 -1.0 -0.5 -1.0 -1.0 v -10.0 c 0.0 -0.5 0.5 -1.0 1.0 -1.0 z" />
+  <path
+     id="LeaderI"
+     class="I Leader"
+     d="M 8.5 181.0 H 13.5" />
+  <text
+     id="LabelI"
+     class="I Label"
+     x="7.0"
+     y="181.0"
+     style="text-anchor:end">I</text>
+  <path
+     id="ButtonJ"
+     class="J Button"
+     d="M 49.0 172.0 H 33.0 v 12.0 h 16.0 c 0.5 0.0 1.0 -0.5 1.0 -1.0 v -10.0 c 0.0 -0.5 -0.5 -1.0 -1.0 -1.0 z" />
+  <path
+     id="LeaderJ"
+     class="J Leader"
+     d="M 56.5 181.0 H 51.5" />
+  <text
+     id="LabelJ"
+     class="J Label"
+     x="57.0"
+     y="181.0"
+     style="text-anchor:start">J</text>
+  <path
+     id="ButtonK"
+     class="K Button"
+     d="m 16.0 196.0 h 16.0 v 12.0 H 16.0 c -0.5 0.0 -1.0 -0.5 -1.0 -1.0 v -10.0 c 0.0 -0.5 0.5 -1.0 1.0 -1.0 z" />
+  <path
+     id="LeaderK"
+     class="K Leader"
+     d="M 8.5 205.0 H 13.5" />
+  <text
+     id="LabelK"
+     class="K Label"
+     x="7.0"
+     y="205.0"
+     style="text-anchor:end">K</text>
+  <path
+     id="ButtonL"
+     class="L Button"
+     d="M 49.0 196.0 H 33.0 v 12.0 h 16.0 c 0.5 0.0 1.0 -0.5 1.0 -1.0 v -10.0 c 0.0 -0.5 -0.5 -1.0 -1.0 -1.0 z" />
+  <path
+     id="LeaderL"
+     class="L Leader"
+     d="M 56.5 205.0 H 51.5" />
+  <text
+     id="LabelL"
+     class="L Label"
+     x="57.0"
+     y="205.0"
+     style="text-anchor:start">L</text>
+  
+
+    <circle
+	id="Ring"
+	class="Ring TouchRing"
+	cx="34"
+	cy="121"
+	r="19.5" />
+	<path
+	id="LeaderRingCCW"
+	class="RingCCW Ring Leader"
+	d="M 34 101 L 34 99 L 60 99" />
+	<text
+	id="LabelRingCCW"
+	class="RingCCW Ring Label"
+	x="62"
+	y="99"
+	style="text-anchor:start;">CCW</text>
+	<path
+	id="RingCCW"
+	class="RingCCW Button"
+	d="M 31 107 l 3 -1.5 l 0 1 a 7.5 7.5 0 0 1 5 1.5 a 6.5 6.5 0 0 0 -5 -0.5 l 0 1 z" />
+	<path
+	id="LeaderRingCW"
+	class="RingCW Ring Leader"
+	d="M 34 141 L 34 143 L 60 143" />
+	<text
+	id="LabelRingCW"
+	class="RingCW Ring Label"
+	x="62"
+	y="143"
+	style="text-anchor:start;">CW</text>
+	<path
+	id="RingCW"
+	class="RingCW Button"
+	d="M 31 135 l 3 -1.5 l 0 1 a 7.5 7.5 0 0 0 5 -1 a 6.5 6.5 0 0 1 -5 2 l 0 1 z" />
+  <circle
+	id="ButtonM"
+	class="M Button"
+	cx="34"
+	cy="121"
+	r="9.5" />
+  <path
+	id="LeaderM"
+	class="M Leader"
+	d="M 56 121 L 60 121" />
+  <text
+	id="LabelM"
+	class="M Label"
+	x="62"
+	y="121"
+	style="text-anchor:start;">M</text>
+
+  
+</svg>
+


### PR DESCRIPTION
I created the description files for the Huion HS-610. The tablet has a circular touch ring, that's the only thing that I can't configure from the GNOME-Settings. The "test your settings" page does nothing, although I can use the tablet with Xournal for example. The 13 buttons work perfectly.