### PR TITLE
Add Chuwi MiniBook X

### DIFF
--- a/data/chuwi-minibookx.tablet
+++ b/data/chuwi-minibookx.tablet
@@ -1,5 +1,6 @@
 # This is for the CHUWI MiniBook X
 #
+# sysinfo.CSujtSF02A
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/241
 
 [Device]

--- a/data/chuwi-minibookx.tablet
+++ b/data/chuwi-minibookx.tablet
@@ -5,7 +5,7 @@
 
 [Device]
 Name=Chuwi Minibook X
-Class=ISDV4-aes
+Class=ISDV4
 DeviceMatch=i2c:27C6:011A
 Width=23
 Height=14

--- a/data/chuwi-minibookx.tablet
+++ b/data/chuwi-minibookx.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=Chuwi Minibook X
 Class=ISDV4
-DeviceMatch=i2c:27C6:011A
+DeviceMatch=i2c:27c6:011a
 Width=9
 Height=6
 IntegratedIn=Display;System;

--- a/data/chuwi-minibookx.tablet
+++ b/data/chuwi-minibookx.tablet
@@ -1,0 +1,17 @@
+# This is for the CHUWI MiniBook X
+#
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/241
+
+[Device]
+Name=Chuwi Minibook X
+Class=ISDV4-aes
+DeviceMatch=i2c:27C6:011A
+Width=23
+Height=14
+IntegratedIn=Display;System;
+Styli=0x621
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0

--- a/data/chuwi-minibookx.tablet
+++ b/data/chuwi-minibookx.tablet
@@ -1,4 +1,5 @@
-# This is for the CHUWI MiniBook X
+# CHUWI
+# MiniBook X
 #
 # sysinfo.CSujtSF02A
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/241

--- a/data/chuwi-minibookx.tablet
+++ b/data/chuwi-minibookx.tablet
@@ -8,8 +8,8 @@
 Name=Chuwi Minibook X
 Class=ISDV4
 DeviceMatch=i2c:27C6:011A
-Width=23
-Height=14
+Width=9
+Height=6
 IntegratedIn=Display;System;
 Styli=0x621
 


### PR DESCRIPTION
Link: linuxwacom/wacom-hid-descriptors#241

This PR adds the configuration file necessary for the Chuwi MiniBook X' built-in touch panel to show up in the GNOME Settings Wacom panel.

One minor note; I have picked a Stylus ID that functionally matches the actual pen (Chuwi's H7 pen), but I am not sure if there is a more correct way of selecting this. With the more generic choices the configuration screens were showing two buttons, but the H7's secondary pen button only works as an eraser switch. Please let me know if there is another stylus I should pick, or if there is some kind of command I can run to help provide relevant information of this specific pen if that isn't already in the descriptors shared separately.

Thank you!