### PR TITLE
tools: remove ID_INPUT_TABLET from "foo Keyboard" devices

### DIFF
--- a/tools/libwacom-update-db.py
+++ b/tools/libwacom-update-db.py
@@ -78,6 +78,15 @@ class HWDBFile:
         if tablet.has_pad:
             entries["* Pad"] = ["ID_INPUT_TABLET_PAD=1"]
 
+        # Non-Wacom devices often have a Keyboard node instead of a Pad
+        # device. If they share the USB ID with the tablet, we likely just
+        # assigned ID_INPUT_TABLET to a keyboard device - and libinput refuses
+        # to accept those.
+        # Let's add a generic exclusion rule for anything we know of with a
+        # Keyboard device name.
+        if int(vid, 16) != 0x56a:
+            entries["* Keyboard"] = ["ID_INPUT_TABLET=0"]
+
         lines = [f"# {tablet.name}"]
         for name, props in entries.items():
             lines.append(f"libwacom:name:{name}:input:{match}*")


### PR DESCRIPTION
Non-Wacom devices often have a Keyboard device node for the pad instead
of a real pad node. The same devices often share the USB IDs so the
keyboards get caught up by the main tablet rule. Assigning
ID_INPUT_TABLET to a keyboard means libinput won't load them because
they don't look like a keyboard.

Fix this with a non-wacom catchall rule: any device node ending in
Keyboard has ID_INPUT_TABLET removed again.

Fixes #409 

cc @tviel can you test this please with your device?