### PR TITLE
github: bump freebsd workflow to 0.1.5

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -8,11 +8,11 @@ jobs:
   # FreeBSD build job
   #
   freebsd:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
     - name: meson test
-      uses: vmactions/freebsd-vm@v0.1.3
+      uses: vmactions/freebsd-vm@v0.1.5
       with:
         prepare: |
           pkg install -y meson pkgconf evdev-proto libgudev libxml++ bash libevdev


### PR DESCRIPTION
And use macos-10.15 as requested in the README



Maybe this resolves the freebsd unreliability