### PR TITLE
doc: fix the check for integration flags in the example code

### DIFF
--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -62,7 +62,7 @@
       if (!device)
            return; // should check for error here
 
-      if (libwacom_device_is_builtin(device))
+      if (libwacom_get_integration_flags(device) & WACOM_DEVICE_INTEGRATED_SYSTEM)
            printf("This is a built-in device\n");
 
       libwacom_destroy(device);


### PR DESCRIPTION
Should've been libwacom_is_builtin() but that is deprecated now, so
let's switch to libwacom_get_integration_flags() instead.

Fixes #450