### PR TITLE
test: add a test for matching the button count with the evdev codes

### DIFF
--- a/test/test_data_files.py
+++ b/test/test_data_files.py
@@ -69,3 +69,18 @@ def test_svg_exists(tabletfile):
 
     except KeyError:
         pass
+
+
+def test_button_evcodes(tabletfile):
+    config = configparser.ConfigParser(strict=True)
+    # Don't convert to lowercase
+    config.optionxform = lambda option: option
+    config.read(tabletfile)
+
+    try:
+        nbuttons = int(config['Features']['Buttons'])
+        str = config['Buttons']['EvdevCodes']
+        codes = [c for c in str.split(";") if c]  # drop empty strings from trailing semicolons
+        assert len(codes) == nbuttons, "Number of buttons mismatches the EvdevCodes"
+    except KeyError:
+        pass


### PR DESCRIPTION
Slightly superfluous since all the other tests will fail anyway thanks
to the libwacom database check but this is a more confined test and
possibly easier to understand in the output.

cc @albfan