### PR TITLE
Add elan-2cf7 (HP Pavilion x360 Convertible 14-dy0xxx)

### DIFF
--- a/data/elan-2cf7.tablet
+++ b/data/elan-2cf7.tablet
@@ -2,8 +2,8 @@
 Name=ELAN 2CF7
 Class=ISDV4
 DeviceMatch=i2c:04F3:2CF7
-Width=12.1
-Height=6.8
+Width=12
+Height=7
 IntegratedIn=Display;System
 
 

--- a/data/elan-2cf7.tablet
+++ b/data/elan-2cf7.tablet
@@ -1,0 +1,13 @@
+[Device]
+Name=ELAN 2CF7
+Class=ISDV4
+DeviceMatch=i2c:04F3:2CF7
+Width=12.1
+Height=6.8
+IntegratedIn=Display;System
+
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
Link: https://github.com/linuxwacom/wacom-hid-descriptors/issues/223

This PR allows to display ELAN-2cf7 stylus from HP Pavilion x360 Convertible 14-dy0xxx on Gnome Shell Wacom Tablet setting.