### PR TITLE
Add Kamva Pro 12 

### DIFF
--- a/data/kamvas-pro-13.tablet
+++ b/data/kamvas-pro-13.tablet
@@ -1,6 +1,6 @@
 # Huion
-# Kamvas Pro 13
-# GT-133
+# Kamvas Pro 12/13
+# GT-116/GT-133
 #
 # sysinfo.6ktY6Uln9z.tar.gz
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/160
@@ -19,9 +19,20 @@
 #    E     |                       |
 #          *-----------------------*
 #
-# Touch Strip Map:
+# Kamva Pro 13? Touch Strip Map:
 # NOTE: not enabled because i couldnt get it to work
 # evtest reports 0x108 (BTN_8), 0x109 (BTN_9), 0x130 (BTN_SOUTH)
+#
+#    *-----------------------*
+#    |                       |
+#  A |                       |
+#  a |        DISPLAY        |
+#    |                       |
+#    *-----------------------*
+#
+# Kamva Pro 12 Tablet Monitor Touch Strip:
+# NOTE: It does not work also in the Pro 12
+# evtest reports the touch strip as a ABS_WHEEL with code 8 and reports ABS_MISC with code 40
 #
 #    *-----------------------*
 #    |                       |
@@ -35,10 +46,10 @@
 # there is nothing we can do about this.
 
 [Device]
-Name=Huion Kamvas Pro 13
-ModelName=GT-133
+Name=Huion Kamvas Pro 12/13
+ModelName=GT-116/GT-133
 Class=Cintiq
-DeviceMatch=usb:256c:006e:Tablet Monitor Pen;usb:256c:006e:Tablet Monitor Pad;
+DeviceMatch=usb:256c:006e:Tablet Monitor Pen;usb:256c:006e:Tablet Monitor Pad;usb:256c:006e:Tablet Monitor
 Width=12
 Height=7
 Layout=kamvas-pro-13.svg
@@ -51,6 +62,8 @@ Reversible=false
 Touch=false
 Ring=false
 Buttons=5
+# Does not work
+NumStrips=1
 
 [Buttons]
 Left=A;B;C;D;E


### PR DESCRIPTION
This `.tablet` file works with the Kamva Pro 12, not shure about the Pro 13.
Also the vertical strip isnt working, but `evtest` and `libinput record` report ABS_WHEEL events not buttons.