### PR TITLE
Support for Huion h640p

### DIFF
--- a/data/huion-h640p.tablet
+++ b/data/huion-h640p.tablet
@@ -17,6 +17,7 @@
 Name=Huion H640P
 ModelName=
 DeviceMatch=usb:256c:006d
+PairedIDs=usb:256c:006d
 Class=Bamboo
 Width=6.3
 Height=3.9

--- a/data/huion-h640p.tablet
+++ b/data/huion-h640p.tablet
@@ -1,0 +1,25 @@
+# HUION
+# H640P
+# 
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/145
+
+[Device]
+Name=Huion H640P
+ModelName=
+DeviceMatch=usb:256c:006d
+Class=Bamboo
+Width=6.3
+Height=3.9
+IntegratedIn=
+Layout=huion-h640p.svg
+Styli=0xffffd;
+
+[Features]
+Stylus=true
+Reversible=false
+Touch=false
+Buttons=6
+
+[Buttons]
+Left=A;B;C;D;E;F
+EvdevCodes=0x100;0x101;0x102;0x103;0x104;0x105

--- a/data/huion-h640p.tablet
+++ b/data/huion-h640p.tablet
@@ -1,33 +1,32 @@
 # HUION
 # H640P
-# 
-#      *-----------------------------------*
-#    A |                                   |
-#    B |                                   |
-#    C |                                   |
-#      |              DISPLAY              |
-#    D |                                   |
-#    E |                                   |
-#    F |                                   |
-#      *-----------------------------------*
+#
+#      *-------------------------------*
+#    A |                               |
+#    B |                               |
+#    C |                               |
+#      |            DISPLAY            |
+#    D |                               |
+#    E |                               |
+#    F |                               |
+#      *-------------------------------*
 #
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/145
 
 [Device]
 Name=Huion H640P
 ModelName=
-DeviceMatch=usb:256c:006d
-PairedIDs=usb:256c:006d
+DeviceMatch=usb:256c:006d:HUION Huion Tablet_H640P Pad;usb:256c:006d:HUION Huion Tablet_H640P Pen
 Class=Bamboo
-Width=6.3
-Height=3.9
+Width=6
+Height=4
 IntegratedIn=
 Layout=huion-h640p.svg
 Styli=0xffffd;
 
 [Features]
 Stylus=true
-Reversible=false
+Reversible=true
 Touch=false
 Buttons=6
 

--- a/data/huion-h640p.tablet
+++ b/data/huion-h640p.tablet
@@ -1,6 +1,16 @@
 # HUION
 # H640P
 # 
+#      *-----------------------------------*
+#    A |                                   |
+#    B |                                   |
+#    C |                                   |
+#      |              DISPLAY              |
+#    D |                                   |
+#    E |                                   |
+#    F |                                   |
+#      *-----------------------------------*
+#
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/145
 
 [Device]

--- a/data/layouts/huion-h640p.svg
+++ b/data/layouts/huion-h640p.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
+   id="intuos-pro-m"
+   width="355"
+   height="226">
+  <title
+     id="title">Huion H950P</title>
+  <g>
+   	<rect
+   	   id="ButtonA"
+       class="A ModeSwitch Button"
+       width="22"
+       height="12"
+       x="18"
+       y="50"
+       ry="5" />
+    <path
+       id="LeaderA"
+       class="A ModeSwitch Leader"
+       d="m 51,56 4,0" />
+    <text
+       id="LabelA"
+       class="A ModeSwitch Label"
+       x="57"
+       y="57"
+       style="text-anchor:start">A</text>
+  </g>
+  <g>
+    <rect
+   	   id="ButtonB"
+       class="B ModeSwitch Button"
+       width="22"
+       height="12"
+       x="18"
+       y="69"
+       ry="5" />
+    <path
+       d="m 51,75 4,0"
+       class="B ModeSwitch Leader"
+       id="LeaderB" />
+    <text
+       style="text-anchor:start"
+       y="76"
+       x="57"
+       class="B ModeSwitch Label"
+       id="LabelB">B</text>
+  </g>
+  <g>
+    <rect
+   	   id="ButtonC"
+       class="C ModeSwitch Button"
+       width="22"
+       height="12"
+       x="18"
+       y="88"
+       ry="5" />
+    <path
+       id="LeaderC"
+       class="C ModeSwitch Leader"
+       d="m 51,94 4,0" />
+    <text
+       id="LabelC"
+       class="C ModeSwitch Label"
+       x="57"
+       y="95"
+       style="text-anchor:start">C</text>
+  </g>
+
+
+
+  
+  <g>
+    <rect
+   	   id="ButtonD"
+       class="D ModeSwitch Button"
+       width="22"
+       height="12"
+       x="18"
+       y="112"
+       ry="5" />
+    <path
+       id="LeaderD"
+       class="D ModeSwitch Leader"
+       d="m 51,113 4,0" />
+    <text
+       id="LabelD"
+       class="D ModeSwitch Label"
+       x="57"
+       y="119"
+       style="text-anchor:start">D</text>
+  </g>
+  <g>
+    <rect
+   	   id="ButtonE"
+       class="E ModeSwitch Button"
+       width="22"
+       height="12"
+       x="18"
+       y="131"
+       ry="5" />
+    <path
+       id="LeaderE"
+       class="E ModeSwitch Leader"
+       d="m 51,137 4,0" />
+    <text
+       id="LabelE"
+       class="E ModeSwitch Label"
+       x="57"
+       y="138"
+       style="text-anchor:start">E</text>
+  </g>
+  <g>
+    <rect
+   	   id="ButtonF"
+       class="F ModeSwitch Button"
+       width="22"
+       height="12"
+       x="18"
+       y="150"
+       ry="5" />
+    <path
+       id="LeaderF"
+       class="F ModeSwitch Leader"
+       d="m 51,156 4,0" />
+    <text
+       id="LabelF"
+       class="F ModeSwitch Label"
+       x="57"
+       y="157"
+       style="text-anchor:start">F</text>
+  </g>
+</svg>

--- a/data/layouts/huion-h640p.svg
+++ b/data/layouts/huion-h640p.svg
@@ -9,7 +9,7 @@
    width="355"
    height="226">
   <title
-     id="title">Huion H950P</title>
+     id="title">Huion H640P</title>
   <g>
    	<rect
    	   id="ButtonA"


### PR DESCRIPTION
The tarball with the data is in queue to be accepted: https://github.com/linuxwacom/wacom-hid-descriptors/issues/145

Both the `.tablet` and `.svg` files are forks of the respective huion h950p variants