### PR TITLE
tools: always write out custom hwdb files as 66-libwacom.hwdb

### DIFF
--- a/tools/libwacom-update-db.py
+++ b/tools/libwacom-update-db.py
@@ -172,16 +172,15 @@ def find_udev_base_dir(path):
 
 
 # udev's behaviour is that where a file X exists in two locations,
-# only the highest-precedence one is read. Our files in /etc are
-# supposed to be complimentary to the system ones so we have to
-# change the filename accordingly. We do so based on the prefix.
+# only the highest-precedence one is read. Our files are supposed to be
+# complimentary to the system-installed ones (which default to
+# 65-libwacom.hwdb) so we bump the filename number.
 def guess_hwdb_filename(basedir):
     hwdbdir = Path(basedir) / "hwdb.d"
     if not hwdbdir.exists():
         raise FileNotFoundError(hwdbdir)
 
-    number = 66 if str(hwdbdir).startswith("/etc/") else 66
-    fname = hwdbdir / f"{number}-libwacom.hwdb"
+    fname = hwdbdir / f"66-libwacom.hwdb"
     return fname
 
 

--- a/tools/libwacom-update-db.py
+++ b/tools/libwacom-update-db.py
@@ -193,7 +193,7 @@ if __name__ == "__main__":
         help="Directory to load .tablet files from"
     )
     # buildsystem-mode is what we use from meson/autotools, it changes the
-    # the behavior to just generate the file
+    # the behavior to just generate the file and print it
     parser.add_argument(
         "--buildsystem-mode",
         action="store_true",


### PR DESCRIPTION
The (broken) rename to 66-libwacom.hwdb was motivated from a version
of this tool that didn't yet have the --buildsystem-mode. Let's get rid
of the check and always write out a filename that won't overwrite the
system-provided ones.