### PR TITLE
Fix a few compiler warnings

### DIFF
--- a/.github/actions/meson/action.yml
+++ b/.github/actions/meson/action.yml
@@ -32,7 +32,7 @@ runs:
     - run: |
         ${{inputs.meson_precmd}} meson setup ${{inputs.builddir}} ${{inputs.srcdir}} ${{inputs.meson_args}}
         ${{inputs.meson_precmd}} meson configure ${{inputs.builddir}}
-        ${{inputs.ninja_precmd}} ninja -C ${{inputs.builddir}} ${{inputs.ninja_args}}
+        ${{inputs.ninja_precmd}} ninja --verbose -C ${{inputs.builddir}} ${{inputs.ninja_args}}
         if [[ -z "${{inputs.meson_skip_test}}" ]]; then
           ${{inputs.meson_precmd}} meson test -C ${{inputs.builddir}} --print-errorlogs ${{inputs.meson_test_args}};
         fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: "Build and test"
 on: [ push, pull_request ]
 
 env:
-  CFLAGS: "-Werror -Wno-error=sign-compare -Wno-error=missing-field-initializers"
+  CFLAGS: "-Werror -Wno-error=missing-field-initializers"
   UBUNTU_PACKAGES: libgudev-1.0-dev libxml++2.6-dev valgrind tree python3-pip python3-setuptools libevdev2
   PIP_PACKAGES: meson ninja libevdev pyudev pytest yq
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: "Build and test"
 on: [ push, pull_request ]
 
 env:
-  CFLAGS: "-Werror -Wall -Wextra -Wno-error=sign-compare -Wno-error=unused-parameter -Wno-error=missing-field-initializers"
+  CFLAGS: "-Werror -Wno-error=sign-compare -Wno-error=missing-field-initializers"
   UBUNTU_PACKAGES: libgudev-1.0-dev libxml++2.6-dev valgrind tree python3-pip python3-setuptools libevdev2
   PIP_PACKAGES: meson ninja libevdev pyudev pytest yq
 

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -181,7 +181,7 @@ match_from_string(const char *str, WacomBusType *bus, int *vendor_id, int *produ
 }
 
 static WacomMatch *
-libwacom_match_from_string(WacomDevice *device, const char *matchstr)
+libwacom_match_from_string(const char *matchstr)
 {
 	char *name = NULL;
 	int vendor_id, product_id;
@@ -678,8 +678,7 @@ libwacom_parse_tablet_keyfile(WacomDeviceDatabase *db,
 		guint i;
 		guint nmatches = 0;
 		for (i = 0; string_list[i]; i++) {
-			WacomMatch *m = libwacom_match_from_string(device,
-								   string_list[i]);
+			WacomMatch *m = libwacom_match_from_string(string_list[i]);
 			if (!m) {
 				DBG("'%s' is an invalid DeviceMatch in '%s'\n",
 				    string_list[i], path);

--- a/meson.build
+++ b/meson.build
@@ -7,9 +7,9 @@ project('libwacom', 'c',
 dir_bin     = get_option('prefix') / get_option('bindir')
 dir_data    = get_option('prefix') / get_option('datadir') / 'libwacom'
 dir_etc     = get_option('prefix') / get_option('sysconfdir') / 'libwacom'
-dir_src     = meson.source_root()  / 'libwacom'
-dir_src_data= meson.source_root()  / 'data'
-dir_test    = meson.source_root()  / 'test'
+dir_src     = meson.current_source_dir()  / 'libwacom'
+dir_src_data= meson.current_source_dir()  / 'data'
+dir_test    = meson.current_source_dir()  / 'test'
 dir_sys_udev= get_option('prefix') / 'lib' / 'udev'
 
 dir_udev = get_option('udev-dir')
@@ -120,7 +120,7 @@ install_subdir('data',
 
 test('files-in-git',
      find_program('test/check-files-in-git.sh'),
-     args: [meson.source_root()],
+     args: [meson.current_source_dir()],
      suite: ['all'])
 
 # This is a generic pytest invocation. If we end up with more than one
@@ -128,7 +128,7 @@ test('files-in-git',
 pytest = find_program('pytest-3', required: false)
 if pytest.found()
 	test('pytests', pytest,
-	     workdir: meson.source_root(),
+	     workdir: meson.current_source_dir(),
 	     env: ['LIBWACOM_DATA_DIR=@0@'.format(dir_src_data)])
 endif
 
@@ -209,7 +209,7 @@ if doxygen.found()
 	doc_config = configuration_data()
 	doc_config.set('PACKAGE_NAME', meson.project_name())
 	doc_config.set('PACKAGE_VERSION', meson.project_version())
-	doc_config.set('TOPSRCDIR', meson.source_root())
+	doc_config.set('TOPSRCDIR', meson.current_source_dir())
 
 	doxyfile = configure_file(input: 'doc/doxygen.conf.in',
 				  output: 'doxygen.conf',
@@ -227,7 +227,7 @@ if get_option('tests').enabled()
 	dep_libxml  = dependency('libxml-2.0', required : false)
 	dep_dl      = cc.find_library('dl')
 
-	tests_cflags = ['-DTOPSRCDIR="@0@"'.format(meson.source_root())]
+	tests_cflags = ['-DTOPSRCDIR="@0@"'.format(meson.current_source_dir())]
 
 	test_load = executable('test-load',
 			       'test/test-load.c',
@@ -289,8 +289,8 @@ if get_option('tests').enabled()
 	pytest = find_program('pytest-3', 'pytest')
 	test('pytest',
 	     pytest,
-	     args: [meson.source_root()],
-	     env: ['MESON_SOURCE_ROOT=@0@'.format(meson.source_root())],
+	     args: [meson.current_source_dir()],
+	     env: ['MESON_SOURCE_ROOT=@0@'.format(meson.current_source_dir())],
 	     suite: ['all'])
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -44,6 +44,7 @@ cflags = cc.get_supported_arguments(
 	'-Wredundant-decls',
 	'-Wincompatible-pointer-types',
 	'-Wformat=2',
+	'-Wsign-compare',
 	'-Wmissing-declarations',
 )
 add_project_arguments(cflags, language: 'c')

--- a/meson.build
+++ b/meson.build
@@ -45,7 +45,6 @@ cflags = cc.get_supported_arguments(
 	'-Wincompatible-pointer-types',
 	'-Wformat=2',
 	'-Wmissing-declarations',
-	'-fvisibility=hidden',
 )
 add_project_arguments(cflags, language: 'c')
 
@@ -97,6 +96,7 @@ lib_libwacom = shared_library('wacom',
 				'-DDATADIR="@0@"'.format(dir_data),
 				'-DETCDIR="@0@"'.format(dir_etc),
 			      ],
+			      gnu_symbol_visibility: 'hidden',
 			      install: true)
 dep_libwacom = declare_dependency(link_with: lib_libwacom)
 

--- a/test/test-dbverify.c
+++ b/test/test-dbverify.c
@@ -135,7 +135,7 @@ test_database_size(void)
 }
 
 static int
-compare_databases(WacomDeviceDatabase *orig, WacomDeviceDatabase *new)
+compare_databases(WacomDeviceDatabase *new)
 {
 	int i, rc;
 	WacomDevice **devs_new, **n;
@@ -249,7 +249,7 @@ int main(int argc, char **argv)
 	g_assert(db_new);
 
 	db_old = db;
-	rc = compare_databases(db_old, db_new);
+	rc = compare_databases(db_new);
 	libwacom_database_destroy(db_new);
 	libwacom_database_destroy(db_old);
 


### PR DESCRIPTION
This also updates the `meson` github action to use `ninja --verbose` which will affect builds of `xf86-input-wacom` (since they just grab that from libwacom master).

The biggest change is: [CI: don't enable -Wall -Wextra in the CI](https://github.com/linuxwacom/libwacom/commit/3e4041b9ca556d4dabc145add4a631bc008a9fd2)

This is a leftover from autotools builds, meson uses the warning_level
option for this. The net result of our CFLAGS being appended was this
sequence: `-Wall -Wextra -Wno-foo -Wall -Wextra`

The second set of `-Wall -Wextra` undid all the `-Wno-foo` we carefully
selected in `meson.build` - at least with clang, possibly with gcc too.

cc @jigpu because it probably matters for https://github.com/linuxwacom/xf86-input-wacom/pull/254