### PR TITLE
tools: add list-local-devices as builddir tool

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -136,13 +136,21 @@ endif
 
 ############### tools ###########################
 
+tools_cflags = ['-DDATABASEPATH="@0@"'.format(dir_src_data)]
+
 executable('libwacom-list-local-devices',
 	   'tools/list-local-devices.c',
 	   dependencies: [dep_libwacom, dep_glib, dep_gudev],
 	   include_directories: [includes_src],
 	   install: true)
 
-tools_cflags = ['-DDATABASEPATH="@0@"'.format(dir_src_data)]
+# The non-installed version of list-local-devices uses the git tree's data files
+executable('list-local-devices',
+	   'tools/list-local-devices.c',
+	   dependencies: [dep_libwacom, dep_glib, dep_gudev],
+	   include_directories: [includes_src],
+	   c_args: tools_cflags,
+	   install: false)
 
 updatedb = configure_file(input: 'tools/libwacom-update-db.py',
 			  output: '@BASENAME@',

--- a/tools/list-local-devices.c
+++ b/tools/list-local-devices.c
@@ -187,7 +187,11 @@ int main(int argc, char **argv)
 		db = libwacom_database_new_for_path(database_path);
 		g_free (database_path);
 	} else {
+#ifdef DATABASEPATH
+		db = libwacom_database_new_for_path(DATABASEPATH);
+#else
 		db = libwacom_database_new();
+#endif
 	}
 
 	if (!db) {


### PR DESCRIPTION
An uninstalled version of libwacom-list-local-devices that does not require the database path to be given on the commandline. Makes things a bit more convenient for debugging, same as the existing builddir/list-devices.