### PR TITLE
Add generic groups for the generic styli

### DIFF
--- a/data/dell-canvas-27.tablet
+++ b/data/dell-canvas-27.tablet
@@ -27,7 +27,7 @@ PairedID=usb:2575:0204
 Width=23
 Height=13
 # No pad buttons, so no layout
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 IntegratedIn=Display
 
 [Features]

--- a/data/elan-2072.tablet
+++ b/data/elan-2072.tablet
@@ -8,7 +8,7 @@ Width=12
 Height=7
 Class=PenDisplay
 IntegratedIn=Display;System
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true

--- a/data/elan-22e2.tablet
+++ b/data/elan-22e2.tablet
@@ -6,7 +6,7 @@ ModelName=
 DeviceMatch=i2c:04f3:22e2
 Class=ISDV4
 IntegratedIn=Display;System
-Styli=0xffffe;0xfffff;
+Styli=@generic-with-eraser;
 
 [Features]
 Stylus=true

--- a/data/elan-24d8.tablet
+++ b/data/elan-24d8.tablet
@@ -8,7 +8,7 @@ Class=ISDV4
 Width=12
 Height=7
 IntegratedIn=Display;System;
-Styli=0xffffe;0xfffff;
+Styli=@generic-with-eraser;
 
 [Features]
 Reversible=false

--- a/data/elan-264c.tablet
+++ b/data/elan-264c.tablet
@@ -9,7 +9,7 @@ Width=14
 Height=8
 IntegratedIn=Display;System
 # This device supports both pens with eraser and without eraser
-Styli=@generic-no-eraser;0xffffe;0xfffff;
+Styli=@generic-no-eraser;@generic-with-eraser;
 
 [Features]
 Stylus=true

--- a/data/elan-264c.tablet
+++ b/data/elan-264c.tablet
@@ -9,7 +9,7 @@ Width=14
 Height=8
 IntegratedIn=Display;System
 # This device supports both pens with eraser and without eraser
-Styli=0xffffd;0xffffe;0xfffff;
+Styli=@generic-no-eraser;0xffffe;0xfffff;
 
 [Features]
 Stylus=true

--- a/data/elan-2fc2.tablet
+++ b/data/elan-2fc2.tablet
@@ -10,7 +10,7 @@ Class=ISDV4
 Width=14
 Height=8
 IntegratedIn=Display;System
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true

--- a/data/gaomon-s620.tablet
+++ b/data/gaomon-s620.tablet
@@ -17,7 +17,7 @@ Width=6
 Height=4
 Layout=gaomon-s620.svg
 IntegratedIn=
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true

--- a/data/huion-420.tablet
+++ b/data/huion-420.tablet
@@ -10,7 +10,7 @@ Class=Bamboo
 Width=4
 Height=2
 IntegratedIn=
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true

--- a/data/huion-h1060p.tablet
+++ b/data/huion-h1060p.tablet
@@ -12,7 +12,7 @@ Width=10
 Height=6
 IntegratedIn=
 Layout=huion-h1060p.svg
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true

--- a/data/huion-h420.tablet
+++ b/data/huion-h420.tablet
@@ -21,7 +21,7 @@ Width=4
 Height=2
 IntegratedIn=
 Layout=huion-h420.svg
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true

--- a/data/huion-h610-pro.tablet
+++ b/data/huion-h610-pro.tablet
@@ -11,7 +11,7 @@ Width=10
 Height=6
 IntegratedIn=
 Layout=huion-h610-pro.svg
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true

--- a/data/huion-h640p.tablet
+++ b/data/huion-h640p.tablet
@@ -22,7 +22,7 @@ Width=6
 Height=4
 IntegratedIn=
 Layout=huion-h640p.svg
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true

--- a/data/huion-h950p.tablet
+++ b/data/huion-h950p.tablet
@@ -12,7 +12,7 @@ Width=9
 Height=5
 IntegratedIn=
 Layout=huion-h950p.svg
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true

--- a/data/huion-hs611.tablet
+++ b/data/huion-hs611.tablet
@@ -42,7 +42,7 @@ Width=10
 Height=6
 IntegratedIn=
 Layout=huion-hs611.svg
-Styli=0xffffd
+Styli=@generic-no-eraser
 
 [Features]
 Stylus=true

--- a/data/huion-kamvas-13.tablet
+++ b/data/huion-kamvas-13.tablet
@@ -30,7 +30,7 @@ Width=12
 Height=7
 IntegratedIn=Display
 Layout=huion-kamvas-13.svg
-Styli=0xffffd
+Styli=@generic-no-eraser
 
 [Features]
 Stylus=true

--- a/data/huion-new-1060-plus.tablet
+++ b/data/huion-new-1060-plus.tablet
@@ -11,7 +11,7 @@ Width=10
 Height=6
 IntegratedIn=
 Layout=huion-new-1060-plus.svg
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true

--- a/data/isdv4-016c.tablet
+++ b/data/isdv4-016c.tablet
@@ -14,7 +14,7 @@ Class=ISDV4
 Width=12
 Height=7
 IntegratedIn=Display;System
-Styli=0xfffff;0xffffe;0xffffd
+Styli=0xfffff;0xffffe;@generic-no-eraser
 
 [Features]
 Stylus=true

--- a/data/isdv4-016c.tablet
+++ b/data/isdv4-016c.tablet
@@ -14,7 +14,7 @@ Class=ISDV4
 Width=12
 Height=7
 IntegratedIn=Display;System
-Styli=0xfffff;0xffffe;@generic-no-eraser
+Styli=@generic-with-eraser;@generic-no-eraser
 
 [Features]
 Stylus=true

--- a/data/isdv4-2d1f-002c.tablet
+++ b/data/isdv4-2d1f-002c.tablet
@@ -14,7 +14,7 @@ Class=ISDV4
 Width=10
 Height=6
 IntegratedIn=Display;System
-Styli=0xfffff;0xffffe;
+Styli=@generic-with-eraser;
 
 [Features]
 Stylus=true

--- a/data/isdv4-2d1f-0066.tablet
+++ b/data/isdv4-2d1f-0066.tablet
@@ -14,7 +14,7 @@ Class=ISDV4
 Width=11
 Height=7
 IntegratedIn=Display;System
-Styli=0xfffff;0xffffe;
+Styli=@generic-with-eraser;
 
 [Features]
 Stylus=true

--- a/data/isdv4-2d1f-0095.tablet
+++ b/data/isdv4-2d1f-0095.tablet
@@ -14,7 +14,7 @@ Class=ISDV4
 Width=8
 Height=6
 IntegratedIn=Display;System
-Styli=0xfffff;0xffffe;
+Styli=@generic-with-eraser;
 
 [Features]
 Stylus=true

--- a/data/isdv4-2d1f-0114.tablet
+++ b/data/isdv4-2d1f-0114.tablet
@@ -15,7 +15,7 @@ Class=ISDV4
 Width=12
 Height=7
 IntegratedIn=Display;System
-Styli=0xfffff;0xffffe;
+Styli=@generic-with-eraser;
 
 [Features]
 Stylus=true

--- a/data/isdv4-2d1f-0136.tablet
+++ b/data/isdv4-2d1f-0136.tablet
@@ -15,7 +15,7 @@ Class=ISDV4
 Width=14
 Height=8
 IntegratedIn=Display;System
-Styli=0xfffff;0xffffe;
+Styli=@generic-with-eraser;
 
 [Features]
 Stylus=true

--- a/data/isdv4-5019.tablet
+++ b/data/isdv4-5019.tablet
@@ -14,7 +14,7 @@ Class=ISDV4
 Width=12
 Height=7
 IntegratedIn=Display;System
-Styli=0xfffff;0xffffe;
+Styli=@generic-with-eraser;
 
 [Features]
 Stylus=true

--- a/data/kamvas-pro-13.tablet
+++ b/data/kamvas-pro-13.tablet
@@ -42,7 +42,7 @@ DeviceMatch=usb:256c:006e:Tablet Monitor Pen;usb:256c:006e:Tablet Monitor Pad;
 Width=12
 Height=7
 Layout=kamvas-pro-13.svg
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 IntegratedIn=Display
 
 [Features]

--- a/data/libwacom.stylus
+++ b/data/libwacom.stylus
@@ -16,6 +16,7 @@ Type=General
 
 [0xffffd]
 Name=General Pen with no Eraser
+Group=generic-no-eraser
 Buttons=2
 Axes=Pressure;
 Type=General

--- a/data/libwacom.stylus
+++ b/data/libwacom.stylus
@@ -1,6 +1,7 @@
 # Some generic fallback styli
 [0xfffff]
 Name=General Pen
+Group=generic-with-eraser
 PairedStylusIds=0xffffe;
 Buttons=2
 Axes=Tilt;Pressure;Distance;
@@ -8,6 +9,7 @@ Type=General
 
 [0xffffe]
 Name=General Pen Eraser
+Group=generic-with-eraser
 PairedStylusIds=0xfffff;
 EraserType=Invert
 Buttons=2

--- a/data/volito-4x5.tablet
+++ b/data/volito-4x5.tablet
@@ -9,7 +9,7 @@ DeviceMatch=usb:056a:0060
 Class=Graphire
 Width=5
 Height=4
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true

--- a/data/wacom.example
+++ b/data/wacom.example
@@ -111,7 +111,7 @@ Layout=bamboo-16fg-m-pt.svg
 # This is a list of stylus IDs supported by the tablet. Non-Wacom devices
 # usually do not support specific stylus IDs and default to the generic
 # pens. If the stylus has an eraser:
-# Styli=0xffffe;0xfffff;
+# Styli=@generic-with-eraser
 # If the stylus does not have an eraser:
 # Styli=@generic-no-eraser
 #

--- a/data/wacom.example
+++ b/data/wacom.example
@@ -113,7 +113,7 @@ Layout=bamboo-16fg-m-pt.svg
 # pens. If the stylus has an eraser:
 # Styli=0xffffe;0xfffff;
 # If the stylus does not have an eraser:
-# Styli=0xffffd
+# Styli=@generic-no-eraser
 #
 # For Wacom devices this is needed only for the professional series devices,
 # i.e. Intuos Pro and Cintiq.

--- a/data/waltop-slim-tablet-12-1.tablet
+++ b/data/waltop-slim-tablet-12-1.tablet
@@ -14,7 +14,7 @@ DeviceMatch=usb:172f:0031
 Class=Bamboo
 Width=10
 Height=6
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true

--- a/data/xp-pen-artist12.tablet
+++ b/data/xp-pen-artist12.tablet
@@ -14,7 +14,7 @@ Width=10
 Height=6
 IntegratedIn=
 Layout=xp-pen-artist12.svg
-Styli=0xffffe;0xfffff;
+Styli=@generic-with-eraser;
 
 [Features]
 Stylus=true

--- a/data/xp-pen-deco-l.tablet
+++ b/data/xp-pen-deco-l.tablet
@@ -14,7 +14,7 @@ Width=10
 Height=6
 IntegratedIn=
 Layout=xp-pen-deco-l.svg
-Styli=0xffffd
+Styli=@generic-no-eraser
 
 [Features]
 Stylus=true

--- a/data/xp-pen-deco-mw.tablet
+++ b/data/xp-pen-deco-mw.tablet
@@ -12,7 +12,7 @@ Class=Bamboo
 Width=8
 Height=5
 Layout=xp-pen-deco-mw.svg
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true

--- a/data/xp-pen-deco-pro-mw.tablet
+++ b/data/xp-pen-deco-pro-mw.tablet
@@ -27,7 +27,7 @@ Width=11
 Height=6
 IntegratedIn=
 Layout=xp-pen-deco-pro-s-m-sw-mw.svg
-Styli=0xffffd
+Styli=@generic-no-eraser
 
 [Features]
 Stylus=true

--- a/data/xp-pen-deco-pro-sw.tablet
+++ b/data/xp-pen-deco-pro-sw.tablet
@@ -14,7 +14,7 @@ Width=9
 Height=5
 IntegratedIn=
 Layout=xp-pen-deco-pro-s-m-sw-mw.svg
-Styli=0xffffd
+Styli=@generic-no-eraser
 
 [Features]
 Stylus=true

--- a/data/xp-pen-deco01-v2.tablet
+++ b/data/xp-pen-deco01-v2.tablet
@@ -14,7 +14,7 @@ Width=10
 Height=6
 IntegratedIn=
 Layout=xp-pen-deco01-v2.svg
-Styli=0xffffd
+Styli=@generic-no-eraser
 
 [Features]
 Stylus=true

--- a/data/xp-pen-g430.tablet
+++ b/data/xp-pen-g430.tablet
@@ -9,7 +9,7 @@ DeviceMatch=usb:28bd:0075
 Class=Bamboo
 Width=4
 Height=3
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true

--- a/data/xp-pen-g640.tablet
+++ b/data/xp-pen-g640.tablet
@@ -9,7 +9,7 @@ DeviceMatch=usb:28bd:0914;usb:28bd:0094
 Class=Bamboo
 Width=6
 Height=4
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true

--- a/data/xp-pen-star03.tablet
+++ b/data/xp-pen-star03.tablet
@@ -11,7 +11,7 @@ Width=10
 Height=6
 IntegratedIn=
 Layout=xp-pen-star03.svg
-Styli=0xffffd;
+Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true


### PR DESCRIPTION
A readability improvement, nothing else. Poor souls that have to stare at a `.tablet` file are probably more comfortable reading `@generic-with-eraser` than `0xfffff;0xffffe`, doubly so since neither of those IDs actually exist or can be observed in the device data stream.