### PR TITLE
CI: unhardcode pip and install python3 symlink

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         prepare: |
           pkg install -y meson pkgconf evdev-proto libgudev libxml++ bash libevdev
-          pkg install -y -g py\*-pip python3
+          pkg install -y -g py3\*-pip python3
           pip install libevdev pytest pyudev
         run: |
           meson setup builddir

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -15,7 +15,8 @@ jobs:
       uses: vmactions/freebsd-vm@v0.1.2
       with:
         prepare: |
-          pkg install -y meson pkgconf evdev-proto libgudev libxml++ bash libevdev py37-pip
+          pkg install -y meson pkgconf evdev-proto libgudev libxml++ bash libevdev
+          pkg install -y -g py\*-pip python3
           pip install libevdev pytest pyudev
         run: |
           meson setup builddir


### PR DESCRIPTION
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=253815 will replace `py37-pip` with `py38-pip`. While `devel/py-pip` will work other Python packages may not be under `devel/` directory (or physical category), so let's use `-g` to enable glob expansion of `*`, `?`, `[`.