### PR TITLE
configure: disable static libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ LIBWACOM_LT_VERSION=8:1:6
 AC_SUBST(LIBWACOM_LT_VERSION)
 
 # Initialize libtool
-AC_PROG_LIBTOOL
+LT_INIT([disable-static])
 
 # Checks for programs.
 AC_PROG_CC


### PR DESCRIPTION
Use LT_INIT which is the replacement for AC_PROG_LIBTOOL. That takes a
disable-static argument to disable the creation of libwacom.a. Static
libraries were never really supported anyway, let's not install those.