### PR TITLE
data: Add support for the Samsung Chromebook Plus v2

### DIFF
--- a/data/isdv4-2d1f-0040.tablet
+++ b/data/isdv4-2d1f-0040.tablet
@@ -3,13 +3,14 @@
 # Features: Touch (External), Tilt
 # HW Resolution: 26277 x 16423
 #
+# sysinfo.8ZlJQ67o0i.tar.gz
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/318
 
 [Device]
 Name=Samsung Chromebook Plus v2
 ModelName=
-DeviceMatch=i2c:2D1F:0040:ACPI0C50:00 2D1F:0040 Stylus
-PairedIDs=i2c:06CB:7813
+DeviceMatch=i2c:2d1f:0040:ACPI0C50:00 2D1F:0040 Stylus
+PairedIDs=i2c:06cB:7813
 Class=ISDV4
 Width=12
 Height=8

--- a/data/isdv4-2d1f-0040.tablet
+++ b/data/isdv4-2d1f-0040.tablet
@@ -1,0 +1,22 @@
+# Samsung Chromebook Plus v2 (XE520QAB)
+# Sensor Type: EMR
+# Features: Touch (External), Tilt
+# HW Resolution: 26277 x 16423
+#
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/318
+
+[Device]
+Name=Samsung Chromebook Plus v2
+ModelName=
+DeviceMatch=i2c:2D1F:0040:ACPI0C50:00 2D1F:0040 Stylus
+PairedIDs=i2c:06CB:7813
+Class=ISDV4
+Width=12
+Height=8
+IntegratedIn=Display;System
+Styli=@isdv4-aes;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
Link: linuxwacom/wacom-hid-descriptors#318

Fixes: linuxwacom#584