### PR TITLE
Add tablet file for 5155 version of Lenovo X380

### DIFF
--- a/data/isdv4-5155.tablet
+++ b/data/isdv4-5155.tablet
@@ -1,4 +1,7 @@
 # this is for the Wacom pen + touchscreen as found in some versions of the Lenovo ThinkPad X380 Yoga
+# 
+# sysinfo.k4zWHNsL8F.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/235
 
 [Device]
 Name=Wacom ISDv4 5155

--- a/data/isdv4-5155.tablet
+++ b/data/isdv4-5155.tablet
@@ -1,0 +1,16 @@
+# this is for the Wacom pen + touchscreen as found in some versions of the Lenovo ThinkPad X380 Yoga
+
+[Device]
+Name=Wacom ISDv4 5155
+ModelName=
+DeviceMatch=usb:056a:5155
+Class=ISDV4
+Width=12
+Height=7
+IntegratedIn=Display;System
+Styli=@isdv4-aes;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
I installed Fedora 36 on my Lenovo 20LHS04L00 ThinkPad X380 Yoga and noticed that whilst it seemed to (partially) work, it didn't show up in GNOME Wacom settings.
After a lot of looking around and googling I found these related links (issue and PR) implying that the laptop was supported.

https://github.com/linuxwacom/wacom-hid-descriptors/tree/master/Lenovo%20ThinkPad%20X380%20Yoga
https://github.com/linuxwacom/wacom-hid-descriptors/issues/38

However my device was not being picked up by:

```
$ libwacom-list-local-devices
/dev/input/event8 is a tablet but not supported by libwacom
Failed to find any devices known to libwacom.
```

`evtest` reported the following:

```
/dev/input/event7:	Wacom Pen and multitouch sensor Finger
/dev/input/event8:	Wacom Pen and multitouch sensor Pen
...
Input driver version is 1.0.1
Input device ID: bus 0x3 vendor 0x56a product 0x5155 version 0x111
Input device name: "Wacom Pen and multitouch sensor Pen"
```

So I edited the `DeviceMatch` string of `/usr/share/libwacom/isdv4-5150.tablet` from `usb:056a:5150` to `usb:056a:5155`, restarted my GNOME session and it showed up in GNOME config.

I then changed it back and followed the instructions to create a new .tablet file in /etc/libwacom and ran `libwacom-update-db /etc/libwacom` - things still seem to be working.

```
 $ libwacom-list-local-devices
devices:
- name: 'Wacom ISDv4 5155'
  bus: 'usb'
  vid: '0x056a'
  pid: '0x5155'
  nodes: 
  - /dev/input/event8
  - /dev/input/event7
```

Related HID descriptor issue here: https://github.com/linuxwacom/wacom-hid-descriptors/issues/235