### PR TITLE
Install libwacom-list-devices and change to a oneline format

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,12 +142,12 @@ jobs:
           ninja_args: install
           ninja_precmd: sudo
       - name: list devices with database in /usr
-        run: ./builddir/list-devices --format=datafile > devicelist.default.txt
+        run: libwacom-list-devices --format=datafile > devicelist.default.txt
       - run: sudo mkdir /etc/libwacom
       - name: split the databases between /usr/share and /etc
         run: ${{matrix.command}}
       - name: list devices with database in /etc and /usr
-        run: ./builddir/list-devices --format=datafile > devicelist.modified.txt
+        run: libwacom-list-devices --format=datafile > devicelist.modified.txt
       - name: compare device database
         run: diff -u8 devicelist.default.txt devicelist.modified.txt
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,12 +142,12 @@ jobs:
           ninja_args: install
           ninja_precmd: sudo
       - name: list devices with database in /usr
-        run: ./builddir/list-devices > devicelist.default.txt
+        run: ./builddir/list-devices --format=datafile > devicelist.default.txt
       - run: sudo mkdir /etc/libwacom
       - name: split the databases between /usr/share and /etc
         run: ${{matrix.command}}
       - name: list devices with database in /etc and /usr
-        run: ./builddir/list-devices > devicelist.modified.txt
+        run: ./builddir/list-devices --format=datafile > devicelist.modified.txt
       - name: compare device database
         run: diff -u8 devicelist.default.txt devicelist.modified.txt
 

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -917,16 +917,12 @@ load_stylus_files(WacomDeviceDatabase *db, const char *datadir)
 	return true;
 }
 
-static bool
-load_from_datadir(WacomDeviceDatabase *db, const char *datadir)
-{
-	return load_stylus_files(db, datadir) && load_tablet_files(db, datadir);
-}
-
 static WacomDeviceDatabase *
 database_new_for_paths (size_t npaths, const char **datadirs)
 {
 	WacomDeviceDatabase *db;
+	size_t n;
+	const char **datadir;
 
 	db = g_new0 (WacomDeviceDatabase, 1);
 	db->device_ht = g_hash_table_new_full (g_str_hash,
@@ -938,8 +934,13 @@ database_new_for_paths (size_t npaths, const char **datadirs)
 					       NULL,
 					       (GDestroyNotify) stylus_destroy);
 
-	for (const char **datadir = datadirs; npaths--; datadir++) {
-		if (!load_from_datadir(db, *datadir))
+	for (datadir = datadirs, n = npaths; n--; datadir++) {
+		if (!load_stylus_files(db, *datadir))
+			goto error;
+	}
+
+	for (datadir = datadirs, n = npaths; n--; datadir++) {
+		if (!load_tablet_files(db, *datadir))
 			goto error;
 	}
 

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,6 @@ project('libwacom', 'c',
 dir_bin     = join_paths(get_option('prefix'), get_option('bindir'))
 dir_data    = join_paths(get_option('prefix'), get_option('datadir'), 'libwacom')
 dir_etc     = join_paths(get_option('prefix'), get_option('sysconfdir'), 'libwacom')
-dir_man1    = join_paths(get_option('prefix'), get_option('mandir'), 'man1')
 dir_src     = join_paths(meson.source_root(), 'libwacom')
 dir_src_data= join_paths(meson.source_root(), 'data')
 dir_test    = join_paths(meson.source_root(), 'test')

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,7 @@ dir_data    = join_paths(get_option('prefix'), get_option('datadir'), 'libwacom'
 dir_etc     = join_paths(get_option('prefix'), get_option('sysconfdir'), 'libwacom')
 dir_man1    = join_paths(get_option('prefix'), get_option('mandir'), 'man1')
 dir_src     = join_paths(meson.source_root(), 'libwacom')
+dir_src_data= join_paths(meson.source_root(), 'data')
 dir_test    = join_paths(meson.source_root(), 'test')
 dir_sys_udev= join_paths(get_option('prefix'), 'lib', 'udev')
 
@@ -134,7 +135,7 @@ executable('libwacom-list-local-devices',
 	   include_directories: [includes_src],
 	   install: true)
 
-tools_cflags = ['-DTOPSRCDIR="@0@"'.format(meson.source_root())]
+tools_cflags = ['-DDATABASEPATH="@0@"'.format(dir_src_data)]
 
 gen_hwdb = executable('generate-hwdb',
 		      'tools/generate-hwdb.c',

--- a/meson.build
+++ b/meson.build
@@ -156,12 +156,20 @@ configure_file(input: 'tools/65-libwacom.rules.in',
 	       install: true,
 	       install_dir: join_paths(dir_udev, 'rules.d'))
 
+# The non-installed version of list-devices uses the git tree's data files
 executable('list-devices',
 	   'tools/list-devices.c',
 	   dependencies: [dep_libwacom, dep_glib],
 	   include_directories: [includes_src],
 	   c_args: tools_cflags,
 	   install: false)
+
+# The installed version of list-devices uses the installed data files
+executable('libwacom-list-devices',
+	   'tools/list-devices.c',
+	   dependencies: [dep_libwacom, dep_glib],
+	   include_directories: [includes_src],
+	   install: true)
 
 executable('list-compatible-styli',
 	   'tools/list-compatible-styli.c',
@@ -171,6 +179,10 @@ executable('list-compatible-styli',
 	   install: false)
 
 install_man(configure_file(input: 'tools/libwacom-list-local-devices.man',
+			   output: '@BASENAME@.1',
+			   copy: true))
+
+install_man(configure_file(input: 'tools/libwacom-list-devices.man',
 			   output: '@BASENAME@.1',
 			   copy: true))
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -7,7 +7,8 @@ generate_hwdb_LDADD=$(top_builddir)/libwacom/libwacom.la $(GLIB_LIBS)
 generate_hwdb_CFLAGS=$(GLIB_CFLAGS)
 
 list_devices_SOURCES = list-devices.c
-list_devices_LDADD=$(top_builddir)/libwacom/libwacom.la
+list_devices_LDADD=$(top_builddir)/libwacom/libwacom.la $(GLIB_LIBS)
+list_devices_CFLAGS=$(GLIB_CFLAGS)
 
 list_compatible_styli_SOURCES = list-compatible-styli.c
 list_compatible_styli_LDADD=$(top_builddir)/libwacom/libwacom.la

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,24 +1,32 @@
-AM_CPPFLAGS=-I$(top_srcdir)/libwacom -DDATABASEPATH="\"$(abs_top_srcdir)/data\""
+AM_CPPFLAGS=-I$(top_srcdir)/libwacom
+
+DBPATH_CFLAGS=-DDATABASEPATH="\"$(abs_top_srcdir)/data\""
 
 noinst_PROGRAMS = generate-hwdb list-devices list-compatible-styli
 
 generate_hwdb_SOURCES = generate-hwdb.c
 generate_hwdb_LDADD=$(top_builddir)/libwacom/libwacom.la $(GLIB_LIBS)
-generate_hwdb_CFLAGS=$(GLIB_CFLAGS)
+generate_hwdb_CFLAGS=$(GLIB_CFLAGS) $(DBPATH_CFLAGS)
 
 list_devices_SOURCES = list-devices.c
 list_devices_LDADD=$(top_builddir)/libwacom/libwacom.la $(GLIB_LIBS)
-list_devices_CFLAGS=$(GLIB_CFLAGS)
+list_devices_CFLAGS=$(GLIB_CFLAGS) $(DBPATH_CFLAGS)
 
 list_compatible_styli_SOURCES = list-compatible-styli.c
 list_compatible_styli_LDADD=$(top_builddir)/libwacom/libwacom.la
+list_compatible_styli_CFLAGS=$(DBPATH_CFLAGS)
 
-bin_PROGRAMS = libwacom-list-local-devices
+bin_PROGRAMS = libwacom-list-local-devices libwacom-list-devices
+
+libwacom_list_devices_SOURCES = list-devices.c
+libwacom_list_devices_LDADD=$(top_builddir)/libwacom/libwacom.la $(GLIB_LIBS)
+libwacom_list_devices_CFLAGS=$(GLIB_CFLAGS)
+
 libwacom_list_local_devices_SOURCES = list-local-devices.c
 libwacom_list_local_devices_LDADD=$(top_builddir)/libwacom/libwacom.la $(GLIB_LIBS)
 libwacom_list_local_devices_CFLAGS=$(GLIB_CFLAGS)
 
-dist_man1_MANS = libwacom-list-local-devices.man
+dist_man1_MANS = libwacom-list-local-devices.man libwacom-list-devices.man
 
 rules = 65-libwacom.rules
 udev_rulesdir=$(UDEV_DIR)/rules.d

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS=-I$(top_srcdir)/libwacom -DTOPSRCDIR="\"$(abs_top_srcdir)\""
+AM_CPPFLAGS=-I$(top_srcdir)/libwacom -DDATABASEPATH="\"$(abs_top_srcdir)/data\""
 
 noinst_PROGRAMS = generate-hwdb list-devices list-compatible-styli
 

--- a/tools/generate-hwdb.c
+++ b/tools/generate-hwdb.c
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
 	WacomDeviceDatabase *db;
 	WacomDevice **list, **p;
 
-	db = libwacom_database_new_for_path(TOPSRCDIR"/data");
+	db = libwacom_database_new_for_path(DATABASEPATH);
 
 	list = libwacom_list_devices_from_database(db, NULL);
 	if (!list) {

--- a/tools/libwacom-list-devices.man
+++ b/tools/libwacom-list-devices.man
@@ -1,0 +1,19 @@
+.TH libwacom-list-devices 1
+
+.SH NAME
+libwacom-list-devices - utility to list supported tablet devices
+
+.SH SYNOPSIS
+.B libwacom-list-devices [--format=oneline|datafile]
+
+.SH DESCRIPTION
+libwacom-list-devices is a debug utility to list all supported tablet
+devices identified by libwacom. It is usually used to check whether a
+libwacom installation is correct after adding custom data files.
+.SH OPTIONS
+.TP 8
+.B --format=oneline|datafile
+Sets the output format to be used. If \fIoneline\fR, the output format is a
+one-line format comprising the bus type, vendor and product ID and the
+device name. If \fIdatafile\fR, the output format matches
+the tablet data files. The default is \fIoneline\fR.

--- a/tools/list-compatible-styli.c
+++ b/tools/list-compatible-styli.c
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
 	       return !!(strcmp(argv[1], "--help"));
 	}
 
-	db = libwacom_database_new_for_path(TOPSRCDIR"/data");
+	db = libwacom_database_new_for_path(DATABASEPATH);
 
 	list = libwacom_list_devices_from_database(db, NULL);
 	if (!list) {

--- a/tools/list-devices.c
+++ b/tools/list-devices.c
@@ -42,10 +42,11 @@ static void print_device_info (WacomDevice *device, WacomBusType bus_type_filter
 
 	for (match = libwacom_get_matches(device); *match; match++) {
 		WacomBusType type = libwacom_match_get_bustype(*match);
-		if (type == bus_type_filter) {
-			libwacom_print_device_description(STDOUT_FILENO, device);
-			dprintf(STDOUT_FILENO, "---------------------------------------------------------------\n");
-		}
+		if (type != bus_type_filter)
+			continue;
+
+		libwacom_print_device_description(STDOUT_FILENO, device);
+		dprintf(STDOUT_FILENO, "---------------------------------------------------------------\n");
 	}
 }
 

--- a/tools/list-devices.c
+++ b/tools/list-devices.c
@@ -60,7 +60,7 @@ int main(int argc, char **argv)
 	       return !!(strcmp(argv[1], "--help"));
 	}
 
-	db = libwacom_database_new_for_path(TOPSRCDIR"/data");
+	db = libwacom_database_new_for_path(DATABASEPATH);
 
 	list = libwacom_list_devices_from_database(db, NULL);
 	if (!list) {

--- a/tools/list-devices.c
+++ b/tools/list-devices.c
@@ -114,7 +114,11 @@ int main(int argc, char **argv)
 	}
 	g_option_context_free (context);
 
+#ifdef DATABASEPATH
 	db = libwacom_database_new_for_path(DATABASEPATH);
+#else
+	db = libwacom_database_new();
+#endif
 
 	list = libwacom_list_devices_from_database(db, NULL);
 	if (!list) {


### PR DESCRIPTION
This sits on top of #368

We had the `list-devices` tool for a while but it didn't get installed. Let's install it and change the output format to a matchstring(-ish) based oneline format. Having this tool makes it easier to answer the question "is my device supported" or, in the case of #367, "is my tablet file being picked up".

Fixes #367 