### PR TITLE
Fix Huion New 1060 Plus

### DIFF
--- a/data/huion-new-1060-plus.tablet
+++ b/data/huion-new-1060-plus.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Huion New 1060 Plus
 ModelName=
-DeviceMatch=usb:256c:006e:HID 256c:006e Pen;usb:256c:006e:HID 256c:006e Pad
+DeviceMatch=usb:256c:006e:HID 256c:006e;usb:256c:006e:HID 256c:006e Pad
 Class=Bamboo
 Width=10
 Height=6


### PR DESCRIPTION
Apparently the "Pen" string has changed. 

I'm sure this happened quite a while ago but I can't pinpoint it.

Before commit (tablet not shown in GNOME Settings):
```
/dev/input/event29 is a tablet but not supported by libwacom
/dev/input/event28 is a tablet but not supported by libwacom
/dev/input/event26 is a tablet but not supported by libwacom
devices:
- name: 'Huion New 1060 Plus'
  bus: 'usb'
  vid: '0x256c'
  pid: '0x006e'
  nodes: 
  - /dev/input/event27
```

After commit (tablet shown in GNOME Settings):
```
/dev/input/event29 is a tablet but not supported by libwacom
/dev/input/event28 is a tablet but not supported by libwacom
devices:
- name: 'Huion New 1060 Plus'
  bus: 'usb'
  vid: '0x256c'
  pid: '0x006e'
  nodes: 
  - /dev/input/event27
- name: 'Huion New 1060 Plus'
  bus: 'usb'
  vid: '0x256c'
  pid: '0x006e'
  nodes: 
  - /dev/input/event26
```