### PR TITLE
CI: update FreeBSD macos base to macos-12

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -8,7 +8,7 @@ jobs:
   # FreeBSD build job
   #
   freebsd:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v2
     - name: meson test

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: meson test
-      uses: vmactions/freebsd-vm@v0.1.7
+      uses: vmactions/freebsd-vm@v0
       with:
         prepare: |
           pkg install -y meson pkgconf evdev-proto libgudev libxml++ bash libevdev


### PR DESCRIPTION
The current 10.15 is about to be deprecated,
see https://github.com/vmactions/freebsd-vm/issues/50

Fixes #510 