### PR TITLE
De-duplicate the device list returned by the database

### DIFF
--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -994,6 +994,8 @@ device_compare(gconstpointer pa, gconstpointer pb)
 	cmp = libwacom_get_vendor_id(a) - libwacom_get_vendor_id(b);
 	if (cmp == 0)
 		cmp = libwacom_get_product_id(a) - libwacom_get_product_id(b);
+	if (cmp == 0)
+		cmp = g_strcmp0(libwacom_get_name(a), libwacom_get_name(b));
 	return cmp;
 }
 

--- a/tools/list-devices.c
+++ b/tools/list-devices.c
@@ -75,6 +75,9 @@ int main(int argc, char **argv)
 		print_device_info ((WacomDevice *) *p, WBUSTYPE_BLUETOOTH);
 
 	for (p = list; *p; p++)
+		print_device_info ((WacomDevice *) *p, WBUSTYPE_I2C);
+
+	for (p = list; *p; p++)
 		print_device_info ((WacomDevice *) *p, WBUSTYPE_SERIAL);
 
 	for (p = list; *p; p++)


### PR DESCRIPTION
This reduces the device list from currently 423 to a more reasonable 329, for 302 .tablet files.

There is still some duplication due to how we print and list devices - any device with more than one bustype will be listed once per bus type. But at last it will no longer be listed once per match entry per bus type (e.g. ISDv4 90 had 4 entries before).