### PR TITLE
Add support for a new "Wacom One Pen Display 13"

### DIFF
--- a/data/wacom-one.tablet
+++ b/data/wacom-one.tablet
@@ -6,7 +6,7 @@
 Name=Wacom One Pen Display 13
 ModelName=DTC133
 Class=PenDisplay
-DeviceMatch=usb:056a:03a6
+DeviceMatch=usb:056a:03a6;usb:056a:03bd
 Width=11
 Height=6
 # No pad buttons, so no layout


### PR DESCRIPTION
Except the PID change, there was only a minor update in the tablet's
cordinate for this model.

Signed-off-by: Ping Cheng <ping.cheng@wacom.com>