### PR TITLE
data: Added support for "Cintiq Pro 27"

### DIFF
--- a/data/cintiq-13hd.tablet
+++ b/data/cintiq-13hd.tablet
@@ -29,7 +29,7 @@ DeviceMatch=usb:056a:0304
 Width=12
 Height=7
 Layout=cintiq-13hd.svg
-Styli=@intuos5;@intuos4;
+Styli=@intuos5;@intuos4;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-13hdt.tablet
+++ b/data/cintiq-13hdt.tablet
@@ -31,7 +31,7 @@ PairedID=usb:056a:0335
 Width=12
 Height=7
 Layout=cintiq-13hd.svg
-Styli=@intuos5;@intuos4;
+Styli=@intuos5;@intuos4;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-16-2.tablet
+++ b/data/cintiq-16-2.tablet
@@ -10,7 +10,7 @@ DeviceMatch=usb:056a:03ae
 Width=14
 Height=8
 # No pad buttons, so no layout
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-16.tablet
+++ b/data/cintiq-16.tablet
@@ -10,7 +10,7 @@ DeviceMatch=usb:056a:0390
 Width=14
 Height=8
 # No pad buttons, so no layout
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-21ux2.tablet
+++ b/data/cintiq-21ux2.tablet
@@ -50,7 +50,7 @@ Class=Cintiq
 Width=17
 Height=13
 Layout=cintiq-21ux2.svg
-Styli=@intuos5;@intuos4;
+Styli=@intuos5;@intuos4;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-22.tablet
+++ b/data/cintiq-22.tablet
@@ -10,7 +10,7 @@ DeviceMatch=usb:056a:0391
 Width=19
 Height=10
 # No pad buttons, so no layout
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-22hd.tablet
+++ b/data/cintiq-22hd.tablet
@@ -38,7 +38,7 @@ Class=Cintiq
 Width=19
 Height=11
 Layout=cintiq-22hd.svg
-Styli=@intuos5;@intuos4;
+Styli=@intuos5;@intuos4;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-22hdt.tablet
+++ b/data/cintiq-22hdt.tablet
@@ -40,7 +40,7 @@ Class=Cintiq
 Width=19
 Height=11
 Layout=cintiq-22hd.svg
-Styli=@intuos5;@intuos4;
+Styli=@intuos5;@intuos4;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-24hd-touch.tablet
+++ b/data/cintiq-24hd-touch.tablet
@@ -48,7 +48,7 @@ Class=Cintiq
 Width=21
 Height=13
 Layout=cintiq-24hd.svg
-Styli=@intuos5;@intuos4;
+Styli=@intuos5;@intuos4;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-24hd.tablet
+++ b/data/cintiq-24hd.tablet
@@ -46,7 +46,7 @@ Class=Cintiq
 Width=21
 Height=13
 Layout=cintiq-24hd.svg
-Styli=@intuos5;@intuos4;
+Styli=@intuos5;@intuos4;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-27hd.tablet
+++ b/data/cintiq-27hd.tablet
@@ -10,7 +10,7 @@ DeviceMatch=usb:056a:032a
 Class=Cintiq
 Width=24
 Height=12
-Styli=@intuos5;
+Styli=@intuos5;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-27hdt.tablet
+++ b/data/cintiq-27hdt.tablet
@@ -12,7 +12,7 @@ PairedID=usb:056a:032c
 Class=Cintiq
 Width=24
 Height=12
-Styli=@intuos5;
+Styli=@intuos5;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-companion-2.tablet
+++ b/data/cintiq-companion-2.tablet
@@ -35,7 +35,7 @@ PairedID=usb:056a:0326
 Width=12
 Height=7
 Layout=cintiq-companion-2.svg
-Styli=@intuos5;@intuos4;
+Styli=@intuos5;@intuos4;@propengen2;
 IntegratedIn=Display;System
 
 [Features]

--- a/data/cintiq-companion-hybrid.tablet
+++ b/data/cintiq-companion-hybrid.tablet
@@ -33,7 +33,7 @@ PairedID=usb:056a:0309
 Width=12
 Height=7
 Layout=cintiq-companion-hybrid.svg
-Styli=@intuos5;@intuos4;
+Styli=@intuos5;@intuos4;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-companion.tablet
+++ b/data/cintiq-companion.tablet
@@ -33,7 +33,7 @@ PairedID=usb:056a:030c
 Width=12
 Height=7
 Layout=cintiq-companion.svg
-Styli=@intuos5;@intuos4;
+Styli=@intuos5;@intuos4;@propengen2;
 IntegratedIn=Display;System
 
 [Features]

--- a/data/cintiq-pro-13.tablet
+++ b/data/cintiq-pro-13.tablet
@@ -35,7 +35,7 @@ PairedID=usb:056a:0353
 Width=12
 Height=7
 # No pad buttons, so no layout
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-pro-16.tablet
+++ b/data/cintiq-pro-16.tablet
@@ -35,7 +35,7 @@ PairedID=usb:056a:0354
 Width=14
 Height=8
 # No pad buttons, so no layout
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-pro-24-p.tablet
+++ b/data/cintiq-pro-24-p.tablet
@@ -34,7 +34,7 @@ DeviceMatch=usb:056a:037c
 Width=20
 Height=12
 # No pad buttons, so no layout
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-pro-24-pt.tablet
+++ b/data/cintiq-pro-24-pt.tablet
@@ -35,7 +35,7 @@ PairedID=usb:056a:0355
 Width=20
 Height=12
 # No pad buttons, so no layout
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-pro-27.tablet
+++ b/data/cintiq-pro-27.tablet
@@ -1,6 +1,6 @@
 # Wacom
-# Cintiq Pro 16
-# DTH167
+# Cintiq Pro 27
+# DTH-271
 #
 # Button Map:
 # (A=1, B=2, C=3, ...)
@@ -24,15 +24,14 @@
 #
 
 [Device]
-Name=Wacom Cintiq Pro 16
-ModelName=DTH167
+Name=Wacom Cintiq Pro 27
+ModelName=DTH-271
 Class=Cintiq
-DeviceMatch=usb:056a:03b2
-PairedID=usb:056a:03b3
-Width=14
-Height=8
-Layout=cintiq-pro-16-2.svg
-Styli=@intuos5;@mobilestudio;@propengen2;
+DeviceMatch=usb:056a:03c0
+Width=24
+Height=13
+Layout=cintiq-pro-27.svg
+Styli=@cintiqpro2022;@mobilestudio;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/cintiq-pro-27.tablet
+++ b/data/cintiq-pro-27.tablet
@@ -22,6 +22,8 @@
 # NOTE: Buttons are on the back side of the device rather
 # than on the top bezel.
 #
+# sysinfo.rLRz2hqrEy
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/260#issue-1391416660
 
 [Device]
 Name=Wacom Cintiq Pro 27

--- a/data/cintiq-pro-32.tablet
+++ b/data/cintiq-pro-32.tablet
@@ -35,7 +35,7 @@ PairedID=usb:056a:0356
 Width=27
 Height=15
 # No pad buttons, so no layout
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/dtk-1660e-2.tablet
+++ b/data/dtk-1660e-2.tablet
@@ -9,7 +9,7 @@ DeviceMatch=usb:056a:03b0
 Width=14
 Height=8
 # No pad buttons, so no layout
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/dtk-1660e.tablet
+++ b/data/dtk-1660e.tablet
@@ -9,7 +9,7 @@ DeviceMatch=usb:056a:0396
 Width=14
 Height=8
 # No pad buttons, so no layout
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/intuos-pro-2-l.tablet
+++ b/data/intuos-pro-2-l.tablet
@@ -51,7 +51,7 @@ Width=12
 Height=8
 Layout=intuos-pro-2-l.svg
 IntegratedIn=
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 
 [Features]
 Stylus=true

--- a/data/intuos-pro-2-m.tablet
+++ b/data/intuos-pro-2-m.tablet
@@ -51,7 +51,7 @@ Width=9
 Height=6
 Layout=intuos-pro-2-m.svg
 IntegratedIn=
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 
 [Features]
 Stylus=true

--- a/data/intuos-pro-2-s.tablet
+++ b/data/intuos-pro-2-s.tablet
@@ -32,13 +32,13 @@
 [Device]
 Name=Wacom Intuos Pro S
 ModelName=PTH-460
-DeviceMatch=usb:056a:0392;bluetooth:056a:0393;usb:056a:03dc;bluetooth:056a:03dd;
+DeviceMatch=usb:056a:0392;bluetooth:056a:0393;
 Class=Intuos5
 Width=6
 Height=4
 Layout=intuos-pro-2-s.svg
 IntegratedIn=
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 
 [Features]
 Stylus=true

--- a/data/intuos-pro-2-s.tablet
+++ b/data/intuos-pro-2-s.tablet
@@ -32,7 +32,7 @@
 [Device]
 Name=Wacom Intuos Pro S
 ModelName=PTH-460
-DeviceMatch=usb:056a:0392;bluetooth:056a:0393;
+DeviceMatch=usb:056a:0392;bluetooth:056a:0393;usb:056a:03dc;bluetooth:056a:03dd;
 Class=Intuos5
 Width=6
 Height=4

--- a/data/intuos-pro-l.tablet
+++ b/data/intuos-pro-l.tablet
@@ -51,7 +51,7 @@ Width=13
 Height=8
 Layout=intuos-pro-l.svg
 IntegratedIn=
-Styli=@intuos4-lens;@intuos4-puck;@intuos5;@intuos4;
+Styli=@intuos4-lens;@intuos4-puck;@intuos5;@intuos4;@propengen2;
 
 [Features]
 Stylus=true

--- a/data/intuos-pro-m.tablet
+++ b/data/intuos-pro-m.tablet
@@ -51,7 +51,7 @@ Width=9
 Height=6
 Layout=intuos-pro-m.svg
 IntegratedIn=
-Styli=@intuos4-puck;@intuos5;@intuos4;
+Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 
 [Features]
 Stylus=true

--- a/data/intuos-pro-s.tablet
+++ b/data/intuos-pro-s.tablet
@@ -49,7 +49,7 @@ Width=6
 Height=4
 Layout=intuos-pro-s.svg
 IntegratedIn=
-Styli=@intuos4-puck;@intuos5;@intuos4;
+Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 
 [Features]
 Stylus=true

--- a/data/intuos4-12x19.tablet
+++ b/data/intuos4-12x19.tablet
@@ -41,7 +41,7 @@ Width=19
 Height=12
 Layout=intuos4-12x19.svg
 IntegratedIn=
-Styli=@intuos4-lens;@intuos4-puck;@intuos5;@intuos4;
+Styli=@intuos4-lens;@intuos4-puck;@intuos5;@intuos4;@propengen2;
 
 [Features]
 Reversible=true

--- a/data/intuos4-4x6.tablet
+++ b/data/intuos4-4x6.tablet
@@ -42,7 +42,7 @@ Width=6
 Height=4
 Layout=intuos4-4x6.svg
 IntegratedIn=
-Styli=@intuos4-puck;@intuos5;@intuos4;
+Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 
 [Features]
 Reversible=true

--- a/data/intuos4-6x9-wl.tablet
+++ b/data/intuos4-6x9-wl.tablet
@@ -41,7 +41,7 @@ Width=8
 Height=5
 IntegratedIn=
 Layout=intuos4-6x9-wl.svg
-Styli=@intuos4-puck;@intuos5;@intuos4;
+Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 
 [Features]
 Reversible=true

--- a/data/intuos4-6x9.tablet
+++ b/data/intuos4-6x9.tablet
@@ -41,7 +41,7 @@ Width=9
 Height=6
 Layout=intuos4-6x9.svg
 IntegratedIn=
-Styli=@intuos4-puck;@intuos5;@intuos4;
+Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 
 [Features]
 Reversible=true

--- a/data/intuos4-8x13.tablet
+++ b/data/intuos4-8x13.tablet
@@ -41,7 +41,7 @@ Width=13
 Height=8
 Layout=intuos4-8x13.svg
 IntegratedIn=
-Styli=@intuos4-puck;@intuos5;@intuos4;
+Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 
 [Features]
 Reversible=true

--- a/data/intuos5-m.tablet
+++ b/data/intuos5-m.tablet
@@ -51,7 +51,7 @@ Width=9
 Height=6
 Layout=intuos5-m.svg
 IntegratedIn=
-Styli=@intuos4-puck;@intuos5;@intuos4;
+Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 
 [Features]
 Stylus=true

--- a/data/intuos5-s.tablet
+++ b/data/intuos5-s.tablet
@@ -49,7 +49,7 @@ Width=6
 Height=4
 Layout=intuos5-s.svg
 IntegratedIn=
-Styli=@intuos4-puck;@intuos5;@intuos4;
+Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 
 [Features]
 Stylus=true

--- a/data/intuos5-touch-l.tablet
+++ b/data/intuos5-touch-l.tablet
@@ -51,7 +51,7 @@ Width=13
 Height=8
 Layout=intuos5-l.svg
 IntegratedIn=
-Styli=@intuos4-lens;@intuos4-puck;@intuos5;@intuos4;
+Styli=@intuos4-lens;@intuos4-puck;@intuos5;@intuos4;@propengen2;
 
 [Features]
 Stylus=true

--- a/data/intuos5-touch-m.tablet
+++ b/data/intuos5-touch-m.tablet
@@ -51,7 +51,7 @@ Width=9
 Height=6
 Layout=intuos5-m.svg
 IntegratedIn=
-Styli=@intuos4-puck;@intuos5;@intuos4;
+Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 
 [Features]
 Stylus=true

--- a/data/intuos5-touch-s.tablet
+++ b/data/intuos5-touch-s.tablet
@@ -49,7 +49,7 @@ Width=6
 Height=4
 Layout=intuos5-s.svg
 IntegratedIn=
-Styli=@intuos4-puck;@intuos5;@intuos4;
+Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 
 [Features]
 Stylus=true

--- a/data/layouts/cintiq-pro-27.svg
+++ b/data/layouts/cintiq-pro-27.svg
@@ -1,0 +1,181 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
+   id="cintiq-pro-27"
+   width="410"
+   height="264">
+  <title
+     id="title">Wacom Cintiq Pro 27</title>
+  <g>
+    <rect
+       id="ButtonA"
+       class="A Button"
+       rx=".5"
+       ry=".5"
+       x="1"
+       y="40"
+       width="15"
+       height="5" />
+    <path
+       id="LeaderA"
+       class="A Leader"
+       d="M 20 42 L 40 42" />
+    <text
+       id="LabelA"
+       class="A Label"
+       x="45"
+       y="42"
+       style="text-anchor:start;">A</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonB"
+       class="B Button"
+       rx=".5"
+       ry=".5"
+       x="1"
+       y="55"
+       width="15"
+       height="5" />
+    <path
+       id="LeaderB"
+       class="B Leader"
+       d="M 20 57 L 40 57" />
+    <text
+       id="LabelB"
+       class="B Label"
+       x="45"
+       y="57"
+       style="text-anchor:start;">B</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonC"
+       class="C Button"
+       rx=".5"
+       ry=".5"
+       x="1"
+       y="70"
+       width="15"
+       height="5" />
+    <path
+       id="LeaderC"
+       class="C Leader"
+       d="M 20 72 L 40 72" />
+    <text
+       id="LabelC"
+       class="C Label"
+       x="45"
+       y="72"
+       style="text-anchor:start;">C</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonD"
+       class="D Button"
+       rx=".5"
+       ry=".5"
+       x="1"
+       y="85"
+       width="15"
+       height="5" />
+    <path
+       id="LeaderD"
+       class="D Leader"
+       d="M 20 87 L 40 87" />
+    <text
+       id="LabelD"
+       class="D Label"
+       x="45"
+       y="87"
+       style="text-anchor:start;">D</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonE"
+       class="E Button"
+       rx=".5"
+       ry=".5"
+       x="394"
+       y="40"
+       width="15"
+       height="5" />
+    <path
+       id="LeaderE"
+       class="E Leader"
+       d="M 380 42 L 360 42" />
+    <text
+       id="LabelE"
+       class="E Label"
+       x="355"
+       y="42"
+       style="text-anchor:end;">E</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonF"
+       class="F Button"
+       rx=".5"
+       ry=".5"
+       x="394"
+       y="55"
+       width="15"
+       height="5" />
+    <path
+       id="LeaderF"
+       class="F Leader"
+       d="M 380 57 L 360 57" />
+    <text
+       id="LabelF"
+       class="F Label"
+       x="355"
+       y="57"
+       style="text-anchor:end;">F</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonG"
+       class="G Button"
+       rx=".5"
+       ry=".5"
+       x="394"
+       y="70"
+       width="15"
+       height="5" />
+    <path
+       id="LeaderG"
+       class="G Leader"
+       d="M 380 72 L 360 72" />
+    <text
+       id="LabelG"
+       class="G Label"
+       x="355"
+       y="72"
+       style="text-anchor:end;">G</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonH"
+       class="H Button"
+       rx=".5"
+       ry=".5"
+       x="394"
+       y="85"
+       width="15"
+       height="5" />
+    <path
+       id="LeaderH"
+       class="H Leader"
+       d="M 380 87 L 360 87" />
+    <text
+       id="LabelH"
+       class="H Label"
+       x="355"
+       y="87"
+       style="text-anchor:end;">H</text>
+  </g>
+</svg>

--- a/data/libwacom.stylus
+++ b/data/libwacom.stylus
@@ -299,7 +299,7 @@ Buttons=3
 Axes=Tilt;Pressure;Distance;
 Type=General
 
-[0x04200]
+[0x40200]
 # Cintiq Pro 2022
 Name=Pro Pen 3
 Group=cintiqpro2022

--- a/data/libwacom.stylus
+++ b/data/libwacom.stylus
@@ -291,6 +291,22 @@ Buttons=2
 Axes=Tilt;Pressure;Distance;
 Type=General
 
+[0x200]
+# Cintiq Pro 2022
+Name=Pro Pen 3
+Group=cintiqpro2022
+Buttons=3
+Axes=Tilt;Pressure;Distance;
+Type=General
+
+[0x04200]
+# Cintiq Pro 2022
+Name=Pro Pen 3
+Group=cintiqpro2022
+Buttons=3
+Axes=Tilt;Pressure;Distance;
+Type=General
+
 [0x80842]
 # MobileStudio Pro
 Name=Pro Pen 3D
@@ -355,7 +371,7 @@ Type=Marker
 [0x100804]
 # Intuos4, 5 and Cintiq 21UX2, 22HD, 24HD
 Name=Art Pen
-Group=intuos5
+Group=propengen2
 PairedStylusIds=0x10080c;
 Buttons=2
 Axes=Tilt;Pressure;Distance;RotationZ;
@@ -364,7 +380,7 @@ Type=Marker
 [0x100802]
 # Intuos4, 5 and Cintiq 21UX2, 24HD
 Name=Grip Pen
-Group=intuos5
+Group=propengen2
 PairedStylusIds=0x10080a;
 Buttons=2
 Axes=Tilt;Pressure;Distance;
@@ -390,7 +406,7 @@ Type=Classic
 [0x140802]
 # Intuos4, 5 and Cintiq 21UX2, 24HD
 Name=Classic Pen
-Group=intuos5
+Group=propengen2
 PairedStylusIds=0x14080a;
 Buttons=2
 Axes=Tilt;Pressure;Distance;
@@ -399,7 +415,7 @@ Type=Classic
 [0x160802]
 # Cintiq 13HD Pro Pen
 Name=Pro Pen
-Group=intuos5
+Group=propengen2
 PairedStylusIds=0x16080a;
 Buttons=2
 Axes=Tilt;Pressure;Distance;
@@ -536,7 +552,7 @@ Type=Classic
 [0x14080a]
 # Intuos4, 5 and Cintiq 21UX2, 24HD
 Name=Classic Pen Eraser
-Group=intuos5
+Group=propengen2
 PairedStylusIds=0x140802;
 EraserType=Invert
 Buttons=2
@@ -546,7 +562,7 @@ Type=Classic
 [0x10080c]
 # Intuos4, 5 and 13HD, 24HD Art Pen
 Name=Art Pen Eraser
-Group=intuos5
+Group=propengen2
 PairedStylusIds=0x100804;
 EraserType=Invert
 Buttons=2
@@ -556,7 +572,7 @@ Type=Marker
 [0x10080a]
 # Intuos4, 5 and Cintiq 21UX2, 24HD
 Name=Grip Pen Eraser
-Group=intuos5
+Group=propengen2
 PairedStylusIds=0x100802;
 EraserType=Invert
 Buttons=2
@@ -576,7 +592,7 @@ Type=General
 [0x16080a]
 # Cintiq 13HD
 Name=Pro Pen Eraser
-Group=intuos5
+Group=propengen2
 PairedStylusIds=0x160802;
 EraserType=Invert
 Buttons=2

--- a/data/mobilestudio-pro-13-2.tablet
+++ b/data/mobilestudio-pro-13-2.tablet
@@ -42,7 +42,7 @@ PairedID=usb:056a:039a
 Width=12
 Height=7
 Layout=mobilestudio-pro-13.svg
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 IntegratedIn=Display;System
 
 [Features]

--- a/data/mobilestudio-pro-13.tablet
+++ b/data/mobilestudio-pro-13.tablet
@@ -42,7 +42,7 @@ PairedID=usb:056a:034a
 Width=12
 Height=7
 Layout=mobilestudio-pro-13.svg
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 IntegratedIn=Display;System
 
 [Features]

--- a/data/mobilestudio-pro-16-2.tablet
+++ b/data/mobilestudio-pro-16-2.tablet
@@ -44,7 +44,7 @@ PairedID=usb:056a:039b
 Width=14
 Height=8
 Layout=mobilestudio-pro-16.svg
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 IntegratedIn=Display;System
 
 [Features]

--- a/data/mobilestudio-pro-16-3.tablet
+++ b/data/mobilestudio-pro-16-3.tablet
@@ -44,7 +44,7 @@ PairedID=usb:056a:03ac
 Width=14
 Height=8
 Layout=mobilestudio-pro-16.svg
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 IntegratedIn=Display;System
 
 [Features]

--- a/data/mobilestudio-pro-16.tablet
+++ b/data/mobilestudio-pro-16.tablet
@@ -44,7 +44,7 @@ PairedID=usb:056a:034b
 Width=14
 Height=8
 Layout=mobilestudio-pro-16.svg
-Styli=@intuos5;@mobilestudio;
+Styli=@intuos5;@mobilestudio;@propengen2;
 IntegratedIn=Display;System
 
 [Features]


### PR DESCRIPTION
To fix issues with pen compatibility on the new tablet with current libwacom.stylus groups the intuos5 group had certain pens split off into a new group called propengen2. All .tablet files affected by this change were updated to include this new group.

Signed-off-by: Joshua Dickens <joshua.dickens@wacom.com>