### PR TITLE
tools: don't match "* Keyboard" devices

### DIFF
--- a/tools/65-libwacom.rules.in
+++ b/tools/65-libwacom.rules.in
@@ -3,9 +3,10 @@
 ACTION=="remove", GOTO="libwacom_end"
 KERNEL!="event[0-9]*", GOTO="libwacom_end"
 
-# HUION and GAOMON consumer and system control devices are not tablets.
+# HUION and GAOMON keyboard, consumer and system control devices are not tablets.
 ATTRS{name}=="* Consumer Control", GOTO="libwacom_end"
 ATTRS{name}=="* System Control", GOTO="libwacom_end"
+ATTRS{name}=="* Keyboard", GOTO="libwacom_end"
 
 # Match all serial wacom tablets with a serial ID starting with WACf
 ENV{ID_BUS}=="tty|pnp", ATTRS{id}=="WACf*", ENV{ID_INPUT}="1", ENV{ID_INPUT_TABLET}="1", GOTO="libwacom_end"


### PR DESCRIPTION
Just like the Consumer Control and other special names we already match,
the device's Keyboard node should not be a tablet we need to handle.

Extracted from #288 so we can track regressions for this separately.

cc @lucalandolfi