### PR TITLE
tests: fix failure if system doesn't use systemd

### DIFF
--- a/test/test_udev_rules.py
+++ b/test/test_udev_rules.py
@@ -23,8 +23,13 @@ import sys
 def systemd_reload():
     '''Make sure our hwdb and udev rules are up-to-date'''
     import subprocess
-    subprocess.run(['systemd-hwdb', 'update'])
-    subprocess.run(['systemctl', 'daemon-reload'])
+    try:
+        subprocess.run(['systemd-hwdb', 'update'])
+        subprocess.run(['systemctl', 'daemon-reload'])
+    except FileNotFoundError:
+        # If any of the commands above are not found (most likely the system
+        # simply does not use systemd), just skip.
+        raise pytest.skip()
 
 
 def pytest_generate_tests(metafunc):


### PR DESCRIPTION
Fixes https://github.com/linuxwacom/libwacom/issues/515.

Edit: the CI failure seems to be an unrelated issue.