### PR TITLE
Update huion-h610-pro.tablet

### DIFF
--- a/data/huion-h610-pro.tablet
+++ b/data/huion-h610-pro.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Huion H610 Pro
 ModelName=
-DeviceMatch=usb:256c:006e:HUION PenTablet Pen;usb:256c:006e:HUION PenTablet Pad;usb:256c:006e:Turcom TS-6610 Pen;usb:256c:006e:Turcom TS-6610 Pad;usb:256c:006e:HUION Huion Tablet Pen;usb:256c:006e:HUION Huion Tablet Pad
+DeviceMatch=usb:256c:006e:HUION PenTablet Pen;usb:256c:006e:HUION PenTablet Pad;usb:256c:006e:Turcom TS-6610 Pen;usb:256c:006e:Turcom TS-6610 Pad;usb:256c:006e:HUION Huion Tablet Pen;usb:256c:006e:HUION Huion Tablet Pad;usb:256c:006e:HUION H610 Pen;usb:256c:006e:HUION H610 Pad
 Class=Bamboo
 Width=10
 Height=6


### PR DESCRIPTION
my tablet, a v1 from 2014, presents a different name (HUION H610 Pen & HUION H610 Pad) than the current `DeviceMatch` list.

There is also an additional device that appears in the output of `libwacom-list-local-devices` (HUION H610 Mouse) but I don't think it's needed.