### PR TITLE
Add tablet description for Dell Latitude 5290

### DIFF
--- a/data/isdv4-484e.tablet
+++ b/data/isdv4-484e.tablet
@@ -1,4 +1,4 @@
-# Active electrostatic (AES) sensor used by the Dell Latitude 5285
+# Active electrostatic (AES) sensor used by the Dell Latitude 5290
 
 [Device]
 Name=Wacom ISDv4 484e

--- a/data/isdv4-484e.tablet
+++ b/data/isdv4-484e.tablet
@@ -1,0 +1,16 @@
+# Active electrostatic (AES) sensor used by the Dell Latitude 5285
+
+[Device]
+Name=Wacom ISDv4 484e
+ModelName=
+DeviceMatch=i2c:056a:484e
+Class=ISDV4
+Width=10
+Height=7
+IntegratedIn=Display;System
+Styli=@isdv4-aes;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
Just recently received a Dell Latitude 5290 and noticed the internal tablet missed a description file.
This is a copy of the file for it's predecessor, the Latitude 5285, with updated device id, making it recognized by, for example, Gnome's settings.