### PR TITLE
Add support for Lenovo Ideapad Duet 5i (isdv4-121a.tablet)

### DIFF
--- a/data/isdv4-121a.tablet
+++ b/data/isdv4-121a.tablet
@@ -1,0 +1,22 @@
+# IdeaPad Duet 5 12IAU7
+# Sensor Type: AES
+# Features: Touch (Integrated), Tilt, Pressure
+#
+# Manually generated
+# Sysinfo: sysinfo.vcgNVDx9C0
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/278#issue-1509517203
+
+[Device]
+Name=ISDv4 121a
+ModelName=
+DeviceMatch=i2c:4858:121a
+Class=ISDV4
+Width=10
+Height=6
+IntegratedIn=Display;System
+Styli=@isdv4-aes;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
I've added support for the Lenovo Ideapad Duet 5i (Ideapad Duet 5 12IAU7).

Sysinfo issue: https://github.com/linuxwacom/wacom-hid-descriptors/issues/278.

Thanks for maintaining this project!