### PR TITLE
Fix libwacom_new_from_path() failing in mocked environment

### DIFF
--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -587,7 +587,7 @@ libwacom_new_from_path(const WacomDeviceDatabase *db, const char *path, WacomFal
 out:
 	g_free (name);
 	if (ret == NULL)
-		libwacom_error_set(error, WERROR_UNKNOWN_MODEL, NULL);
+		libwacom_error_set(error, WERROR_UNKNOWN_MODEL, "unknown model");
 	return ret;
 }
 


### PR DESCRIPTION
umockdev doesn't support mocking device nodes, so libwacom_new_from_path()
fails to find devices after calling g_udev_client_query_by_device_file()
that always fails as it cannot stat() the device node to get its type
and major and minor numbers.

Using this reimplementation of g_udev_client_query_by_subsystem_and_device_file()
(see https://gitlab.gnome.org/GNOME/libgudev/-/merge_requests/22),
no I/O is made at all, and all the data comes from the mocked udev database.

Closes: #438

Signed-off-by: Bastien Nocera <hadess@hadess.net>
