### PR TITLE
tools: use a YAML-compatible format by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: [ push, pull_request ]
 env:
   CFLAGS: "-Werror -Wall -Wextra -Wno-error=sign-compare -Wno-error=unused-parameter -Wno-error=missing-field-initializers"
   UBUNTU_PACKAGES: libgudev-1.0-dev libxml++2.6-dev valgrind tree python3-pip python3-setuptools libevdev2
-  PIP_PACKAGES: meson ninja libevdev pyudev pytest
+  PIP_PACKAGES: meson ninja libevdev pyudev pytest yq
 
 jobs:
   ###
@@ -197,7 +197,7 @@ jobs:
           ninja_args: install
           ninja_precmd: sudo
       - name: list devices with database in /usr
-        run: libwacom-list-devices --format=oneline > devicelist.default.txt
+        run: libwacom-list-devices --format=yaml > devicelist.default.txt
       - run: sudo mkdir /etc/libwacom
         # We override a Cintiq 27QHD with a single device match, and one of
         # the multiple matches of the Intuos Pro L.
@@ -206,17 +206,17 @@ jobs:
           sed -e 's/27QHD/27QHD MODIFIED/' data/cintiq-27hd.tablet | sudo tee /etc/libwacom/modified-cintiq.tablet
           sed -e 's/Pro L/Pro L MODIFIED/' -e 's/usb:056a:0358;//' data/intuos-pro-2-l.tablet | sudo tee /etc/libwacom/modified-intuos.tablet
       - name: list all devices for debugging
-        run: libwacom-list-devices --format=oneline
+        run: libwacom-list-devices --format=yaml
 
       # We expect the modified tablets to be listed
       # We expect the remaining match for a modified tablet to be listed
       # We expect the overridden match *not* to be listed
       - name: check for the expected devices to be present (or not present)
         run: |
-          libwacom-list-devices --format=oneline | grep "usb:056a:032a:Wacom Cintiq 27QHD MODIFIED"
-          libwacom-list-devices --format=oneline | grep "bluetooth:056a:0361:Wacom Intuos Pro L MODIFIED"
-          test $(libwacom-list-devices --format=oneline | grep "usb:056a:0358" | wc -l) -eq 1
-          test $(libwacom-list-devices --format=oneline | grep "usb:056a:032a:Wacom Cintiq 27QHD M" | wc -l) -eq 1
+          test "$(libwacom-list-devices --format=yaml | yq -r '.devices[] | select(.bus == "usb") | select(.vid == "0x056a") | select(.pid == "0x032a") | .name')" == "Wacom Cintiq 27QHD MODIFIED"
+          test "$(libwacom-list-devices --format=yaml | yq -r '.devices[] | select(.bus == "bluetooth") | select(.vid == "0x056a") | select(.pid == "0x0361") | .name')" == "Wacom Intuos Pro L MODIFIED"
+          test $(libwacom-list-devices --format=yaml | yq -r '.devices[] | select(.bus == "usb") | select(.vid == "0x056a") | select(.pid == "0x0358") | .name' | wc -l) -eq 1
+          test $(libwacom-list-devices --format=yaml | yq -r '.devices[] | select(.bus == "usb") | select(.vid == "0x056a") | select(.pid == "0x032a") | .name' | wc -l) -eq 1
 
   ###
   #

--- a/tools/libwacom-list-devices.man
+++ b/tools/libwacom-list-devices.man
@@ -4,7 +4,7 @@
 libwacom-list-devices - utility to list supported tablet devices
 
 .SH SYNOPSIS
-.B libwacom-list-devices [--format=oneline|datafile]
+.B libwacom-list-devices [--format=yaml|datafile]
 
 .SH DESCRIPTION
 libwacom-list-devices is a debug utility to list all supported tablet
@@ -12,8 +12,8 @@ devices identified by libwacom. It is usually used to check whether a
 libwacom installation is correct after adding custom data files.
 .SH OPTIONS
 .TP 8
-.B --format=oneline|datafile
-Sets the output format to be used. If \fIoneline\fR, the output format is a
-one-line format comprising the bus type, vendor and product ID and the
+.B --format=yaml|datafile
+Sets the output format to be used. If \fIyaml\fR, the output format is
+YAML comprising the bus type, vendor and product ID and the
 device name. If \fIdatafile\fR, the output format matches
-the tablet data files. The default is \fIoneline\fR.
+the tablet data files. The default is \fIyaml\fR.

--- a/tools/list-compatible-styli.c
+++ b/tools/list-compatible-styli.c
@@ -37,31 +37,31 @@
 static void
 print_device_info(const WacomDeviceDatabase *db, const WacomDevice *device)
 {
-    const int *styli;
-    int nstyli;
+	const int *styli;
+	int nstyli;
 
-    printf("- name: '%s'\n", libwacom_get_name(device));
-    if (libwacom_get_model_name(device)) {
-	    printf("  model: '%s'\n", libwacom_get_model_name(device));
-    }
-    if (!libwacom_has_stylus(device)) {
-        printf("  styli: []  # no styli defined\n");
-        return;
-    }
+	printf("- name: '%s'\n", libwacom_get_name(device));
+	if (libwacom_get_model_name(device)) {
+		printf("  model: '%s'\n", libwacom_get_model_name(device));
+	}
+	if (!libwacom_has_stylus(device)) {
+		printf("  styli: []  # no styli defined\n");
+		return;
+	}
 
-    printf("  styli:\n");
+	printf("  styli:\n");
 
-    styli = libwacom_get_supported_styli(device, &nstyli);
-    for (int i = 0; i < nstyli; i++) {
-        const WacomStylus *s;
-        char id[64];
+	styli = libwacom_get_supported_styli(device, &nstyli);
+	for (int i = 0; i < nstyli; i++) {
+		const WacomStylus *s;
+		char id[64];
 
-        s = libwacom_stylus_get_for_id(db, styli[i]);
-        snprintf(id, sizeof(id), "0x%x", libwacom_stylus_get_id(s));
-        printf("    - { id: %*s'%s', name: '%s' }\n",
-               (int)(7 - strlen(id)), " ", id,
-               libwacom_stylus_get_name(s));
-    }
+		s = libwacom_stylus_get_for_id(db, styli[i]);
+		snprintf(id, sizeof(id), "0x%x", libwacom_stylus_get_id(s));
+		printf("    - { id: %*s'%s', name: '%s' }\n",
+		       (int)(7 - strlen(id)), " ", id,
+		       libwacom_stylus_get_name(s));
+	}
 }
 
 int main(int argc, char **argv)

--- a/tools/list-compatible-styli.c
+++ b/tools/list-compatible-styli.c
@@ -40,24 +40,26 @@ print_device_info(const WacomDeviceDatabase *db, const WacomDevice *device)
     const int *styli;
     int nstyli;
 
-    printf("%s", libwacom_get_name(device));
+    printf("- name: '%s'\n", libwacom_get_name(device));
     if (libwacom_get_model_name(device)) {
-	    printf(" (%s)", libwacom_get_model_name(device));
+	    printf("  model: '%s'\n", libwacom_get_model_name(device));
     }
-    printf(":\n");
-
     if (!libwacom_has_stylus(device)) {
-        printf("\tno styli defined\n");
+        printf("  styli: []  # no styli defined\n");
         return;
     }
+
+    printf("  styli:\n");
 
     styli = libwacom_get_supported_styli(device, &nstyli);
     for (int i = 0; i < nstyli; i++) {
         const WacomStylus *s;
+        char id[64];
 
         s = libwacom_stylus_get_for_id(db, styli[i]);
-        printf("\t%#8x:\t%s\n",
-               libwacom_stylus_get_id(s),
+        snprintf(id, sizeof(id), "0x%x", libwacom_stylus_get_id(s));
+        printf("    - { id: %*s'%s', name: '%s' }\n",
+               (int)(7 - strlen(id)), " ", id,
                libwacom_stylus_get_name(s));
     }
 }
@@ -68,7 +70,7 @@ int main(int argc, char **argv)
 	WacomDevice **list, **p;
 
 	if (argc > 1) {
-		printf("Usage: %s [--help] - list all supported devices\n",
+		printf("Usage: %s [--help] - list compatible styli\n",
 		       basename(argv[0]));
 	       return !!(strcmp(argv[1], "--help"));
 	}


### PR DESCRIPTION
Let's output something that is both human- and machine-readable. This makes
it easier to search for specific devices with YAML parsers, e.g. to select all
bluetooth devices one could use:
``
  $ libwacom-list-devices | yq '.devices[] | select(.bus == "bluetooth") | .name'
``
Output for list-devices is now:
```
    devices:
    - {bus: i2c, vid: '056a', pid: '5169', name: Wacom ISDv4 5169}
      ...
```
Output for list-local-devices is now for example:
```
    devices:
    - name: 'Wacom Intuos Pro M'
      bus: usb
      vid: '056a'
      pid: '0357'
      nodes:
      - /dev/input/event24
      - /dev/input/event23
      - /dev/input/event22
```