### PR TITLE
CI: update freebsd-vm to 12.2

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: meson test
-      uses: vmactions/freebsd-vm@v0.0.7
+      uses: vmactions/freebsd-vm@v0.1.2
       with:
         prepare: |
           pkg install -y meson pkgconf evdev-proto libgudev libxml++ bash libevdev py37-pip


### PR DESCRIPTION
freebsd-vm@v0.0.7 uses FreeBSD 12.1 which has reached EOL on 2021-01-31. FreeBSD Project doesn't keep old packages for [/latest](https://pkg.freebsd.org/FreeBSD:12:amd64/latest/) and [/quarterly](https://pkg.freebsd.org/FreeBSD:12:amd64/quarterly/). Once 12.2 packages are built there would be none for 12.1 except for [/release_1](https://pkg.freebsd.org/FreeBSD:12:amd64/release_1/) which is more than 1 year old.