### PR TITLE
data: Add Microsoft Surface Go 2

### DIFF
--- a/data/surface-go-2.tablet
+++ b/data/surface-go-2.tablet
@@ -1,0 +1,18 @@
+# This is for the Microsoft Surface Go 2
+#
+# Elan I2C sensor
+#
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/192
+
+[Device]
+Name=Microsoft Surface Go 2
+Class=ISDV4
+DeviceMatch=i2c:04f3:2a1c
+Width=10
+Height=7
+IntegratedIn=Display;System;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0

--- a/data/surface-go-2.tablet
+++ b/data/surface-go-2.tablet
@@ -3,6 +3,7 @@
 # Elan I2C sensor
 #
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/192
+# sysinfo.43RvL0wF2a
 
 [Device]
 Name=Microsoft Surface Go 2


### PR DESCRIPTION
Link: https://github.com/linuxwacom/wacom-hid-descriptors/issues/192

The tablet definition couldn't automatically be created. I manually created this file, based on https://github.com/linuxwacom/libwacom/pull/352 and the output from `libinput list-devices`. After adding to `/etc/libwacom` and running `libwacom-update-db` I was able to configure my stylus in Gnome Settings.