### PR TITLE
Add support for XP-Pen Artist 12.

### DIFF
--- a/data/layouts/xp-pen-artist12.svg
+++ b/data/layouts/xp-pen-artist12.svg
@@ -1,0 +1,168 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg
+   id="xp-pen-artist12"
+   width="650.0"
+   height="400.0"
+   style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <rect
+       id="ButtonA"
+       class="A Button"
+       x="24.0"
+       y="139.0"
+       width="20.0"
+       height="12.0"
+       rx="0.5"
+       ry="0.5" />
+    <path
+       id="LeaderA"
+       class="A Leader"
+       d="m 46.0 145.0 h 5.0 V 96.0 h 20.0" />
+    <text
+       id="LabelA"
+       class="A Label"
+       x="73.0"
+       y="96.0"
+       style="text-anchor:start;">A</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonB"
+       class="B Button"
+       x="24.0"
+       y="152.0"
+       width="20.0"
+       height="12.0"
+       rx="0.5"
+       ry="0.5" />
+    <path
+       id="LeaderB"
+       class="B Leader"
+       d="M 46.0 158.0 H 56.0 V 122.0 H 71.0" />
+    <text
+       id="LabelB"
+       class="B Label"
+       x="73.0"
+       y="122.0"
+       style="text-anchor:start;">B</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonC"
+       class="C Button"
+       x="24.0"
+       y="165.0"
+       width="20.0"
+       height="12.0"
+       rx="0.5"
+       ry="0.5" />
+    <path
+       id="LeaderC"
+       class="C Leader"
+       d="M 46.0 171.0 l 15.0 0.0 l 0.0 -23.0 l 10.0 0.0" />
+    <text
+       id="LabelC"
+       class="C Label"
+       x="73.0"
+       y="148.0"
+       style="text-anchor:start;">C</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonD"
+       class="D Button"
+       x="24.0"
+       y="223.0"
+       width="20.0"
+       height="12.0"
+       rx="0.5"
+       ry="0.5" />
+    <path
+       id="LeaderD"
+       class="D Leader"
+       d="M 46.0 230.0 l 15.0 0.0 l 0.0 23.0 l 10.0 0.0" />
+    <text
+       id="LabelD"
+       class="D Label"
+       x="73.0"
+       y="252.0"
+       style="text-anchor:start;">D</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonE"
+       class="E Button"
+       x="24.0"
+       y="236.0"
+       width="20.0"
+       height="12.0"
+       rx="0.5"
+       ry="0.5" />
+    <path
+       id="LeaderE"
+       class="E Leader"
+       d="m 46.0 242.0 h 10.0 v 36.0 h 15.0" />
+    <text
+       id="LabelE"
+       class="E Label"
+       x="73.0"
+       y="278.0"
+       style="text-anchor:start;">E</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonF"
+       class="F Button"
+       x="24.0"
+       y="249.0"
+       width="20.0"
+       height="12.0"
+       rx="0.5"
+       ry="0.5" />
+    <path
+       id="LeaderF"
+       class="F Leader"
+       d="m 46.0 255.0 h 5.0 v 49.0 h 20.0" />
+    <text
+       id="LabelF"
+       class="F Label"
+       x="73.0"
+       y="304.0"
+       style="text-anchor:start;">F</text>
+  </g>
+  <g>
+    <rect
+       id="Strip"
+       class="Strip TouchStrip"
+       x="24.0"
+       y="177.0"
+       width="20.0"
+       height="46.0"
+       rx="1.5"
+       ry="1.0" />
+    <path
+       id="LeaderStripUp"
+       class="StripUp Strip Leader"
+       d="M 11.0 177.0 V 79.0 h 60.0" />
+    <path
+       id="LeaderStripDown"
+       class="StripDown Strip Leader"
+       d="m 11.0 223.0 v 98.0 h 60.0" />
+    <text
+       id="LabelStripUp"
+       class="StripUp Strip Label"
+       x="73.0"
+       y="79.0"
+       style="text-anchor:start;">Up</text>
+    <text
+       id="LabelStripDown"
+       class="StripDown Strip Label"
+       x="73.0"
+       y="321.0"
+       style="text-anchor:start;">Down</text>
+  </g>
+</svg>

--- a/data/xp-pen-artist12.tablet
+++ b/data/xp-pen-artist12.tablet
@@ -1,0 +1,29 @@
+# XP-Pen
+# Artist 12
+#
+
+[Device]
+Name=XP-Pen Artist 12
+ModelName=
+DeviceMatch=usb:28bd:80a:UGTABLET 11.6 inch PenDisplay Mouse;usb:28bd:80a:UGTABLET 11.6 inch PenDisplay;usb:28bd:80a:UGTABLET 11.6 inch PenDisplay;usb:28bd:80a:UGTABLET 11.6 inch PenDisplay Keyboard
+PairedIDs=
+Class=Bamboo
+Width=
+Height=
+IntegratedIn=
+Layout=xp-pen-artist12.svg
+Styli=0xffffe;0xfffff;
+
+[Features]
+Stylus=true
+Reversible=true
+Touch=false
+TouchSwitch=false
+Ring=false
+Ring2=false
+NumStrips=1
+Buttons=6
+
+[Buttons]
+Left=A;B;C;D;E;F
+EvdevCodes=0x100;0x101;0x102;0x103;0x104;0x105

--- a/data/xp-pen-artist12.tablet
+++ b/data/xp-pen-artist12.tablet
@@ -1,15 +1,17 @@
 # XP-Pen
 # Artist 12
 #
+# sysinfo.BPdqfy3fcP
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/238
 
 [Device]
 Name=XP-Pen Artist 12
 ModelName=
-DeviceMatch=usb:28bd:80a:UGTABLET 11.6 inch PenDisplay Mouse;usb:28bd:80a:UGTABLET 11.6 inch PenDisplay;usb:28bd:80a:UGTABLET 11.6 inch PenDisplay;usb:28bd:80a:UGTABLET 11.6 inch PenDisplay Keyboard
+DeviceMatch=usb:28bd:080a:UGTABLET 11.6 inch PenDisplay Mouse;usb:28bd:080a:UGTABLET 11.6 inch PenDisplay;usb:28bd:080a:UGTABLET 11.6 inch PenDisplay;usb:28bd:080a:UGTABLET 11.6 inch PenDisplay Keyboard
 PairedIDs=
 Class=Bamboo
-Width=
-Height=
+Width=10
+Height=6
 IntegratedIn=
 Layout=xp-pen-artist12.svg
 Styli=0xffffe;0xfffff;


### PR DESCRIPTION
Although my XP-Pen Artist 12 (mostly) worked under Arch Linux with Gnome 42, it didn't show up in gnome settings.

According to this issue https://gitlab.gnome.org/GNOME/mutter/-/issues/1272, the solution is to add the tablet's definition here.

Right now adding `xp-pen-artist12.tablet` and `layouts/xp-pen-artist12.tablet` to `/etc/libwacom`, running `libwacom-update-db /etc/libwacom` and re-plugging the device adds it to the gnome wacom settings, though the option to remap the keys is missing.

Since my attempts to fix this issue have been unsuccessful, I'm opening this PR in search of guidance.