### PR TITLE
Add tablet definition for Wacom HID 52FA Pen

### DIFF
--- a/data/wacom-hid-52fa-pen.tablet
+++ b/data/wacom-hid-52fa-pen.tablet
@@ -1,0 +1,20 @@
+# Wacom
+# Wacom HID 52FA Pen
+# WACF2200
+
+[Device]
+Name=Wacom HID 52FA Pen
+ModelName=WACF2200
+Class=ISDV4
+DeviceMatch=i2c:056a:52fa;
+# Width=11
+# Height=6
+# No pad buttons, so no layout
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Reversible=false
+Touch=true
+Ring=false
+Buttons=0

--- a/data/wacom-hid-52fa-pen.tablet
+++ b/data/wacom-hid-52fa-pen.tablet
@@ -1,6 +1,9 @@
 # Wacom
 # Wacom HID 52FA Pen
 # WACF2200
+#
+# sysinfo.VBqR9LHvjY
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/275
 
 [Device]
 Name=Wacom HID 52FA Pen


### PR DESCRIPTION
This PR adds a tablet file for the device identified as the "Wacom HID 52FA Pen" (and elsewhere as WACF2200 ). 

I have this device built into my Lenovo Yoga 6 13ALC7, see the matching [issue` at the wacom-hid-descriptors](https://github.com/linuxwacom/wacom-hid-descriptors/issues/275) repository.  

This file makes the device visible to the Gnome Wacom settings dialog - I'm running a pure Wayland system and I don't actually have a compatible stylus to hand, so I can't make any further guarantees than that, but this seems like as much as would be expected from this change.  