### PR TITLE
meson.build: correct license to HPND

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('libwacom', 'c',
 	version: '2.8.0',
-	license: 'MIT/Expat',
+	license: 'HPND',
 	default_options: [ 'c_std=gnu99', 'warning_level=2' ],
 	meson_version: '>= 0.51.0')
 


### PR DESCRIPTION
Best explanation: 12-ish years ago when I started libwacom, I copied the license from some X11-related repository assuming it was MIT and went with that. Turns out it's actually the HPND-sell-variant: "Historical Permission Notice and Disclaimer - sell variant" https://spdx.org/licenses/HPND-sell-variant.html

No real effects since it's not really that much different to MIT afaict but let's make sure meson prints out the correct SPDX license identifier.

cc @jigpu  @Pinglinux 