### PR TITLE
data: add a new Keys/KeyCodes entry to the tablet files

### DIFF
--- a/data/cintiq-pro-13.tablet
+++ b/data/cintiq-pro-13.tablet
@@ -43,3 +43,7 @@ Stylus=true
 Reversible=false
 Touch=true
 Ring=false
+
+[Keys]
+# first key is in-kernel display toggle
+KeyCodes=0;KEY_CONTROLPANEL;KEY_ONSCREEN_KEYBOARD;KEY_BUTTONCONFIG;SW_MUTE_DEVICE

--- a/data/wacom.example
+++ b/data/wacom.example
@@ -210,3 +210,10 @@ Touchstrip2=J
 # We assume the same number of modes for each of the touchstrips
 # if there is more than one
 StripsNumModes=4
+
+
+# Metadata about the keys on the tablet
+[Keys]
+# The evdev codes for the keys (if any) in order from left to right.
+# Keys that have a code of zero do not produce any events.
+KeyCodes=0;KEY_CONTROLPANEL;KEY_ONSCREEN_KEYBOARD;KEY_BUTTONCONFIG;SW_MUTE_DEVICE

--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -379,6 +379,10 @@ libwacom_copy(const WacomDevice *device)
 		WacomButton *b = g_memdup2(a, sizeof(WacomButton));
 		g_hash_table_insert(d->buttons, k, b);
 	}
+
+	d->num_keycodes = device->num_keycodes;
+	memcpy(d->keycodes, device->keycodes, sizeof(device->keycodes));
+
 	return d;
 }
 
@@ -1118,6 +1122,12 @@ LIBWACOM_EXPORT int
 libwacom_get_num_buttons(const WacomDevice *device)
 {
 	return g_hash_table_size(device->buttons);
+}
+
+LIBWACOM_EXPORT int
+libwacom_get_num_keys(const WacomDevice *device)
+{
+	return device->num_keycodes;
 }
 
 LIBWACOM_EXPORT const int *

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -595,6 +595,16 @@ int libwacom_has_touch(const WacomDevice *device);
 int libwacom_get_num_buttons(const WacomDevice *device);
 
 /**
+ * Tablet keys indices are numbered from zero
+ *
+ * @param device The tablet to query
+ * @return The number of keys on the tablet
+ *
+ * @ingroup devices
+ */
+int libwacom_get_num_keys(const WacomDevice *device);
+
+/**
  * @param device The tablet to query
  * @param num_styli Return location for the number of listed styli
  * @return an array of Styli IDs supported by the device

--- a/libwacom/libwacom.sym
+++ b/libwacom/libwacom.sym
@@ -68,3 +68,7 @@ global:
 local:
         *;
 };
+
+LIBWACOM_2.9 {
+    libwacom_get_num_keys;
+} LIBWACOM_2.0;

--- a/libwacom/libwacomint.h
+++ b/libwacom/libwacomint.h
@@ -67,6 +67,11 @@ typedef struct _WacomButton {
 	int code;
 } WacomButton;
 
+typedef struct _WacomKeycode {
+	unsigned int type;
+	unsigned int code;
+} WacomKeycode;
+
 /* WARNING: When adding new members to this struct
  * make sure to update libwacom_copy() and
  * libwacom_print_device_description() ! */
@@ -92,6 +97,8 @@ struct _WacomDevice {
 
 	GArray *styli;
 	GHashTable *buttons; /* 'A' : WacomButton */
+	WacomKeycode keycodes[32];
+	size_t num_keycodes;
 
 	GArray *status_leds;
 

--- a/test/test-load.c
+++ b/test/test-load.c
@@ -227,6 +227,16 @@ test_cintiq13hd(struct fixture *f, gconstpointer user_data)
 }
 
 static void
+test_cintiqpro13(struct fixture *f, gconstpointer user_data)
+{
+	WacomDevice *device = libwacom_new_from_name(f->db, "Wacom Cintiq Pro 13", NULL);
+	g_assert_nonnull(device);
+	g_assert_cmpint(libwacom_get_num_keys(device), ==, 5);
+
+	libwacom_destroy(device);
+}
+
+static void
 test_bamboopen(struct fixture *f, gconstpointer user_data)
 {
 	WacomDevice *device = libwacom_new_from_name(f->db, "Wacom Bamboo Pen", NULL);
@@ -293,6 +303,9 @@ int main(int argc, char **argv)
 		   fixture_teardown);
 	g_test_add("/load/056a:0304", struct fixture, NULL,
 		   fixture_setup, test_cintiq13hd,
+		   fixture_teardown);
+	g_test_add("/load/056a:034f", struct fixture, NULL,
+		   fixture_setup, test_cintiqpro13,
 		   fixture_teardown);
 	g_test_add("/load/056a:0065", struct fixture, NULL,
 		   fixture_setup, test_bamboopen,

--- a/tools/libwacom-update-db.py
+++ b/tools/libwacom-update-db.py
@@ -147,7 +147,7 @@ class TabletDatabase:
                         )
                 except KeyError:
                     pass
-                t.has_pad = config.has_section("Buttons")
+                t.has_pad = any(config.has_section(s) for s in ["Buttons", "Keys"])
                 yield t
 
 


### PR DESCRIPTION
This is parsed but not exported by libwacom itself, at least not until we know what our callers want.

It is used however to determine if a device has a pad and thus used to set the ID_INPUT_TABLET_PAD property through the hwdb. This fixes the issue with some devices without buttons (but with keys) to not get labelled as pads, e.g. the Cintiq Pro 13.

Fixes #585


Note: draft because I need to know the evdev keycodes for the cintiq before we can commit this, cc @Pinglinux 