### PR TITLE
Add new Intuos BT (CTL-4100WL/CTL-6100WL) device matches

### DIFF
--- a/data/intuos-m-p3-wl-android.tablet
+++ b/data/intuos-m-p3-wl-android.tablet
@@ -25,7 +25,7 @@
 [Device]
 Name=Wacom Intuos BT M (Android Mode)
 ModelName=CTL-6100WL
-DeviceMatch=usb:2d1f:0378
+DeviceMatch=usb:2d1f:0378;usb:2d1f:03c7
 Class=Bamboo
 Width=3
 Height=5

--- a/data/intuos-m-p3-wl.tablet
+++ b/data/intuos-m-p3-wl.tablet
@@ -20,7 +20,7 @@
 [Device]
 Name=Wacom Intuos BT M
 ModelName=CTL-6100WL
-DeviceMatch=usb:056a:0378;bluetooth:056a:0379
+DeviceMatch=usb:056a:0378;bluetooth:056a:0379;usb:056a:03c7;bluetooth:056a:03c8
 Class=Bamboo
 Width=9
 Height=5

--- a/data/intuos-s-p3-wl-android.tablet
+++ b/data/intuos-s-p3-wl-android.tablet
@@ -25,7 +25,7 @@
 [Device]
 Name=Wacom Intuos BT S (Android Mode)
 ModelName=CTL-4100WL
-DeviceMatch=usb:2d1f:0376
+DeviceMatch=usb:2d1f:0376;usb:2d1f:03c5
 Class=Bamboo
 Width=2
 Height=4

--- a/data/intuos-s-p3-wl.tablet
+++ b/data/intuos-s-p3-wl.tablet
@@ -20,7 +20,7 @@
 [Device]
 Name=Wacom Intuos BT S
 ModelName=CTL-4100WL
-DeviceMatch=usb:056a:0376;bluetooth:056a:0377
+DeviceMatch=usb:056a:0376;bluetooth:056a:0377;usb:056a:03c5;bluetooth:056a:03c6
 Class=Bamboo
 Width=6
 Height=4


### PR DESCRIPTION
Adds the new Intuos BT model ID's into the relevant .tablet files.