### PR TITLE
Add ELAN 04F3:2B0A to ELAN 2514 definition file

### DIFF
--- a/data/elan-2514.tablet
+++ b/data/elan-2514.tablet
@@ -23,10 +23,14 @@
 #
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/70
 
+# i2c:04f3:2b0a
+#
+# HP Envy x360 Convertible 15z-ee000
+
 [Device]
 Name=ELAN 2514
 ModelName=
-DeviceMatch=i2c:04f3:29f5;i2c:04f3:2af4;i2c:04f3:2813;i2c:04f3:2817
+DeviceMatch=i2c:04f3:29f5;i2c:04f3:2af4;i2c:04f3:2813;i2c:04f3:2817;i2c:04f3:2b0a
 Class=ISDV4
 Width=12
 Height=7


### PR DESCRIPTION
I have an HP Envy x360 (2020) convertible laptop, with model number 15z-ee000.  This laptop has an ELAN2514 wacom layer, but with a different device identifier than those defined in the elan-2514.tablet file.  I went ahead and added the device identifier to the tablet file and it worked out of the box for me.

The command `libinput list-devices` outputs the following on my 15z-ee000:
```
Device:           ELAN2514:00 04F3:2B0A
Kernel:           /dev/input/event9
Group:            9
Seat:             seat0, default
Size:             332x188mm
Capabilities:     touch 
Tap-to-click:     n/a
Tap-and-drag:     n/a
Tap drag lock:    n/a
Left-handed:      n/a
Nat.scrolling:    n/a
Middle emulation: n/a
Calibration:      identity matrix
Scroll methods:   none
Click methods:    none
Disable-w-typing: n/a
Accel profiles:   n/a
Rotation:         n/a

Device:           ELAN2514:00 04F3:2B0A
Kernel:           /dev/input/event13
Group:            9
Seat:             seat0, default
Size:             343x194mm
Capabilities:     tablet 
Tap-to-click:     n/a
Tap-and-drag:     n/a
Tap drag lock:    n/a
Left-handed:      n/a
Nat.scrolling:    n/a
Middle emulation: n/a
Calibration:      identity matrix
Scroll methods:   none
Click methods:    none
Disable-w-typing: n/a
Accel profiles:   none
Rotation:         n/a
```