### PR TITLE
Added the new isdv4-50a9.tablet file for the Fujitsu U729X.

### DIFF
--- a/data/isdv4-50a9.tablet
+++ b/data/isdv4-50a9.tablet
@@ -1,4 +1,6 @@
 # this is for the Wacom pen + touchscreen as found in the Fujitsu Lifebook U729X
+# sysinfo.Huuazdf011
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/245
 
 [Device]
 Name=Wacom Pen and multitouch sensor Pen

--- a/data/isdv4-50a9.tablet
+++ b/data/isdv4-50a9.tablet
@@ -1,0 +1,16 @@
+# this is for the Wacom pen + touchscreen as found in the Fujitsu Lifebook U729X
+
+[Device]
+Name=Wacom Pen and multitouch sensor Pen
+ModelName=
+DeviceMatch=usb:056a:50a9
+Class=ISDV4
+Width=11
+Height=6
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0
+


### PR DESCRIPTION
Hi,
Here is a pull request for adding the .tablet file for the Fujitsu U729X.  This one works with my U729X.  I'm not terribly versed in creating pull requests, or making .tablet files.  (This is only the second .tablet file for me.)  So please let me know what else you would like me to do.  This file seems to work just fine, but about all I've done is to submit the wacom-hid-descriptors, make sure the Gnome Settings works for calibrating the tablet and stylus, and verified that it is listed.  
`$ libwacom-list-local-devices
devices:
- name: 'Wacom Pen and multitouch sensor Pen'
  bus: 'usb'
  vid: '0x056a'
  pid: '0x50a9'
  nodes: 
  - /dev/input/event6
`
The name came from evtest.
`$ sudo evtest
No device specified, trying to scan all of /dev/input/event*
Available devices:
/dev/input/event0:	Power Button
/dev/input/event1:	Lid Switch
/dev/input/event2:	AT Translated Set 2 keyboard
/dev/input/event3:	ELAN0D03:00 04F3:30FC Mouse
/dev/input/event4:	ELAN0D03:00 04F3:30FC Touchpad
/dev/input/event5:	Wacom Pen and multitouch sensor Finger
/dev/input/event6:	Wacom Pen and multitouch sensor Pen
/dev/input/event7:	Fujitsu FUJ02E3
/dev/input/event8:	Intel Virtual Buttons
/dev/input/event9:	Intel Virtual Switches
/dev/input/event10:	FJ Camera: FJ Camera
/dev/input/event11:	Video Bus
/dev/input/event12:	HDA Intel PCH Headphone
/dev/input/event13:	HDA Intel PCH HDMI/DP,pcm=3
/dev/input/event14:	HDA Intel PCH HDMI/DP,pcm=7
/dev/input/event15:	HDA Intel PCH HDMI/DP,pcm=8
/dev/input/event16:	HDA Intel PCH HDMI/DP,pcm=9
/dev/input/event17:	HDA Intel PCH HDMI/DP,pcm=10
Select the device event number [0-17]: 6
Input driver version is 1.0.1
Input device ID: bus 0x3 vendor 0x56a product 0x50a9 version 0x111
Input device name: "Wacom Pen and multitouch sensor Pen"
Supported events:
  Event type 0 (EV_SYN)
  Event type 1 (EV_KEY)
    Event code 320 (BTN_TOOL_PEN)
    Event code 321 (BTN_TOOL_RUBBER)
    Event code 330 (BTN_TOUCH)
    Event code 331 (BTN_STYLUS)
    Event code 332 (BTN_STYLUS2)
  Event type 3 (EV_ABS)
    Event code 0 (ABS_X)
      Value      0
      Min        0
      Max    27648
      Fuzz       4
      Resolution     100
    Event code 1 (ABS_Y)
      Value      0
      Min        0
      Max    15552
      Fuzz       4
      Resolution     100
    Event code 24 (ABS_PRESSURE)
      Value      0
      Min        0
      Max     2047
    Event code 40 (ABS_MISC)
      Value      0
      Min        0
      Max      255
  Event type 4 (EV_MSC)
    Event code 0 (MSC_SERIAL)
Properties:
  Property type 1 (INPUT_PROP_DIRECT)
Testing ... (interrupt to exit)
` 
I measured the size of the touchscreen, and there are no buttons on the screen.  (There are two on the stylus though, but the description seemed to indicate the buttons were to be on the tablet part.)
Hope this helps!
Rob