### PR TITLE
data: add Huion Kamvas Pro 16 (2.5K) - huion-gt1620

### DIFF
--- a/data/huion-gt1602.tablet
+++ b/data/huion-gt1602.tablet
@@ -1,0 +1,45 @@
+# Huion
+# Kamvas Pro 16 (2.5K)
+# GT1602
+#
+#
+#
+# Button Map:
+# (A=1, B=2, C=3, ...)
+#
+#    *-----------------------*
+#    |                       |
+#  A |                       |
+#  B |                       |
+#  C |                       |
+#  D |                       |
+#  E |        TABLET         |
+#  F |                       |
+#  G |                       |
+#  H |                       |
+#    |                       |
+#    *-----------------------*
+#
+[Device]
+Name=Huion Kamvas 16 Pro (2.5K)
+ModelName=GT1602
+DeviceMatch=usb:256c:006d:HUION Huion Tablet_GT1602 Pad;usb:256c:006d:HUION Huion Tablet_GT1602 Pen
+Class=Cintiq
+Width=13
+Height=7
+IntegratedIn=Display
+Layout=huion-GT1602.svg
+Styli=@generic-no-eraser
+
+[Features]
+Stylus=true
+Reversible=false
+Touch=false
+TouchSwitch=false
+Ring=false
+NumStrips=0
+Buttons=8
+
+[Buttons]
+Left=A;B;C;D;E;F;G;H
+EvdevCodes=0x100;0x101;0x102;0x103;0x104;0x105;0x106;0x107

--- a/data/layouts/huion-gt1620.svg
+++ b/data/layouts/huion-gt1620.svg
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+  version="1.1"
+  style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
+  id="huion-kamvas-13"
+  width="380"
+  height="250"
+  xmlns="http://www.w3.org/2000/svg">
+  <title
+    id="title">Huion Kamvas 13</title>
+  <g id="A">
+    <circle
+      id="ButtonA"
+      class="A Button"
+      cx="29"
+      cy="56"
+      r="7.5" />
+    <path
+      id="LeaderA"
+      class="A Leader"
+      d="m 51,56 4,0" />
+    <text
+      id="LabelA"
+      class="A Label"
+      x="57"
+      y="56">A</text>
+  </g>
+  <g id="B">
+    <circle
+      id="ButtonB"
+      class="B Button"
+      r="7.5"
+      cy="75"
+      cx="29" />
+    <circle
+      id="DotB"
+      class="B Dot"
+      r="1"
+      cy="75"
+      cx="29" />
+    <path
+      id="LeaderB"
+      class="B Leader"
+      d="m 51,75 4,0" />
+    <text
+      id="LabelB"
+      class="B Label"
+      y="75"
+      x="57">B</text>
+  </g>
+  <g id="C">
+    <circle
+      id="ButtonC"
+      class="C Button"
+      cx="29"
+      cy="94"
+      r="7.5" />
+    <path
+      id="LeaderC"
+      class="C Leader"
+      d="m 51,94 4,0" />
+    <text
+      id="LabelC"
+      class="C Label"
+      x="57"
+      y="94">C</text>
+  </g>
+  <g id="D">
+    <path
+      id="ButtonD"
+      class="D Button"
+      d="m 29,110.125 c 4.155,0 7.5,3.345 7.5,7.5 v 5 h -15 v -5 c 0,-4.155 3.345,-7.5 7.5,-7.5 z" />
+    <circle
+      id="DotD"
+      class="D Dot"
+      r="1"
+      cy="117.5"
+      cx="29" />
+    <path
+      id="LeaderD"
+      class="D Leader"
+      d="m 51,118 4,0" />
+    <text
+      id="LabelD"
+      class="D Label"
+      x="57"
+      y="118">D</text>
+  </g>
+  <g id="E">
+    <path
+      id="ButtonE"
+      class="E Button"
+      d="m 29,139.875 c 4.155,0 7.5,-3.345 7.5,-7.5 v -5 h -15 v 5 c 0,4.155 3.345,7.5 7.5,7.5 z" />
+    <circle
+      id="DotE"
+      class="E Dot"
+      r="1"
+      cy="132.5"
+      cx="29" />
+    <path
+      id="LeaderE"
+      class="E Leader"
+      d="m 51,132 4,0" />
+    <text
+      id="LabelE"
+      class="E Label"
+      x="57"
+      y="132">E</text>
+  </g>
+  <g id="F">
+    <circle
+      id="ButtonF"
+      class="F Button"
+      cx="29"
+      cy="156"
+      r="7.5" />
+    <path
+      id="LeaderF"
+      class="F Leader"
+      d="m 51,156 4,0" />
+    <text
+      id="LabelF"
+      class="F Label"
+      x="57"
+      y="156">F</text>
+  </g>
+  <g id="G">
+    <circle
+      id="ButtonG"
+      class="G Button"
+      cx="29"
+      cy="175"
+      r="7.5" />
+    <circle
+      id="DotG"
+      class="G Dot"
+      r="1"
+      cy="175"
+      cx="29" />
+    <path
+      id="LeaderG"
+      class="G Leader"
+      d="m 51,175 4,0" />
+    <text
+      id="LabelG"
+      class="G Label"
+      x="57"
+      y="175">G</text>
+  </g>
+  <g id="H">
+    <circle
+      id="ButtonH"
+      class="H Button"
+      cx="29"
+      cy="194"
+      r="7.5" />
+    <path
+      id="LeaderH"
+      class="H Leader"
+      d="m 51,194 4,0" />
+    <text
+      id="LabelH"
+      class="H Label"
+      x="57"
+      y="194">H</text>
+  </g>
+</svg>


### PR DESCRIPTION
This should add support for Huion Kamvas Pro 16 (2.5K) huion-gt1620.
I copied kamvas-pro-13.svg since the button layout is the same.  

The only issue I couldn't figure out is that the display tablet shows up twice in the gnome-control-center panel, but other than that functionality seems to be in order.

Sorry if I've made a mess trying to understand pull requests and the like.  