### PR TITLE
Two minor cleanups

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -124,16 +124,6 @@ test('files-in-git',
      args: [meson.current_source_dir()],
      suite: ['all'])
 
-# This is a generic pytest invocation. If we end up with more than one
-# pytest-compatible test somewhere, we'll conveniently run that one too.
-pytest = find_program('pytest-3', required: false)
-if pytest.found()
-	test('pytests', pytest,
-	     args: ['-vv', '--log-level=DEBUG'],
-	     workdir: meson.current_source_dir(),
-	     env: ['LIBWACOM_DATA_DIR=@0@'.format(dir_src_data)])
-endif
-
 ############### tools ###########################
 
 tools_cflags = ['-DDATABASEPATH="@0@"'.format(dir_src_data)]

--- a/test/test-tablet-svg-validity.c
+++ b/test/test-tablet-svg-validity.c
@@ -69,7 +69,7 @@ class_found (gchar **classes, gchar *value)
 {
 	gchar **ptr = classes;
 	while (*ptr) {
-		if (strcmp (*ptr++, value) == 0)
+		if (g_str_equal (*ptr++, value))
 			return TRUE;
 	}
 
@@ -365,7 +365,7 @@ static void setup_tests(WacomDevice *device)
 	const char *name;
 
 	name = libwacom_get_name(device);
-	if (strcmp(name, "Generic") == 0)
+	if (g_str_equal(name, "Generic"))
 		return;
 
 	add_test(device, test_filename);

--- a/test/test-tablet-validity.c
+++ b/test/test-tablet-validity.c
@@ -327,7 +327,7 @@ static void setup_tests(WacomDevice *device)
 	WacomClass cls;
 
 	name = libwacom_get_name(device);
-	if (strcmp(name, "Generic") == 0)
+	if (g_str_equal(name, "Generic"))
 		return;
 
 	add_test(device, test_class);

--- a/tools/list-compatible-styli.c
+++ b/tools/list-compatible-styli.c
@@ -32,6 +32,7 @@
 #include <assert.h>
 #include <libgen.h>
 #include <unistd.h>
+#include <glib.h>
 #include "libwacom.h"
 
 static void
@@ -72,7 +73,7 @@ int main(int argc, char **argv)
 	if (argc > 1) {
 		printf("Usage: %s [--help] - list compatible styli\n",
 		       basename(argv[0]));
-	       return !!(strcmp(argv[1], "--help"));
+	       return g_str_equal(argv[1], "--help");
 	}
 
 	db = libwacom_database_new_for_path(DATABASEPATH);


### PR DESCRIPTION
switch from `strcmp` to the safer `g_str_equal()` and drop a duplicate invocation of pytest