### PR TITLE
data: narrow down the Huion H950p to include a name match

### DIFF
--- a/data/huion-h950p.tablet
+++ b/data/huion-h950p.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=Huion H950P
 ModelName=
-DeviceMatch=usb:256c:006d
+DeviceMatch=usb:256c:006d:HID 256c:006d Pen;usb:256c:006d:HID 256c:006d Pad
 Class=Bamboo
 Width=9
 Height=5


### PR DESCRIPTION
Huion re-uses the USB IDs for, presumably, fun and profit and the only way we can distinguish them is with name matches. To make things even more fun, *other* vendors like Gaomon re-use Huion's VID/PID too.

For all devices except the H950p we match on name, but this one was the first one introduced so it only matches on VID/PID. As a result, all devices that don't match on the name get matched for the H950p - including the Dial and Touch Strip subdevices of the Gaomon S620 (see #556). For the user this looks like they have a Gaomon device (pen and pad) and a Huion H950p (dial and touchstrip).

Fix this by narrowing down the H950p to the device name too. The name comes from the sysinfo file linked to in the data file.

cc @jconnolly837 from #308

cc @JoseExposito because he *may* have a H950p or touched the kernel patches for that.1

Fixes #556 