### PR TITLE
data: add support for Waltop Slim Tablet 12.1" and rebrands

### DIFF
--- a/data/waltop-slim-tablet-12-1.tablet
+++ b/data/waltop-slim-tablet-12-1.tablet
@@ -13,7 +13,7 @@ ModelName=
 DeviceMatch=usb:172f:0031
 Class=Bamboo
 Width=10
-Height=6.25
+Height=6
 Styli=0xffffd;
 
 [Features]

--- a/data/waltop-slim-tablet-12-1.tablet
+++ b/data/waltop-slim-tablet-12-1.tablet
@@ -1,0 +1,23 @@
+# Waltop 
+# Slim Tablet 12.1"
+#
+# Also known/rebranded as: Genius G-Pen F610, Trust Slimline Widescreen Tablet, Medion Graphics Pad MD 85637
+#                   guess: VisTablet Original 12", Adesso CyberTablet Z12, Adesso CT-Z12A, PenPower Tooya Pro, Aiptek Slim 12.1 Inch, Aiptek SlimTablet 600u Premium II, NGS Slim Pro, iVistaTablet Slim 12.1, PENTAGRAM ThinType P 2006
+# According to https://digimend.github.io/tablets/Waltop_Slim_Tablet_12.1_inch/
+#
+#
+
+[Device]
+Name=Waltop Slim Tablet 12.1"
+ModelName=
+DeviceMatch=usb:172f:0031
+Class=Bamboo
+Width=10
+Height=6.25
+Styli=0xffffd;
+
+[Features]
+Stylus=true
+Reversible=false
+Touch=false
+Buttons=0


### PR DESCRIPTION
This .tablet-file worked for my "Medion Graphics Pad MD 85637" just fine. Nevertheless I realised that it is a re-branded tablet so I used the "original" name. 
I also found out that many companies used this exact model with seemingly the same USB ID but I wasn't able to confirm that.
Further I wasn't able to add support for some software buttons yet. I'm not sure whether this is even possible or not. The tablet itself and the settings I used are working though.

I found the mentioned information [here (Link to DIGImend)](https://digimend.github.io/tablets/Waltop_Slim_Tablet_12.1_inch/).