### PR TITLE
Add support for XP-Pen Artist 12

### DIFF
--- a/data/xp-pen-artist-12.tablet
+++ b/data/xp-pen-artist-12.tablet
@@ -1,0 +1,14 @@
+[Device]
+Name=XP-Pen Artist 12
+ModelName=
+DeviceMatch=usb:28bd:080a
+Class=Bamboo
+Width=10.09
+Height=5.676
+Styli=0xffffe;
+
+[Features]
+Stylus=true
+Reversible=true
+Touch=false
+Buttons=6


### PR DESCRIPTION
XP-Pen Artist 12 added to libwacom.

Working:
- Screen mapping / calibration
- Configuration through Gnome Settings window (Wacom)
- Stylus pressure sensitivity, button, and eraser
- Tablet buttons / scroll bar

Known issues:
- Inability to remap tablet buttons from their default values