### PR TITLE
Add XP Pen Deco mini7

### DIFF
--- a/data/xp-pen-deco-mini7.tablet
+++ b/data/xp-pen-deco-mini7.tablet
@@ -11,7 +11,7 @@ DeviceMatch=usb:28bd:0928:UGTABLET 6 inch PenTablet
 Class=Bamboo
 Width=7
 Height=4
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true

--- a/data/xp-pen-deco-mini7.tablet
+++ b/data/xp-pen-deco-mini7.tablet
@@ -1,0 +1,23 @@
+# XP-Pen
+# Deco mini7
+#
+# sysinfo.KmirkLjsqr.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/268
+
+[Device]
+Name=XP-Pen Deco mini7
+ModelName=
+DeviceMatch=usb:28bd:0928:UGTABLET 6 inch PenTablet
+Class=Bamboo
+Width=7
+Height=4
+Styli=0xffffd;
+
+[Features]
+Stylus=true
+Reversible=true
+Touch=false
+Buttons=8
+
+[Buttons]
+Left=A;B;C;D;E;F;G;H


### PR DESCRIPTION
Link to the tablet: https://www.xp-pen.com/product/613.html

This at least allows to enable left-handed mode.
It also has 8 pad buttons, but they are handled by the kernel as separate keyboard device.