### PR TITLE
data: Add support for the HP Pro Tablet 408

### DIFF
--- a/data/hp-pro-tablet-408.tablet
+++ b/data/hp-pro-tablet-408.tablet
@@ -1,0 +1,18 @@
+# This is for the HP Pro Tablet 408
+#
+# Synaptics I2C sensor
+#
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/137
+
+[Device]
+Name=HP Pro Tablet 408
+Class=ISDV4
+DeviceMatch=i2c:06cb:125d
+Width=4
+Height=7
+IntegratedIn=Display;System;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
Link: https://github.com/linuxwacom/wacom-hid-descriptors/issues/137