### PR TITLE
Fix a pytest-related test error

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -139,9 +139,9 @@ test('svg-layout-exists',
 # pytest-compatible test somewhere, we'll conveniently run that one too.
 pytest = find_program('pytest-3', required: false)
 if pytest.found()
-	test('receiver-id-test', pytest,
+	test('pytests', pytest,
 	     workdir: meson.source_root(),
-	     env: ['LIBWACOM_DATA_DIR=@0@'.format(join_paths(meson.source_root(), 'data'))])
+	     env: ['LIBWACOM_DATA_DIR=@0@'.format(dir_src_data)])
 endif
 
 ############### tools ###########################

--- a/test/test-dbverify.c
+++ b/test/test-dbverify.c
@@ -241,9 +241,8 @@ int main(int argc, char **argv)
 
 	db = load_database();
 
-	dirname = strdup("tmp.dbverify.XXXXXX");
-	g_assert(mkdtemp(dirname)); /* just check for non-null to avoid
-				       Coverity complaints */
+	dirname = g_dir_make_tmp("tmp.dbverify.XXXXXX", NULL);
+	g_assert(dirname);
 
 	duplicate_database(db, dirname);
 	db_new = libwacom_database_new_for_path(dirname);
@@ -255,7 +254,7 @@ int main(int argc, char **argv)
 	libwacom_database_destroy(db_old);
 
 	rmtmpdir(dirname);
-	free(dirname);
+	g_free(dirname);
 
 	return rc;
 }


### PR DESCRIPTION
Race condition: pytest collects files at the same time as `test-dbverify` adds/removes them. In some cases, this can cause a race where pytest fails to open a file that has since been removed.