### PR TITLE
CI: unbreak FreeBSD build

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: meson test
-      uses: vmactions/freebsd-vm@v0.1.2
+      uses: vmactions/freebsd-vm@v0.1.3
       with:
         prepare: |
           pkg install -y meson pkgconf evdev-proto libgudev libxml++ bash libevdev


### PR DESCRIPTION
Clock desync due to running under a VM confuses Meson. Noticed via https://github.com/intel/libva/commit/fae0a978c304961b670027f644fb9305c009a9bd