### PR TITLE
data: add a test for receiver IDs

### DIFF
--- a/data/test_data_files.py
+++ b/data/test_data_files.py
@@ -8,6 +8,11 @@ import re
 from pathlib import Path
 
 
+WACOM_RECEIVER_USBIDS = [
+    (0x56a, 0x84),
+]
+
+
 def pytest_generate_tests(metafunc):
     # for any function that takes a "tabletfile" argument return the path to
     # a tablet file
@@ -32,3 +37,14 @@ def test_device_match(tabletfile):
         assert bus in ['usb', 'bluetooth', 'i2c', 'serial'], f'{tabletfile}: unknown bus type'
         assert re.match('[0-9a-f]{4}', vid), f'{tabletfile}: {vid} must be lowercase hex'
         assert re.match('[0-9a-f]{4}', pid), f'{tabletfile}: {pid} must be lowercase hex'
+
+
+def test_no_receiver_id(tabletfile):
+    config = configparser.ConfigParser(strict=True)
+    # Don't convert to lowercase
+    config.optionxform = lambda option: option
+    config.read(tabletfile)
+
+    receivers = ['usb:{:04x}:{:04x}'.format(*r) for r in WACOM_RECEIVER_USBIDS]
+    for match in config['Device']['DeviceMatch'].split(';'):
+        assert match not in receivers

--- a/meson.build
+++ b/meson.build
@@ -126,6 +126,15 @@ test('svg-layout-exists',
      args: [meson.source_root()],
      suite: ['all'])
 
+# This is a generic pytest invocation. If we end up with more than one
+# pytest-compatible test somewhere, we'll conveniently run that one too.
+pytest = find_program('pytest-3', required: false)
+if pytest.found()
+	test('receiver-id-test', pytest,
+	     workdir: meson.source_root(),
+	     env: ['LIBWACOM_DATA_DIR=@0@'.format(join_paths(meson.source_root(), 'data'))])
+endif
+
 ############### tools ###########################
 
 executable('libwacom-list-local-devices',


### PR DESCRIPTION
We don't want any .tablet entries with the receiver ID as that may match
multiple devices. We already test this as part of the tablet-validity test
(see 134166f) but it's a bit more obivous this way.

cc @jigpu 