### PR TITLE
Revert "CI: pin the meson version to 0.61.4"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: [ push, pull_request ]
 env:
   CFLAGS: "-Werror -Wno-error=missing-field-initializers"
   UBUNTU_PACKAGES: libgudev-1.0-dev libxml++2.6-dev valgrind tree python3-pip python3-setuptools libevdev2
-  PIP_PACKAGES: "meson==0.61.4 ninja libevdev pyudev pytest yq"
+  PIP_PACKAGES: meson ninja libevdev pyudev pytest yq
 
 jobs:
   build-and-dist:


### PR DESCRIPTION
pip now pulls down meson 0.62.1 with this issue fixed, so let's revert
this.

This reverts commit 7ff829e07622bb01daaad643f981d29e878a063a.


Reverts #489, meson bug in question: https://github.com/mesonbuild/meson/issues/10181