### PR TITLE
CI: pin the meson version to 0.61.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: [ push, pull_request ]
 env:
   CFLAGS: "-Werror -Wno-error=missing-field-initializers"
   UBUNTU_PACKAGES: libgudev-1.0-dev libxml++2.6-dev valgrind tree python3-pip python3-setuptools libevdev2
-  PIP_PACKAGES: meson ninja libevdev pyudev pytest yq
+  PIP_PACKAGES: "meson==0.61.4 ninja libevdev pyudev pytest yq"
 
 jobs:
   build-and-dist:


### PR DESCRIPTION
0.62.0 fails meson dist with a python complaint, which has been fixed
upstream. But until pip pulls down a fixed version, let's pin meson.

See issue https://github.com/mesonbuild/meson/issues/10181