### PR TITLE
Add HP Envy x360 Convertible 13-ar0xxx

### DIFF
--- a/data/elan-2514.tablet
+++ b/data/elan-2514.tablet
@@ -42,7 +42,7 @@
 [Device]
 Name=ELAN 2514
 ModelName=
-DeviceMatch=i2c:04f3:29f5;i2c:04f3:2af4;i2c:04f3:2813;i2c:04f3:2817;i2c:04f3:2b0a;i2c:04f3:23f3;i2c:04f3:2718;i2c:04f3:2beb
+DeviceMatch=i2c:04f3:29f5;i2c:04f3:2af4;i2c:04f3:2813;i2c:04f3:2817;i2c:04f3:2b0a;i2c:04f3:23f3;i2c:04f3:2718;i2c:04f3:2beb;i2c:04f3:23b9
 Class=ISDV4
 Width=12
 Height=7


### PR DESCRIPTION
Sysinfo: https://github.com/linuxwacom/wacom-hid-descriptors/issues/294

Tried adding the ID ```04f3:23b9``` to the tablet files in ```/usr/share/libwacom```  , KDE Plasma can recognize the screen and stylus (with HP Tilt Pen) . Screen touch, pressure sensetivity and stylus button are work.

The stylus button remap only works under X11, and the system warns the screen "is going to run out of battery".