### PR TITLE
Work around lld 13 no longer supporting symver tricks

### DIFF
--- a/libwacom/libwacomint.h
+++ b/libwacom/libwacomint.h
@@ -132,6 +132,9 @@ WacomStylus* libwacom_stylus_unref(WacomStylus *stylus);
 WacomMatch* libwacom_match_ref(WacomMatch *match);
 WacomMatch* libwacom_match_unref(WacomMatch *match);
 
+#define libwacom_error_set libwacom_internal_error_set
+#define libwacom_match_new libwacom_internal_match_new
+
 void libwacom_error_set(WacomError *error, enum WacomErrorCode code, const char *msg, ...);
 void libwacom_add_match(WacomDevice *device, WacomMatch *newmatch);
 void libwacom_set_default_match(WacomDevice *device, WacomMatch *newmatch);


### PR DESCRIPTION
In b9961dbe912 a special trick was added to hide accidentally exposed ABI symbols: by using `.symver` to define `@LIBWACOM_0.33` versioned symbols, but not defining the default versions, the non-versioned symbols would be effectively hidden.

Unfortunately, this trick no longer works with lld 13 after https://github.com/llvm/llvm-project/commit/66d44304921 ("[ELF] Combine foo@v1 and foo with the same versionId if both are defined"): the versioned and non-versioned symbols get merged, and instead of the desired internal functions, the empty stubs get called. This leads to various null pointer accesses, and in case of the FreeBSD port (which is still at libwacom 1.5), it segfaults in `generate-hwdb`.

I would like to propose fixing this in a minimalistic fashion, by renaming the two affected internal functions, `libwacom_error_set` and `libwacom_match_new`. To minimize the number of source code changes, I use a `#define` in `libwacomint.h`, which adds a `libwacom_internal_ prefix` to
both functions. See also https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=258463.

An alternative approach would be to mechanically rename all the internal function invocations, but that is much more invasive. And it seems there is already a pull request to completely drop the deprecated symbols, and bump the .so version. But this pull request is mostly about fixing it in a minimal fashion, to make it easier to update the FreeBSD port in the future.
