### PR TITLE
Allow duplicate devices as long as they're in separate data dirs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,6 +153,52 @@ jobs:
       - name: compare device database
         run: diff -u8 devicelist.default.txt devicelist.modified.txt
 
+  ####
+  # duplicate device check
+  duplicate-devices:
+    needs: meson
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      # install python so we get pip for meson
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.8'
+      # Run as sudo because we install to /etc and thus need the pip
+      # packages available to root
+      - uses: ./.github/actions/pkginstall
+        with:
+          apt: $UBUNTU_PACKAGES
+          pip: $PIP_PACKAGES
+          pip_precmd: sudo
+      - uses: ./.github/actions/meson
+        with:
+          meson_args: --prefix=/usr
+          meson_skip_test: yes
+          ninja_args: install
+          ninja_precmd: sudo
+      - name: list devices with database in /usr
+        run: libwacom-list-devices --format=oneline > devicelist.default.txt
+      - run: sudo mkdir /etc/libwacom
+        # We override a Cintiq 27QHD with a single device match, and one of
+        # the multiple matches of the Intuos Pro L.
+      - name: copy and modify tablet files to override another one
+        run: |
+          sed -e 's/27QHD/27QHD MODIFIED/' data/cintiq-27hd.tablet | sudo tee /etc/libwacom/modified-cintiq.tablet
+          sed -e 's/Pro L/Pro L MODIFIED/' -e 's/usb:056a:0358;//' data/intuos-pro-2-l.tablet | sudo tee /etc/libwacom/modified-intuos.tablet
+      - name: list all devices for debugging
+        run: libwacom-list-devices --format=oneline
+
+      # We expect the modified tablets to be listed
+      # We expect the remaining match for a modified tablet to be listed
+      # We expect the overridden match *not* to be listed
+      - name: check for the expected devices to be present (or not present)
+        run: |
+          libwacom-list-devices --format=oneline | grep "usb:056a:032a:Wacom Cintiq 27QHD MODIFIED"
+          libwacom-list-devices --format=oneline | grep "bluetooth:056a:0361:Wacom Intuos Pro L MODIFIED"
+          test $(libwacom-list-devices --format=oneline | grep "usb:056a:0358" | wc -l) -eq 1
+          test $(libwacom-list-devices --format=oneline | grep "usb:056a:032a:Wacom Cintiq 27QHD M" | wc -l) -eq 1
+
   ###
   #
   # tarball verification

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -639,6 +639,7 @@ libwacom_parse_tablet_keyfile(WacomDeviceDatabase *db,
 
 	device = g_new0 (WacomDevice, 1);
 	device->refcnt = 1;
+	device->matches = g_array_new(TRUE, TRUE, sizeof(WacomMatch*));
 
 	string_list = g_key_file_get_string_list(keyfile, DEVICE_GROUP, "DeviceMatch", NULL, NULL);
 	if (!string_list) {

--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -941,6 +941,19 @@ libwacom_add_match(WacomDevice *device, WacomMatch *newmatch)
 	g_array_append_val(device->matches, newmatch);
 }
 
+void
+libwacom_remove_match(WacomDevice *device, WacomMatch *to_remove)
+{
+	for (guint i= 0; i < device->matches->len; i++) {
+		WacomMatch *m = g_array_index(device->matches, WacomMatch*, i);
+		if (streq(m->match, to_remove->match)) {
+			g_array_remove_index(device->matches, i);
+			libwacom_match_unref(to_remove);
+			break;
+		}
+	}
+}
+
 LIBWACOM_EXPORT int
 libwacom_get_vendor_id(const WacomDevice *device)
 {

--- a/libwacom/libwacomint.h
+++ b/libwacom/libwacomint.h
@@ -136,6 +136,7 @@ WacomMatch* libwacom_match_unref(WacomMatch *match);
 
 void libwacom_error_set(WacomError *error, enum WacomErrorCode code, const char *msg, ...);
 void libwacom_add_match(WacomDevice *device, WacomMatch *newmatch);
+void libwacom_remove_match(WacomDevice *device, WacomMatch *newmatch);
 WacomMatch* libwacom_match_new(const char *name, WacomBusType bus,
 			       int vendor_id, int product_id);
 

--- a/libwacom/libwacomint.h
+++ b/libwacom/libwacomint.h
@@ -72,9 +72,8 @@ struct _WacomDevice {
 	int width;
 	int height;
 
-	int match;	/* used match or first match by default */
-	WacomMatch **matches; /* NULL-terminated */
-	int nmatches; /* not counting NULL-terminated element */
+	guint match;	/* used match or first match by default */
+	GArray *matches;
 
 	WacomMatch *paired;
 

--- a/tools/list-devices.c
+++ b/tools/list-devices.c
@@ -142,6 +142,7 @@ int main(int argc, char **argv)
 		print_device_info ((WacomDevice *) *p, WBUSTYPE_UNKNOWN, output_format);
 
 	libwacom_database_destroy (db);
+	free(list);
 
 	return 0;
 }


### PR DESCRIPTION
This enables a user to copy/paste a `.tablet` file to `/etc/libwacom/`, change the `DeviceMatch=` line and have it magically work, even if the original file still exists in `/usr/share/libwacom`.

Previously we failed with an error about this being a duplicate - that error is still there but only if duplicate matches are used within the same data directory.

Fixes #379

cc @Big-FG