### PR TITLE
Github CI: use a custom actions installing and meson building

### DIFF
--- a/.github/actions/meson/action.yml
+++ b/.github/actions/meson/action.yml
@@ -1,0 +1,41 @@
+# A Github Action to build a repository with meson
+name: "Setup and run meson"
+description: "Setup and run meson"
+inputs:
+  builddir:
+    description: "The build directory"
+    default: "builddir"
+  srcdir:
+    description: "The source directory"
+    default: "."
+  meson_args:
+    description: "Arguments passed to meson setup"
+    default: ""
+  meson_skip_test:
+    description: "Set to a nonempty string to skip meson test"
+    default: ""
+  meson_test_args:
+    description: "Arguments passed to meson test"
+    default: ""
+  meson_precmd:
+    description: "Set to 'sudo' to run with sudo"
+    default: ""
+  ninja_args:
+    description: "Arguments passed to ninja"
+    default: ""
+  ninja_precmd:
+    description: "Set to 'sudo' to run with sudo"
+    default: ""
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        pushd ${{inputs.srcdir}}
+        ${{inputs.meson_precmd}} meson setup ${{inputs.builddir}} ${{inputs.meson_args}}
+        ${{inputs.meson_precmd}} meson configure ${{inputs.builddir}}
+        ${{inputs.ninja_precmd}} ninja -C ${{inputs.builddir}} ${{inputs.ninja_args}}
+        if [[ -z "${{inputs.meson_skip_test}}" ]]; then
+          ${{inputs.meson_precmd}} meson test -C ${{inputs.builddir}} --print-errorlogs ${{inputs.meson_test_args}};
+        fi
+        popd
+      shell: bash

--- a/.github/actions/pkginstall/action.yml
+++ b/.github/actions/pkginstall/action.yml
@@ -1,0 +1,17 @@
+name: "Install packages"
+description: "Install a set of packages from sources"
+inputs:
+  apt:
+    description: "The package list to install with apt"
+  pip:
+    description: "The package list to install with pip"
+  pip_precmd:
+    description: "Set to the string 'sudo' to run through sudo"
+    default: ""
+runs:
+  using: "composite"
+  steps:
+    - run: sudo ${{ github.action_path }}/install-apt.sh ${{ inputs.apt }}
+      shell: bash
+    - run: ${{inputs.pip_precmd}} ${{ github.action_path }}/install-pip.sh ${{ inputs.pip }}
+      shell: bash

--- a/.github/actions/pkginstall/install-apt.sh
+++ b/.github/actions/pkginstall/install-apt.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -x
+
+# If called without arguments, just skip the rest
+if [[ -z "$@" ]]; then
+	exit
+fi
+
+# Don't care about these bits
+echo 'path-exclude=/usr/share/doc/*' > /etc/dpkg/dpkg.cfg.d/99-exclude-cruft
+echo 'path-exclude=/usr/share/locale/*' >> /etc/dpkg/dpkg.cfg.d/99-exclude-cruft
+echo 'path-exclude=/usr/share/man/*' >> /etc/dpkg/dpkg.cfg.d/99-exclude-cruft
+
+# Something about the postgres repo is weird - it randomly returns 404 for the
+# Release file and breaks the build
+mv /etc/apt/sources.list.d/pgdg.list /etc/apt/sources.list.d/pgdg.list.backup
+
+apt-get update
+apt-get install -yq --no-install-suggests --no-install-recommends $@
+
+mv /etc/apt/sources.list.d/pgdg.list.backup /etc/apt/sources.list.d/pgdg.list

--- a/.github/actions/pkginstall/install-pip.sh
+++ b/.github/actions/pkginstall/install-pip.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+
+# If called without arguments, just skip the rest
+if [[ -z "$@" ]]; then
+	exit
+fi
+
+python -m pip install --upgrade pip
+python -m pip install --upgrade "$@"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,7 @@ on: [ push, pull_request ]
 env:
   CFLAGS: "-Werror -Wall -Wextra -Wno-error=sign-compare -Wno-error=unused-parameter -Wno-error=missing-field-initializers"
   UBUNTU_PACKAGES: libgudev-1.0-dev libxml++2.6-dev valgrind tree python3-pip python3-setuptools libevdev2
+  PIP_PACKAGES: meson ninja libevdev pyudev pytest
 
 jobs:
   ###
@@ -20,8 +21,9 @@ jobs:
           - distcheck
     steps:
       - uses: actions/checkout@v2
-      - name: Install libwacom dependencies
-        run: sudo apt update && sudo apt install -yq --no-install-suggests --no-install-recommends $UBUNTU_PACKAGES
+      - uses: ./.github/actions/pkginstall
+        with:
+          apt: $UBUNTU_PACKAGES
       - name: autotools make ${{matrix.make_args}}
         run: |
           mkdir _build && pushd _build > /dev/null
@@ -73,28 +75,26 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: '3.8'
-      - name: install meson
-        run: python -m pip install --upgrade pip meson ninja
-      - name: Install libwacom dependencies
-        run: sudo apt update && sudo apt install -yq --no-install-suggests --no-install-recommends $UBUNTU_PACKAGES
-      - name: install pip dependencies
-        run: python -m pip install --upgrade libevdev pyudev pytest
+      - uses: ./.github/actions/pkginstall
+        with:
+          apt: $UBUNTU_PACKAGES
+          pip: $PIP_PACKAGES
       # for the non-valgrind case, we pass the meson options through and run
       # meson test
       - name: meson test ${{matrix.meson_options}}
         if: ${{matrix.meson_options != 'valgrind'}}
-        run: |
-          meson setup builddir ${{matrix.meson_options}}
-          meson test -C builddir --print-errorlogs
+        uses: ./.github/actions/meson
+        with:
+          meson_args: ${{matrix.meson_options}}
         env:
           CC: ${{matrix.compiler}}
       # for the valgrind case, we need custom setup, the matrix isn't
       # flexible enough for this
       - name: valgrind - meson test ${{matrix.meson_options}}
         if: ${{matrix.meson_options == 'valgrind'}}
-        run: |
-          meson setup builddir
-          meson test -C builddir --print-errorlogs --setup=valgrind --suite=valgrind
+        uses: ./.github/actions/meson
+        with:
+          meson_test_args: --setup=valgrind --suite=valgrind
         env:
           CC: ${{matrix.compiler}}
       # Capture all the meson logs, even if we failed
@@ -105,7 +105,6 @@ jobs:
           path: |
             builddir/meson-logs/testlog*.txt
             builddir/meson-logs/meson-log.txt
-
   ####
   # /etc/ loading check
   etcdir:
@@ -129,16 +128,19 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: '3.8'
-      # keep this in sync with the meson job above. We just do it as
-      # one step here, it's not supposed to fail if the above succeeded.
-      # Exception: everything is run as sudo because we install to /etc
-      # and thus need the pip bits available as root
-      - name: Prep install
-        run: |
-          sudo python -m pip install --upgrade pip meson ninja
-          sudo apt update && sudo apt install -yq --no-install-suggests --no-install-recommends $UBUNTU_PACKAGES
-          sudo python -m pip install --upgrade libevdev pyudev pytest
-      - run: meson builddir --prefix=/usr && sudo ninja -C builddir install
+      # Run as sudo because we install to /etc and thus need the pip
+      # packages available to root
+      - uses: ./.github/actions/pkginstall
+        with:
+          apt: $UBUNTU_PACKAGES
+          pip: $PIP_PACKAGES
+          pip_precmd: sudo
+      - uses: ./.github/actions/meson
+        with:
+          meson_args: --prefix=/usr
+          meson_skip_test: yes
+          ninja_args: install
+          ninja_precmd: sudo
       - name: list devices with database in /usr
         run: ./builddir/list-devices > devicelist.default.txt
       - run: sudo mkdir /etc/libwacom
@@ -165,18 +167,15 @@ jobs:
       TARBALLDIR: '_tarball_dir'
       INSTALLDIR: '/tmp/libwacom/_inst'
     steps:
-      # libwacom dependencies
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install -yq --no-install-suggests --no-install-recommends $UBUNTU_PACKAGES
+      - uses: actions/checkout@v2
       - name: install python
         uses: actions/setup-python@v1
         with:
           python-version: '3.8'
-      - name: install pip dependencies
-        run: python -m pip install --upgrade libevdev pyudev pytest
-      - name: install meson from pip (if needed)
-        run: python -m pip install --upgrade pip meson ninja
-        if: matrix.buildtool == 'meson'
+      - uses: ./.github/actions/pkginstall
+        with:
+          apt: $UBUNTU_PACKAGES
+          pip: $PIP_PACKAGES
       - name: fetch tarball from previous job(s)
         uses: actions/download-artifact@v2
         with:
@@ -186,14 +185,15 @@ jobs:
           mkdir -p "$TARBALLDIR"
           tar xf libwacom-*.tar.bz2 -C "$TARBALLDIR"
       - run: mkdir -p "$INSTALLDIR"
-      # The next three jobs are conditional on the buildtool,
+      # The next jobs are conditional on the buildtool,
       # it's the easiest way to save on duplication
       - name: build from tarball with meson
         if: matrix.buildtool == 'meson'
-        run: |
-          pushd "$TARBALLDIR"/libwacom-*/
-          meson setup builddir --prefix="$INSTALLDIR"
-          ninja -C builddir test && ninja -C builddir install
+        uses: ./.github/actions/meson
+        with:
+          srcdir: $TARBALLDIR/libwacom-*/
+          meson_args: --prefix="$INSTALLDIR"
+          ninja_args: test install
       - name: build from tarball with autogen
         if: matrix.buildtool == 'autogen'
         run: |


### PR DESCRIPTION
Two github actions are added: pkginstall and meson. They can be trigged with
uses: in the CI jobs and standardize the package installs and meson setup
jobs. This cuts down on duplication and in theory the same actions can be used
by xf86-input-wacom later.

A few noteworthy behaviors:
- the postgres package repo has to be disabled, it causes random CI failures
  with a 404
- the precmd approach is a bit weird but it's the easiest way to use sudo on
  demand.
- every `run:` command starts a new shell, so we can't easily export variables
  between the various steps

cc @jigpu