### PR TITLE
data: add support for ELAN-2AD9 in HP ProBook x360 435 G7

### DIFF
--- a/data/elan-2ad9.tablet
+++ b/data/elan-2ad9.tablet
@@ -1,4 +1,7 @@
 # ELAN touchscreen/pen sensor in the HP Probook x360 435 G7 
+#
+# sysinfo.9FNnwQKhog
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/165
 
 [Device]
 Name=ELAN 2AD9

--- a/data/elan-2ad9.tablet
+++ b/data/elan-2ad9.tablet
@@ -1,0 +1,14 @@
+# ELAN touchscreen/pen sensor in the HP Probook x360 435 G7 
+
+[Device]
+Name=ELAN 2AD9
+DeviceMatch=i2c:04f3:2ad9
+Class=ISDV4
+Width=14
+Height=8
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
This configuration makes the tablet & stylus show up in gnome settings.