### PR TITLE
Add libwacom_database_ref/unref

### DIFF
--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -276,16 +276,55 @@ WacomDeviceDatabase* libwacom_database_new(void);
 WacomDeviceDatabase* libwacom_database_new_for_path(const char *datadir);
 
 /**
- * Free all memory used by the database.
+ * Increase the refcount of the database by one.
+ * Use libwacom_database_unref() to decrease the refcount, libwacom will
+ * free all resources associated with this database when the refcount
+ * reaches zero.
+ *
+ * @param db A Tablet and Stylus database.
+ * @return The passed-in pointer
+ *
+ * @since 1.10
+ */
+WacomDeviceDatabase *
+libwacom_database_ref(WacomDeviceDatabase *db);
+
+/**
+ * Decrease the refcount of the database by one.
+ * libwacom will free all resources associated with this database when the
+ * refcount reaches zero.
+ *
+ * Use libwacom_database_ref() to increase the refcount.
+ *
+ * @param db A Tablet and Stylus database.
+ * @return always NULL
+ *
+ * @since 1.10
+ */
+WacomDeviceDatabase *
+libwacom_database_unref(WacomDeviceDatabase *db);
+
+/**
+ * Destroy the database context. This function is deprecated, use
+ * libwacom_database_unref() instead for any new code.
+ *
+ * Code using libwacom_database_ref() must not use
+ * libwacom_database_destroy().
+ *
+ * @deprecated Use libwacom_database_unref() instead
  *
  * @param db A Tablet and Stylus database.
  */
+LIBWACOM_DEPRECATED
 void libwacom_database_destroy(WacomDeviceDatabase *db);
 
 /**
  * Create a new device reference from the given device path.
  * In case of error, NULL is returned and the error is set to the
  * appropriate value.
+ *
+ * The returned context has a refcount of at least 1, use
+ * libwacom_database_unref() to drop the context.
  *
  * @param db A device database
  * @param path A device path in the form of e.g. /dev/input/event0

--- a/libwacom/libwacom.sym
+++ b/libwacom/libwacom.sym
@@ -77,3 +77,9 @@ global:
     libwacom_stylus_get_eraser_type;
     libwacom_stylus_get_paired_ids;
 } LIBWACOM_0.33;
+
+LIBWACOM_1.10 {
+global:
+    libwacom_database_ref;
+    libwacom_database_unref;
+} LIBWACOM_1.4;

--- a/libwacom/libwacomint.h
+++ b/libwacom/libwacomint.h
@@ -116,6 +116,7 @@ struct _WacomStylus {
 };
 
 struct _WacomDeviceDatabase {
+	gint refcnt;
 	GHashTable *device_ht; /* key = DeviceMatch (str), value = WacomDeviceData * */
 	GHashTable *stylus_ht; /* key = ID (int), value = WacomStylus * */
 };

--- a/test/test-dbverify.c
+++ b/test/test-dbverify.c
@@ -251,8 +251,8 @@ int main(int argc, char **argv)
 
 	db_old = db;
 	rc = compare_databases(db_old, db_new);
-	libwacom_database_destroy(db_new);
-	libwacom_database_destroy(db_old);
+	libwacom_database_unref(db_new);
+	libwacom_database_unref(db_old);
 
 	rmtmpdir(dirname);
 	free(dirname);

--- a/test/test-load.c
+++ b/test/test-load.c
@@ -63,7 +63,7 @@ fixture_setup(struct fixture *f, gconstpointer user_data)
 static void
 fixture_teardown(struct fixture *f, gconstpointer user_data)
 {
-	libwacom_database_destroy(f->db);
+	libwacom_database_unref(f->db);
 }
 
 

--- a/test/test-stylus-validity.c
+++ b/test/test-stylus-validity.c
@@ -527,7 +527,7 @@ int main(int argc, char **argv)
 	rc = g_test_run();
 
 	free(all_styli);
-	libwacom_database_destroy (db);
+	libwacom_database_unref (db);
 
 	return rc;
 }

--- a/test/test-tablet-svg-validity.c
+++ b/test/test-tablet-svg-validity.c
@@ -420,7 +420,7 @@ int main(int argc, char **argv)
 	rc = g_test_run();
 
 	free(devices);
-	libwacom_database_destroy (db);
+	libwacom_database_unref (db);
 
 	return rc;
 }

--- a/test/test-tablet-validity.c
+++ b/test/test-tablet-validity.c
@@ -405,7 +405,7 @@ int main(int argc, char **argv)
 
 	rc = g_test_run();
 
-	libwacom_database_destroy(db);
+	libwacom_database_unref(db);
 	free(devices);
 
 	return rc;

--- a/tools/list-compatible-styli.c
+++ b/tools/list-compatible-styli.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
 	for (p = list; *p; p++)
 		print_device_info(db, (WacomDevice *)*p);
 
-	libwacom_database_destroy(db);
+	libwacom_database_unref(db);
 
         return 0;
 }

--- a/tools/list-devices.c
+++ b/tools/list-devices.c
@@ -139,7 +139,7 @@ int main(int argc, char **argv)
 	for (p = list; *p; p++)
 		print_device_info ((WacomDevice *) *p, WBUSTYPE_UNKNOWN, output_format);
 
-	libwacom_database_destroy (db);
+	libwacom_database_unref (db);
 	free(list);
 
 	return 0;

--- a/tools/list-local-devices.c
+++ b/tools/list-local-devices.c
@@ -230,7 +230,7 @@ int main(int argc, char **argv)
 
 	g_list_free_full(tabletlist, tablet_destroy);
 	g_dir_close(dir);
-	libwacom_database_destroy (db);
+	libwacom_database_unref (db);
 	return 0;
 }
 


### PR DESCRIPTION
This enables a client to re-use a database context without having to jump
through hoops. Specifically libinput right now wraps the libwacom database
into refcounter struct for that reason - it's easier if we can just use a
libwacom-provided function for this use-case.

This deprecates libwacom_database_destroy(), still works the same as before
assuming the refcount is correct.