### PR TITLE
data: add XP Pen Deco mini7

### DIFF
--- a/data/xp-pen-deco-mini7.tablet
+++ b/data/xp-pen-deco-mini7.tablet
@@ -1,0 +1,25 @@
+# XP-Pen
+# Deco mini7
+#
+# sysinfo.KmirkLjsqr.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/268
+
+[Device]
+Name=XP-Pen Deco mini7
+ModelName=
+DeviceMatch=usb:28bd:0928:UGTABLET 6 inch PenTablet
+Class=Bamboo
+Width=7
+Height=4
+Layout=xp-pen-deco-mw.svg
+Styli=@generic-no-eraser;
+
+[Features]
+Stylus=true
+Reversible=true
+Touch=false
+Buttons=8
+
+[Buttons]
+Left=A;B;C;D;E;F;G;H
+EvdevCodes=0x100;0x101;0x102;0x103;0x104;0x105;0x106;0x107


### PR DESCRIPTION
Link to the tablet: https://www.xp-pen.com/product/613.html

[edit by whot: re-using the Deco MW layout here, it's close enough]


Replaces #480 because I can't rebase in github without committing, which means I can't use the new `@generic...` stylus grops.

Two changes compared to #480 
- Re-using the layout from the Deco MW, it's close enough and anyone motivated is free to submit an SVG to fix this properly
- I'm assuming the evdev codes are the same as in the other Deco tablets, let's copy this because we need to define that one for button `E`, otherwise our test suite fails