### PR TITLE
add Thinkpad 11e gen6

### DIFF
--- a/data/elan-901c.tablet
+++ b/data/elan-901c.tablet
@@ -1,0 +1,18 @@
+# touchscreen/stylus in Lenovo Thinkpad 11e Yoga gen6
+
+[Device]
+
+Name=ELAN 901C
+ModelName=
+DeviceMatch=i2c:04f3:2a40
+Class=ISDV4
+Width=10
+Height=6
+IntegratedIn=Display;System
+Styli=0xffffe;0xffffff;
+
+[Features]
+
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
This adds initial support for the touchscreen/stylus in the Lenovo ThinkPad 11e yoga gen 6. 
with the curent version of the file, the tablet shows up in gnome settings but the stylus doesnt. i'm not sure what needs to be edited in order to make it show up as well.
```
$ xinput --list
⎡ Virtual core pointer                    	id=2	[master pointer  (3)]
⎜   ↳ Virtual core XTEST pointer              	id=4	[slave  pointer  (2)]
⎜   ↳ ELAN901C:00 04F3:2A40                   	id=12	[slave  pointer  (2)]
⎜   ↳ Elan Touchpad                           	id=14	[slave  pointer  (2)]
⎜   ↳ ELAN901C:00 04F3:2A40 Stylus Pen (0)    	id=17	[slave  pointer  (2)]
⎜   ↳ ELAN901C:00 04F3:2A40 Stylus Eraser (0) 	id=18	[slave  pointer  (2)]
⎣ Virtual core keyboard                   	id=3	[master keyboard (2)]
    ↳ Virtual core XTEST keyboard             	id=5	[slave  keyboard (3)]
    ↳ Power Button                            	id=6	[slave  keyboard (3)]
    ↳ Video Bus                               	id=7	[slave  keyboard (3)]
    ↳ Power Button                            	id=8	[slave  keyboard (3)]
    ↳ Sleep Button                            	id=9	[slave  keyboard (3)]
    ↳ Integrated Camera: Integrated C         	id=10	[slave  keyboard (3)]
    ↳ Integrated 5M Camera: Integrate         	id=11	[slave  keyboard (3)]
    ↳ ELAN901C:00 04F3:2A40 Stylus            	id=13	[slave  keyboard (3)]
    ↳ AT Translated Set 2 keyboard            	id=15	[slave  keyboard (3)]
    ↳ ThinkPad Extra Buttons                  	id=16	[slave  keyboard (3)]
```
the stylus has one button in addition to the eraser buton, but the button value is only for buttons on external tablets, right?