### PR TITLE
Add support for Huion MiniDial KD100

### DIFF
--- a/data/huion-kd100.tablet
+++ b/data/huion-kd100.tablet
@@ -1,0 +1,56 @@
+# Huion
+# KD100
+#
+# Button Map:
+# (A=1, B=2, C=3, ...)
+# 
+#   S
+#
+# *---------*
+# |         |
+# | A B C D |
+# |         |
+# | E F G H |
+# |         |
+# | I J K L |
+# |         |
+# | M N O P |
+# |       P |
+# | QQQ R P |
+# |         |
+# *---------*
+#
+#
+# Ring:
+# (a=strip min, A=strip max)
+#
+#   L R
+#
+# *---------*
+# |         |
+# |         |
+# |         |
+# *---------*
+#
+
+[Device]
+Name=Huion KD100
+DeviceMatch=usb:256c:006d:HUION Huion Tablet_KD100 Pad;usb:256c:006d:HUION Huion Tablet_KD100 Dial
+Class=Bamboo
+Width=10
+Height=6
+IntegratedIn=
+Layout=huion-kd100.svg
+Styli=0xffffd
+
+[Features]
+Stylus=true
+Reversible=true
+Touch=false
+NumStrips=1
+Buttons=19
+Ring=A
+
+[Buttons]
+Left=A;B;C;D;E;F;G;H;I;J;K;L;M;N;O;P;Q;R;S
+EvdevCodes=0x100;0x101;0x102;0x103;0x104;0x105;0x106;0x107;0x108;0x109;0x130;0x131;0x132;0x133;0x134;0x135;0x136;0x137;0x138

--- a/data/layouts/huion-kd100.svg
+++ b/data/layouts/huion-kd100.svg
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg854"
+   width="1500"
+   height="1500"
+   viewBox="0 0 1500 1500"
+   sodipodi:docname="huion-kd100.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs858" />
+  <sodipodi:namedview
+     id="namedview856"
+     pagecolor="#ffffff"
+     bordercolor="#cccccc"
+     borderopacity="1"
+     inkscape:pageshadow="0"
+     inkscape:pageopacity="1"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="0.59972363"
+     inkscape:cx="946.2692"
+     inkscape:cy="611.94854"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g860">
+    <sodipodi:guide
+       position="796.7302,944.98185"
+       orientation="0,-1"
+       id="guide3153" />
+  </sodipodi:namedview>
+  <g
+     inkscape:groupmode="layer"
+     inkscape:label="Image"
+     id="g860">
+    <ellipse
+       style="fill:none;stroke:#000000;stroke-width:1.81;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="Ring"
+       class="Ring TouchRing"
+       cx="568.63483"
+       cy="376.50467"
+       rx="108.28616"
+       ry="109.82561" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="ButtonD"
+       class="D Button"
+       width="110.93145"
+       height="110.949"
+       x="891.54706"
+       y="555.21362"
+       ry="20.6047" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="ButtonC"
+       class="C Button"
+       width="110.93145"
+       height="110.949"
+       x="760.63318"
+       y="555.67493"
+       ry="20.6047" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="ButtonB"
+       class="B Button"
+       width="110.93145"
+       height="110.949"
+       x="630.69452"
+       y="556.33173"
+       ry="20.6047"
+       inkscape:label="" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="ButtonA"
+       class="A Button"
+       width="110.93145"
+       height="110.949"
+       x="499.78064"
+       y="556.79303"
+       ry="20.6047"
+       inkscape:label="" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="ButtonH"
+       class="H Button"
+       width="110.93145"
+       height="110.949"
+       x="891.23376"
+       y="686.23682"
+       ry="20.6047" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="ButtonG"
+       class="G Button"
+       width="110.93145"
+       height="110.949"
+       x="760.31989"
+       y="686.69812"
+       ry="20.6047" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="ButtonE"
+       class="E Button"
+       width="110.93145"
+       height="110.949"
+       x="499.46759"
+       y="687.81622"
+       ry="20.6047" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="ButtonL"
+       class="L Button"
+       width="110.93145"
+       height="110.949"
+       x="891.21851"
+       y="818.04834"
+       ry="20.6047" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="ButtonR"
+       class="R Button"
+       width="110.93145"
+       height="110.949"
+       x="762.26947"
+       y="1081.0549"
+       ry="20.6047" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="ButtonO"
+       class="O Button"
+       width="110.93145"
+       height="110.949"
+       x="759.35559"
+       y="948.61713"
+       ry="20.6047" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="ButtonM"
+       class="M Button"
+       width="110.93145"
+       height="110.949"
+       x="498.50308"
+       y="949.73523"
+       ry="20.6047" />
+    <g
+       style="fill:none;stroke:#000000;stroke-opacity:1"
+       id="g18">
+      <rect
+         style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="ButtonK"
+         class="K Button"
+         width="110.93145"
+         height="110.949"
+         x="760.30457"
+         y="818.50964"
+         ry="20.6047" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 812.05368,877.34244 6.79652,-4.10235 -7.02734,-4.61069 z"
+         id="path3850"
+         sodipodi:nodetypes="cccc" />
+    </g>
+    <g
+       style="fill:none;stroke:#000000;stroke-opacity:1"
+       id="g22">
+      <rect
+         style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="ButtonI"
+         class="I Button"
+         width="110.93145"
+         height="110.949"
+         x="499.45218"
+         y="819.62775"
+         ry="20.6047" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 555.2058,869.48385 -6.79652,4.4428 7.02734,4.27024 z"
+         id="path3850-2"
+         sodipodi:nodetypes="cccc" />
+    </g>
+    <g
+       style="fill:none;stroke:#000000;stroke-opacity:1"
+       id="g26">
+      <rect
+         style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="ButtonN"
+         class="N Button"
+         width="110.93145"
+         height="110.949"
+         x="629.41693"
+         y="949.27393"
+         ry="20.6047" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 680.93498,1002.7135 4.59639,6.7149 4.11665,-6.9457 z"
+         id="path3850-0"
+         sodipodi:nodetypes="cccc" />
+    </g>
+    <g
+       style="fill:none;stroke:#000000;stroke-opacity:1"
+       id="g30">
+      <rect
+         style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="ButtonF"
+         class="F Button"
+         width="110.93145"
+         height="110.949"
+         x="630.38123"
+         y="687.35492"
+         ry="20.6047" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 689.0792,744.35077 -4.10235,-6.79652 -4.61069,7.02734 z"
+         id="path3850-23"
+         sodipodi:nodetypes="cccc" />
+    </g>
+    <g
+       style="fill:none;stroke:#000000;stroke-opacity:1"
+       id="g34">
+      <rect
+         style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="ButtonJ"
+         class="J Button"
+         width="110.93145"
+         height="110.949"
+         x="630.36603"
+         y="819.16644"
+         ry="20.6047" />
+      <rect
+         style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect4418"
+         width="14.784091"
+         height="0.37428167"
+         x="677.63306"
+         y="903.01031"
+         rx="0.22810741"
+         ry="0" />
+    </g>
+    <g
+       style="fill:none;stroke:#000000;stroke-opacity:1"
+       id="g38">
+      <rect
+         style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="ButtonQ"
+         class="Q Button"
+         width="243.27168"
+         height="110.94897"
+         x="499.03558"
+         y="1081.6763"
+         ry="20.6047" />
+      <ellipse
+         style="fill:none;stroke:#000000;stroke-width:1.45015;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path5119"
+         cx="617.71259"
+         cy="1135.6724"
+         rx="2.9078937"
+         ry="2.9359524" />
+    </g>
+    <g
+       style="fill:none;stroke:#000000;stroke-opacity:1"
+       id="g42">
+      <rect
+         style="fill:none;stroke:#000000;stroke-width:1.81039;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="ButtonP"
+         class="P Button"
+         width="111.04948"
+         height="242.47586"
+         x="891.79578"
+         y="949.86072"
+         ry="20.6047" />
+      <ellipse
+         style="fill:none;stroke:#000000;stroke-width:1.45015;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path5119-7"
+         cx="946.34918"
+         cy="1069.2268"
+         rx="2.9078937"
+         ry="2.9359524" />
+    </g>
+    <ellipse
+       style="fill:none;stroke:#000000;stroke-width:1.81;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="ButtonS"
+       class="S Button"
+       cx="566.99353"
+       cy="374.54028"
+       rx="44.931316"
+       ry="44.010899" />
+  </g>
+</svg>


### PR DESCRIPTION
- [ ] Ring is still not correctly configured ()
- [x] mouse button (was just another button)
- [x] This only covers KD100 connected by wire. 
- [ ] Wireless do not match usb filter (it only shows 256c:006d)
- [x] Only eight buttons are working (using GNOME). Fix rest of buttons in digimend driver

relates #469 
