### PR TITLE
Drop the superfluous Buttons entry in the tablet files

### DIFF
--- a/data/bamboo-0fg-m-p-alt.tablet
+++ b/data/bamboo-0fg-m-p-alt.tablet
@@ -52,7 +52,6 @@ Layout=bamboo-0fg-s-p-alt.svg
 Stylus=true
 Reversible=false
 Touch=false
-Buttons=4
 Ring=true
 
 [Buttons]

--- a/data/bamboo-0fg-s-p-alt.tablet
+++ b/data/bamboo-0fg-s-p-alt.tablet
@@ -53,7 +53,6 @@ Layout=bamboo-0fg-s-p-alt.svg
 Stylus=true
 Reversible=false
 Touch=false
-Buttons=4
 Ring=true
 
 [Buttons]

--- a/data/bamboo-0fg-s-p.tablet
+++ b/data/bamboo-0fg-s-p.tablet
@@ -53,7 +53,6 @@ Layout=bamboo-0fg-s-p.svg
 Stylus=true
 Reversible=false
 Touch=false
-Buttons=4
 Ring=true
 
 [Buttons]

--- a/data/bamboo-16fg-m-pt.tablet
+++ b/data/bamboo-16fg-m-pt.tablet
@@ -22,7 +22,6 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/bamboo-16fg-s-p.tablet
+++ b/data/bamboo-16fg-s-p.tablet
@@ -21,5 +21,4 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=0
 EvdevCodes=BTN_LEFT;BTN_FORWARD;BTN_BACK;BTN_RIGHT

--- a/data/bamboo-16fg-s-pt.tablet
+++ b/data/bamboo-16fg-s-pt.tablet
@@ -22,7 +22,6 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/bamboo-16fg-s-t.tablet
+++ b/data/bamboo-16fg-s-t.tablet
@@ -21,7 +21,6 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/bamboo-2fg-fun-m-pt.tablet
+++ b/data/bamboo-2fg-fun-m-pt.tablet
@@ -34,7 +34,6 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/bamboo-2fg-fun-s-pt.tablet
+++ b/data/bamboo-2fg-fun-s-pt.tablet
@@ -34,7 +34,6 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/bamboo-2fg-m-p.tablet
+++ b/data/bamboo-2fg-m-p.tablet
@@ -21,4 +21,3 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=0

--- a/data/bamboo-2fg-s-p.tablet
+++ b/data/bamboo-2fg-s-p.tablet
@@ -21,4 +21,3 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=0

--- a/data/bamboo-2fg-s-pt.tablet
+++ b/data/bamboo-2fg-s-pt.tablet
@@ -34,7 +34,6 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/bamboo-2fg-s-t.tablet
+++ b/data/bamboo-2fg-s-t.tablet
@@ -33,7 +33,6 @@ IntegratedIn=
 Stylus=false
 Reversible=true
 Touch=true
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/bamboo-4fg-fun-m.tablet
+++ b/data/bamboo-4fg-fun-m.tablet
@@ -22,7 +22,6 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/bamboo-4fg-fun-s.tablet
+++ b/data/bamboo-4fg-fun-s.tablet
@@ -22,7 +22,6 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/bamboo-4fg-s-pt.tablet
+++ b/data/bamboo-4fg-s-pt.tablet
@@ -22,7 +22,6 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/bamboo-4fg-s-t.tablet
+++ b/data/bamboo-4fg-s-t.tablet
@@ -21,7 +21,6 @@ IntegratedIn=
 Stylus=false
 Reversible=true
 Touch=true
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/bamboo-4fg-se-m-pt.tablet
+++ b/data/bamboo-4fg-se-m-pt.tablet
@@ -22,7 +22,6 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/bamboo-4fg-se-s-pt.tablet
+++ b/data/bamboo-4fg-se-s-pt.tablet
@@ -22,7 +22,6 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/bamboo-one-m-p.tablet
+++ b/data/bamboo-one-m-p.tablet
@@ -17,4 +17,3 @@ IntegratedIn=
 [Features]
 Stylus=true
 Touch=false
-Buttons=0

--- a/data/bamboo-one.tablet
+++ b/data/bamboo-one.tablet
@@ -17,4 +17,3 @@ Stylus=true
 Touch=false
 Ring=false
 NumStrips=0
-Buttons=0

--- a/data/bamboo-pad-wireless.tablet
+++ b/data/bamboo-pad-wireless.tablet
@@ -17,7 +17,6 @@ Layout=bamboo-pad.svg
 Stylus=true
 Reversible=false
 Touch=true
-Buttons=2
 
 [Buttons]
 Bottom=A;B

--- a/data/bamboo-pad.tablet
+++ b/data/bamboo-pad.tablet
@@ -17,7 +17,6 @@ Layout=bamboo-pad.svg
 Stylus=true
 Reversible=false
 Touch=true
-Buttons=2
 
 [Buttons]
 Bottom=A;B

--- a/data/chuwi-minibookx.tablet
+++ b/data/chuwi-minibookx.tablet
@@ -16,4 +16,3 @@ Styli=0x621
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/cintiq-12wx.tablet
+++ b/data/cintiq-12wx.tablet
@@ -44,7 +44,6 @@ IntegratedIn=Display
 [Features]
 Stylus=true
 NumStrips=2
-Buttons=10
 
 [Buttons]
 Left=A;B;C;D;I

--- a/data/cintiq-13hd.tablet
+++ b/data/cintiq-13hd.tablet
@@ -37,7 +37,6 @@ Stylus=true
 Reversible=false
 Touch=false
 Ring=false
-Buttons=9
 
 [Buttons]
 Left=B;C;G;H;A;F;I;D;E

--- a/data/cintiq-13hdt.tablet
+++ b/data/cintiq-13hdt.tablet
@@ -39,7 +39,6 @@ Stylus=true
 Reversible=false
 Touch=true
 Ring=false
-Buttons=9
 
 [Buttons]
 Left=B;C;G;H;A;F;I;D;E

--- a/data/cintiq-16-2.tablet
+++ b/data/cintiq-16-2.tablet
@@ -18,4 +18,3 @@ Stylus=true
 Reversible=false
 Touch=false
 Ring=false
-Buttons=0

--- a/data/cintiq-16.tablet
+++ b/data/cintiq-16.tablet
@@ -18,4 +18,3 @@ Stylus=true
 Reversible=false
 Touch=false
 Ring=false
-Buttons=0

--- a/data/cintiq-20wsx.tablet
+++ b/data/cintiq-20wsx.tablet
@@ -48,7 +48,6 @@ IntegratedIn=Display
 Reversible=false
 Stylus=true
 NumStrips=2
-Buttons=14
 
 [Buttons]
 Left=A;B;C;D;I;K;L

--- a/data/cintiq-21ux.tablet
+++ b/data/cintiq-21ux.tablet
@@ -41,7 +41,6 @@ IntegratedIn=Display
 Reversible=false
 Stylus=true
 NumStrips=2
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D

--- a/data/cintiq-21ux2.tablet
+++ b/data/cintiq-21ux2.tablet
@@ -57,7 +57,6 @@ IntegratedIn=Display
 Stylus=true
 Ring=false
 NumStrips=2
-Buttons=18
 StatusLEDs=Touchstrip2;Touchstrip
 
 [Buttons]

--- a/data/cintiq-22.tablet
+++ b/data/cintiq-22.tablet
@@ -18,4 +18,3 @@ Stylus=true
 Reversible=false
 Touch=false
 Ring=false
-Buttons=0

--- a/data/cintiq-22hd.tablet
+++ b/data/cintiq-22hd.tablet
@@ -47,7 +47,6 @@ Reversible=false
 Touch=false
 Ring=false
 NumStrips=2
-Buttons=18
 
 [Buttons]
 Left=B;C;D;E;A;F;G;H;I

--- a/data/cintiq-22hdt.tablet
+++ b/data/cintiq-22hdt.tablet
@@ -49,7 +49,6 @@ Reversible=false
 Touch=true
 Ring=false
 NumStrips=2
-Buttons=18
 
 [Buttons]
 Left=B;C;D;E;A;F;G;H;I

--- a/data/cintiq-24hd-touch.tablet
+++ b/data/cintiq-24hd-touch.tablet
@@ -55,7 +55,6 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Buttons=16
 Ring=true
 Ring2=true
 StatusLEDs=Ring2;Ring

--- a/data/cintiq-24hd.tablet
+++ b/data/cintiq-24hd.tablet
@@ -53,7 +53,6 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Buttons=16
 Ring=true
 Ring2=true
 StatusLEDs=Ring2;Ring

--- a/data/cintiq-27hd.tablet
+++ b/data/cintiq-27hd.tablet
@@ -17,6 +17,5 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Buttons=0
 Ring=false
 Ring2=false

--- a/data/cintiq-27hdt.tablet
+++ b/data/cintiq-27hdt.tablet
@@ -19,6 +19,5 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Buttons=0
 Ring=false
 Ring2=false

--- a/data/cintiq-companion-2.tablet
+++ b/data/cintiq-companion-2.tablet
@@ -42,7 +42,6 @@ IntegratedIn=Display;System
 Stylus=true
 Touch=true
 Ring=false
-Buttons=11
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H;I;J;K

--- a/data/cintiq-companion-hybrid.tablet
+++ b/data/cintiq-companion-hybrid.tablet
@@ -41,7 +41,6 @@ Stylus=true
 Reversible=false
 Touch=true
 Ring=false
-Buttons=9
 
 [Buttons]
 Left=B;C;G;H;A;F;I;D;E

--- a/data/cintiq-companion.tablet
+++ b/data/cintiq-companion.tablet
@@ -40,7 +40,6 @@ IntegratedIn=Display;System
 Stylus=true
 Touch=true
 Ring=false
-Buttons=9
 
 [Buttons]
 Left=B;C;G;H;A;F;I;D;E

--- a/data/cintiq-pro-13.tablet
+++ b/data/cintiq-pro-13.tablet
@@ -43,4 +43,3 @@ Stylus=true
 Reversible=false
 Touch=true
 Ring=false
-Buttons=0

--- a/data/cintiq-pro-16-2.tablet
+++ b/data/cintiq-pro-16-2.tablet
@@ -40,7 +40,6 @@ Stylus=true
 Reversible=false
 Touch=true
 Ring=false
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D

--- a/data/cintiq-pro-16.tablet
+++ b/data/cintiq-pro-16.tablet
@@ -43,4 +43,3 @@ Stylus=true
 Reversible=false
 Touch=true
 Ring=false
-Buttons=0

--- a/data/cintiq-pro-17.tablet
+++ b/data/cintiq-pro-17.tablet
@@ -41,7 +41,6 @@ Stylus=true
 Reversible=false
 Touch=true
 Ring=false
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D

--- a/data/cintiq-pro-22.tablet
+++ b/data/cintiq-pro-22.tablet
@@ -41,7 +41,6 @@ Stylus=true
 Reversible=false
 Touch=true
 Ring=false
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D

--- a/data/cintiq-pro-24-p.tablet
+++ b/data/cintiq-pro-24-p.tablet
@@ -42,4 +42,3 @@ Stylus=true
 Reversible=false
 Touch=false
 Ring=false
-Buttons=0

--- a/data/cintiq-pro-24-pt.tablet
+++ b/data/cintiq-pro-24-pt.tablet
@@ -43,4 +43,3 @@ Stylus=true
 Reversible=false
 Touch=true
 Ring=false
-Buttons=0

--- a/data/cintiq-pro-27.tablet
+++ b/data/cintiq-pro-27.tablet
@@ -41,7 +41,6 @@ Stylus=true
 Reversible=false
 Touch=true
 Ring=false
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D

--- a/data/cintiq-pro-32.tablet
+++ b/data/cintiq-pro-32.tablet
@@ -43,4 +43,3 @@ Stylus=true
 Reversible=false
 Touch=true
 Ring=false
-Buttons=0

--- a/data/dell-canvas-27.tablet
+++ b/data/dell-canvas-27.tablet
@@ -35,4 +35,3 @@ Stylus=true
 Reversible=false
 Touch=true
 Ring=false
-Buttons=0

--- a/data/dtc-121.tablet
+++ b/data/dtc-121.tablet
@@ -20,4 +20,3 @@ Stylus=true
 Reversible=false
 Touch=false
 Ring=false
-Buttons=0

--- a/data/dtf-720.tablet
+++ b/data/dtf-720.tablet
@@ -14,5 +14,4 @@ IntegratedIn=Display
 
 [Features]
 Stylus=true
-Buttons=0
 

--- a/data/dth-1152.tablet
+++ b/data/dth-1152.tablet
@@ -21,4 +21,3 @@ Touch=true
 Ring=false
 Ring2=false
 NumStrips=0
-Buttons=0

--- a/data/dth-134.tablet
+++ b/data/dth-134.tablet
@@ -20,4 +20,3 @@ Stylus=true
 Reversible=false
 Touch=true
 Ring=false
-Buttons=0

--- a/data/dth-2242.tablet
+++ b/data/dth-2242.tablet
@@ -35,7 +35,6 @@ Ring=false
 Ring2=false
 NumStrips=0
 # Actually 7 buttons but one is reserved for onscreen menus
-Buttons=6
 
 [Buttons]
 Top=A;B;C;D;E;F

--- a/data/dth-2452.tablet
+++ b/data/dth-2452.tablet
@@ -32,7 +32,6 @@ Ring=false
 Ring2=false
 NumStrips=0
 # Actually 5 buttons but one is reserved for onscreen menus
-Buttons=4
 
 [Buttons]
 Right=A;B;C;D

--- a/data/dti-520.tablet
+++ b/data/dti-520.tablet
@@ -35,7 +35,6 @@ Ring=false
 Ring2=false
 NumStrips=0
 # Actually 11 buttons but the two Ctrl ones send the same scancode
-Buttons=10
 
 [Buttons]
 Top=F;G;H;I;J

--- a/data/dtk-1651.tablet
+++ b/data/dtk-1651.tablet
@@ -29,7 +29,6 @@ Touch=false
 Ring=false
 Ring2=false
 NumStrips=0
-Buttons=4
 
 [Buttons]
 Right=A;B;C;D

--- a/data/dtk-1660e-2.tablet
+++ b/data/dtk-1660e-2.tablet
@@ -17,4 +17,3 @@ Stylus=true
 Reversible=false
 Touch=false
 Ring=false
-Buttons=0

--- a/data/dtk-1660e.tablet
+++ b/data/dtk-1660e.tablet
@@ -17,4 +17,3 @@ Stylus=true
 Reversible=false
 Touch=false
 Ring=false
-Buttons=0

--- a/data/dtk-2241.tablet
+++ b/data/dtk-2241.tablet
@@ -33,7 +33,6 @@ Ring=false
 Ring2=false
 NumStrips=0
 # Actually 7 buttons but one is reserved for onscreen menus
-Buttons=6
 
 [Buttons]
 Top=A;B;C;D;E;F

--- a/data/dtk-2451.tablet
+++ b/data/dtk-2451.tablet
@@ -31,7 +31,6 @@ Ring=false
 Ring2=false
 NumStrips=0
 # Actually 5 buttons but one is reserved for onscreen menus
-Buttons=4
 
 [Buttons]
 Right=A;B;C;D

--- a/data/dtu-1031.tablet
+++ b/data/dtu-1031.tablet
@@ -32,7 +32,6 @@ Touch=false
 Ring=false
 Ring2=false
 NumStrips=0
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/dtu-1031x.tablet
+++ b/data/dtu-1031x.tablet
@@ -20,4 +20,3 @@ Touch=false
 Ring=false
 Ring2=false
 NumStrips=0
-Buttons=0

--- a/data/dtu-1141.tablet
+++ b/data/dtu-1141.tablet
@@ -32,7 +32,6 @@ Touch=false
 Ring=false
 Ring2=false
 NumStrips=0
-Buttons=4
 
 [Buttons]
 Top=A;B;C;D

--- a/data/dtu-1141b.tablet
+++ b/data/dtu-1141b.tablet
@@ -30,7 +30,6 @@ Touch=false
 Ring=false
 Ring2=false
 NumStrips=0
-Buttons=4
 
 [Buttons]
 Top=A;B;C;D

--- a/data/dtu-1631.tablet
+++ b/data/dtu-1631.tablet
@@ -14,5 +14,4 @@ IntegratedIn=Display
 
 [Features]
 Stylus=true
-Buttons=0
 

--- a/data/dtu-1931.tablet
+++ b/data/dtu-1931.tablet
@@ -13,4 +13,3 @@ IntegratedIn=Display
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/dtu-2231.tablet
+++ b/data/dtu-2231.tablet
@@ -13,5 +13,4 @@ IntegratedIn=Display
 
 [Features]
 Stylus=true
-Buttons=0
 

--- a/data/ek-remote.tablet
+++ b/data/ek-remote.tablet
@@ -22,7 +22,6 @@ Class=Remote
 Stylus=false
 Ring=true
 NumStrips=0
-Buttons=18
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/elan-0732.tablet
+++ b/data/elan-0732.tablet
@@ -11,5 +11,4 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0
 

--- a/data/elan-2072.tablet
+++ b/data/elan-2072.tablet
@@ -13,4 +13,3 @@ Styli=@generic-no-eraser;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-22e2.tablet
+++ b/data/elan-22e2.tablet
@@ -16,4 +16,3 @@ TouchSwitch=false
 Ring=false
 Ring2=false
 NumStrips=0
-Buttons=0

--- a/data/elan-22f7.tablet
+++ b/data/elan-22f7.tablet
@@ -17,4 +17,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-24d8.tablet
+++ b/data/elan-24d8.tablet
@@ -19,4 +19,3 @@ Touch=true
 TouchSwitch=false
 # StatusLEDs=
 NumStrips=0
-Buttons=0

--- a/data/elan-24db.tablet
+++ b/data/elan-24db.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-2513.tablet
+++ b/data/elan-2513.tablet
@@ -15,4 +15,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-2514-alt.tablet
+++ b/data/elan-2514-alt.tablet
@@ -15,4 +15,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-2514-alt2.tablet
+++ b/data/elan-2514-alt2.tablet
@@ -24,4 +24,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-2514.tablet
+++ b/data/elan-2514.tablet
@@ -51,4 +51,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-2537.tablet
+++ b/data/elan-2537.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-2627.tablet
+++ b/data/elan-2627.tablet
@@ -11,5 +11,4 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0
 

--- a/data/elan-2628.tablet
+++ b/data/elan-2628.tablet
@@ -11,4 +11,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-262b.tablet
+++ b/data/elan-262b.tablet
@@ -11,5 +11,4 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0
 

--- a/data/elan-264c.tablet
+++ b/data/elan-264c.tablet
@@ -14,4 +14,3 @@ Styli=@generic-no-eraser;@generic-with-eraser;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-29a1.tablet
+++ b/data/elan-29a1.tablet
@@ -15,4 +15,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-29b6.tablet
+++ b/data/elan-29b6.tablet
@@ -15,4 +15,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-2a70.tablet
+++ b/data/elan-2a70.tablet
@@ -13,5 +13,4 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0
 

--- a/data/elan-2ad9.tablet
+++ b/data/elan-2ad9.tablet
@@ -14,4 +14,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-2bb3.tablet
+++ b/data/elan-2bb3.tablet
@@ -13,4 +13,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-2c1b.tablet
+++ b/data/elan-2c1b.tablet
@@ -17,4 +17,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-2d55.tablet
+++ b/data/elan-2d55.tablet
@@ -17,4 +17,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-2fc2.tablet
+++ b/data/elan-2fc2.tablet
@@ -15,4 +15,3 @@ Styli=@generic-no-eraser;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/elan-5515.tablet
+++ b/data/elan-5515.tablet
@@ -10,4 +10,3 @@ IntegratedIn=Display
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/gaomon-s620.tablet
+++ b/data/gaomon-s620.tablet
@@ -22,7 +22,6 @@ Styli=@generic-no-eraser;
 [Features]
 Stylus=true
 Reversible=true
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/generic.tablet
+++ b/data/generic.tablet
@@ -8,4 +8,3 @@ Reversible=true
 Stylus=true
 Ring=true
 NumStrips=2
-Buttons=4

--- a/data/graphire-usb.tablet
+++ b/data/graphire-usb.tablet
@@ -26,4 +26,3 @@ Height=4
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/graphire-wireless-8x6.tablet
+++ b/data/graphire-wireless-8x6.tablet
@@ -28,7 +28,6 @@ IntegratedIn=
 Reversible=false
 Stylus=true
 Ring=false
-Buttons=2
 
 [Buttons]
 Top=A;B

--- a/data/graphire2-4x5.tablet
+++ b/data/graphire2-4x5.tablet
@@ -26,4 +26,3 @@ Height=4
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/graphire2-5x7.tablet
+++ b/data/graphire2-5x7.tablet
@@ -26,4 +26,3 @@ Height=5
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/graphire3-4x5.tablet
+++ b/data/graphire3-4x5.tablet
@@ -13,4 +13,3 @@ Height=4
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/graphire3-6x8.tablet
+++ b/data/graphire3-6x8.tablet
@@ -13,4 +13,3 @@ Height=6
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/graphire4-4x5.tablet
+++ b/data/graphire4-4x5.tablet
@@ -27,7 +27,6 @@ Layout=graphire4-4x5.svg
 
 [Features]
 Stylus=true
-Buttons=2
 
 [Buttons]
 Top=A;B

--- a/data/graphire4-6x8.tablet
+++ b/data/graphire4-6x8.tablet
@@ -27,7 +27,6 @@ Layout=graphire4-6x8.svg
 
 [Features]
 Stylus=true
-Buttons=2
 
 [Buttons]
 Top=A;B

--- a/data/hp-pro-tablet-408.tablet
+++ b/data/hp-pro-tablet-408.tablet
@@ -16,4 +16,3 @@ IntegratedIn=Display;System;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/huion-420.tablet
+++ b/data/huion-420.tablet
@@ -15,4 +15,3 @@ Styli=@generic-no-eraser;
 [Features]
 Stylus=true
 Reversible=true
-Buttons=0

--- a/data/huion-h1060p.tablet
+++ b/data/huion-h1060p.tablet
@@ -19,7 +19,6 @@ Stylus=true
 Reversible=true
 Touch=false
 NumStrips=0
-Buttons=12
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H;I;J;K;L

--- a/data/huion-h420.tablet
+++ b/data/huion-h420.tablet
@@ -27,7 +27,6 @@ Styli=@generic-no-eraser;
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=3
 
 [Buttons]
 Left=A;B;C

--- a/data/huion-h610-pro.tablet
+++ b/data/huion-h610-pro.tablet
@@ -17,7 +17,6 @@ Styli=@generic-no-eraser;
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H

--- a/data/huion-h640p.tablet
+++ b/data/huion-h640p.tablet
@@ -28,7 +28,6 @@ Styli=@generic-no-eraser;
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=6
 
 [Buttons]
 Left=A;B;C;D;E;F

--- a/data/huion-h950p.tablet
+++ b/data/huion-h950p.tablet
@@ -18,7 +18,6 @@ Styli=@generic-no-eraser;
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H

--- a/data/huion-hs611.tablet
+++ b/data/huion-hs611.tablet
@@ -49,7 +49,6 @@ Stylus=true
 Reversible=true
 Touch=false
 NumStrips=1
-Buttons=10
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H;I;J

--- a/data/huion-kamvas-13.tablet
+++ b/data/huion-kamvas-13.tablet
@@ -39,7 +39,6 @@ Touch=false
 TouchSwitch=false
 Ring=false
 NumStrips=0
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H

--- a/data/huion-new-1060-plus.tablet
+++ b/data/huion-new-1060-plus.tablet
@@ -17,7 +17,6 @@ Styli=@generic-no-eraser;
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=12
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H;I;J;K;L

--- a/data/intuos-12x12.tablet
+++ b/data/intuos-12x12.tablet
@@ -13,4 +13,3 @@ Styli=@intuos-airbrush;@intuos;
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/intuos-12x18.tablet
+++ b/data/intuos-12x18.tablet
@@ -13,4 +13,3 @@ Styli=@intuos-airbrush;@intuos;
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/intuos-4x5.tablet
+++ b/data/intuos-4x5.tablet
@@ -13,4 +13,3 @@ Styli=@intuos-airbrush;@intuos;
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/intuos-6x8.tablet
+++ b/data/intuos-6x8.tablet
@@ -13,4 +13,3 @@ Styli=@intuos-airbrush;@intuos;
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/intuos-9x12.tablet
+++ b/data/intuos-9x12.tablet
@@ -13,4 +13,3 @@ Styli=@intuos-airbrush;@intuos;
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/intuos-m-p.tablet
+++ b/data/intuos-m-p.tablet
@@ -33,7 +33,6 @@ IntegratedIn=
 [Features]
 Stylus=true
 Reversible=false
-Buttons=4
 
 [Buttons]
 Top=A;B;C;D

--- a/data/intuos-m-p2.tablet
+++ b/data/intuos-m-p2.tablet
@@ -35,7 +35,6 @@ Styli=@intuospt;
 [Features]
 Stylus=true
 Reversible=false
-Buttons=4
 
 [Buttons]
 Top=A;B;C;D

--- a/data/intuos-m-p3-android.tablet
+++ b/data/intuos-m-p3-android.tablet
@@ -36,7 +36,6 @@ Styli=@intuospt3;
 [Features]
 Stylus=true
 Reversible=false
-Buttons=4
 
 [Buttons]
 Top=A;B;C;D

--- a/data/intuos-m-p3-wl-android.tablet
+++ b/data/intuos-m-p3-wl-android.tablet
@@ -36,7 +36,6 @@ Styli=@intuospt3;
 [Features]
 Stylus=true
 Reversible=false
-Buttons=4
 
 [Buttons]
 Top=A;B;C;D

--- a/data/intuos-m-p3-wl.tablet
+++ b/data/intuos-m-p3-wl.tablet
@@ -31,7 +31,6 @@ Styli=@intuospt3;
 [Features]
 Stylus=true
 Reversible=false
-Buttons=4
 
 [Buttons]
 Top=A;B;C;D

--- a/data/intuos-m-p3.tablet
+++ b/data/intuos-m-p3.tablet
@@ -31,7 +31,6 @@ Styli=@intuospt3;
 [Features]
 Stylus=true
 Reversible=false
-Buttons=4
 
 [Buttons]
 Top=A;B;C;D

--- a/data/intuos-m-pt.tablet
+++ b/data/intuos-m-pt.tablet
@@ -47,7 +47,6 @@ IntegratedIn=
 Stylus=true
 Reversible=false
 Touch=true
-Buttons=4
 TouchSwitch=true
 
 [Buttons]

--- a/data/intuos-m-pt2.tablet
+++ b/data/intuos-m-pt2.tablet
@@ -49,7 +49,6 @@ Styli=@intuospt;
 Stylus=true
 Reversible=false
 Touch=true
-Buttons=4
 TouchSwitch=true
 
 [Buttons]

--- a/data/intuos-pro-2-l.tablet
+++ b/data/intuos-pro-2-l.tablet
@@ -57,7 +57,6 @@ Styli=@intuos5;@mobilestudio;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=9
 Ring=true
 StatusLEDs=Ring
 

--- a/data/intuos-pro-2-m.tablet
+++ b/data/intuos-pro-2-m.tablet
@@ -57,7 +57,6 @@ Styli=@intuos5;@mobilestudio;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=9
 Ring=true
 StatusLEDs=Ring
 

--- a/data/intuos-pro-2-s.tablet
+++ b/data/intuos-pro-2-s.tablet
@@ -44,7 +44,6 @@ Styli=@intuos5;@mobilestudio;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=7
 Ring=true
 
 [Buttons]

--- a/data/intuos-pro-l.tablet
+++ b/data/intuos-pro-l.tablet
@@ -57,7 +57,6 @@ Styli=@intuos4-lens;@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=9
 Ring=true
 StatusLEDs=Ring
 

--- a/data/intuos-pro-m.tablet
+++ b/data/intuos-pro-m.tablet
@@ -57,7 +57,6 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=9
 Ring=true
 StatusLEDs=Ring
 

--- a/data/intuos-pro-s.tablet
+++ b/data/intuos-pro-s.tablet
@@ -55,7 +55,6 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=7
 Ring=true
 StatusLEDs=Ring
 

--- a/data/intuos-s-p.tablet
+++ b/data/intuos-s-p.tablet
@@ -31,7 +31,6 @@ IntegratedIn=
 [Features]
 Stylus=true
 Reversible=false
-Buttons=4
 
 [Buttons]
 Top=A;B;C;D

--- a/data/intuos-s-p2.tablet
+++ b/data/intuos-s-p2.tablet
@@ -33,7 +33,6 @@ Styli=@intuospt;
 [Features]
 Stylus=true
 Reversible=false
-Buttons=4
 
 [Buttons]
 Top=A;B;C;D

--- a/data/intuos-s-p3-android.tablet
+++ b/data/intuos-s-p3-android.tablet
@@ -36,7 +36,6 @@ Styli=@intuospt3;
 [Features]
 Stylus=true
 Reversible=false
-Buttons=4
 
 [Buttons]
 Top=A;B;C;D

--- a/data/intuos-s-p3-wl-android.tablet
+++ b/data/intuos-s-p3-wl-android.tablet
@@ -36,7 +36,6 @@ Styli=@intuospt3;
 [Features]
 Stylus=true
 Reversible=false
-Buttons=4
 
 [Buttons]
 Top=A;B;C;D

--- a/data/intuos-s-p3-wl.tablet
+++ b/data/intuos-s-p3-wl.tablet
@@ -31,7 +31,6 @@ Styli=@intuospt3;
 [Features]
 Stylus=true
 Reversible=false
-Buttons=4
 
 [Buttons]
 Top=A;B;C;D

--- a/data/intuos-s-p3.tablet
+++ b/data/intuos-s-p3.tablet
@@ -31,7 +31,6 @@ Styli=@intuospt3;
 [Features]
 Stylus=true
 Reversible=false
-Buttons=4
 
 [Buttons]
 Top=A;B;C;D

--- a/data/intuos-s-pt.tablet
+++ b/data/intuos-s-pt.tablet
@@ -47,7 +47,6 @@ IntegratedIn=
 Stylus=true
 Reversible=false
 Touch=true
-Buttons=4
 TouchSwitch=true
 
 [Buttons]

--- a/data/intuos-s-pt2.tablet
+++ b/data/intuos-s-pt2.tablet
@@ -48,7 +48,6 @@ Styli=@intuospt;
 Stylus=true
 Reversible=false
 Touch=true
-Buttons=4
 TouchSwitch=true
 
 [Buttons]

--- a/data/intuos2-12x12.tablet
+++ b/data/intuos2-12x12.tablet
@@ -10,4 +10,3 @@ Styli=0x842;@intuos;@intuos2;
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/intuos2-12x18.tablet
+++ b/data/intuos2-12x18.tablet
@@ -14,4 +14,3 @@ Styli=0x842;@intuos;@intuos2;
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/intuos2-4x5.tablet
+++ b/data/intuos2-4x5.tablet
@@ -14,4 +14,3 @@ Styli=0x842;@intuos;@intuos2;
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/intuos2-6x8.tablet
+++ b/data/intuos2-6x8.tablet
@@ -15,4 +15,3 @@ Styli=0x842;@intuos;@intuos2;
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/intuos2-9x12.tablet
+++ b/data/intuos2-9x12.tablet
@@ -14,4 +14,3 @@ Styli=0x842;@intuos;@intuos2;
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/intuos3-12x12.tablet
+++ b/data/intuos3-12x12.tablet
@@ -42,7 +42,6 @@ Styli=@intuos3-pucks;@intuos3;
 [Features]
 Stylus=true
 NumStrips=2
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D

--- a/data/intuos3-12x19.tablet
+++ b/data/intuos3-12x19.tablet
@@ -42,7 +42,6 @@ Styli=@intuos3-pucks;@intuos3;
 [Features]
 Stylus=true
 NumStrips=2
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D

--- a/data/intuos3-4x5.tablet
+++ b/data/intuos3-4x5.tablet
@@ -42,7 +42,6 @@ Styli=@intuos3-pucks;@intuos3;
 [Features]
 Stylus=true
 NumStrips=1
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/intuos3-4x6.tablet
+++ b/data/intuos3-4x6.tablet
@@ -41,7 +41,6 @@ Styli=@intuos3-pucks;@intuos3;
 [Features]
 Stylus=true
 NumStrips=1
-Buttons=4
 
 [Buttons]
 Left=A;B;C;D

--- a/data/intuos3-6x11.tablet
+++ b/data/intuos3-6x11.tablet
@@ -41,7 +41,6 @@ Styli=@intuos3-pucks;@intuos3;
 [Features]
 Stylus=true
 NumStrips=2
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D

--- a/data/intuos3-6x8.tablet
+++ b/data/intuos3-6x8.tablet
@@ -41,7 +41,6 @@ Styli=@intuos3-pucks;@intuos3;
 [Features]
 Stylus=true
 NumStrips=2
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D

--- a/data/intuos3-9x12.tablet
+++ b/data/intuos3-9x12.tablet
@@ -41,7 +41,6 @@ Styli=@intuos3-pucks;@intuos3;
 [Features]
 Stylus=true
 NumStrips=2
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D

--- a/data/intuos4-12x19.tablet
+++ b/data/intuos4-12x19.tablet
@@ -47,7 +47,6 @@ Styli=@intuos4-lens;@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Reversible=true
 Stylus=true
 Ring=true
-Buttons=9
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos4-4x6.tablet
+++ b/data/intuos4-4x6.tablet
@@ -48,7 +48,6 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Reversible=true
 Stylus=true
 Ring=true
-Buttons=7
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos4-6x9-wl.tablet
+++ b/data/intuos4-6x9-wl.tablet
@@ -47,7 +47,6 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Reversible=true
 Stylus=true
 Ring=true
-Buttons=9
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos4-6x9.tablet
+++ b/data/intuos4-6x9.tablet
@@ -47,7 +47,6 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Reversible=true
 Stylus=true
 Ring=true
-Buttons=9
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos4-8x13.tablet
+++ b/data/intuos4-8x13.tablet
@@ -47,7 +47,6 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Reversible=true
 Stylus=true
 Ring=true
-Buttons=9
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos5-m.tablet
+++ b/data/intuos5-m.tablet
@@ -57,7 +57,6 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=9
 Ring=true
 StatusLEDs=Ring
 

--- a/data/intuos5-s.tablet
+++ b/data/intuos5-s.tablet
@@ -55,7 +55,6 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=7
 Ring=true
 StatusLEDs=Ring
 

--- a/data/intuos5-touch-l.tablet
+++ b/data/intuos5-touch-l.tablet
@@ -57,7 +57,6 @@ Styli=@intuos4-lens;@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=9
 Ring=true
 StatusLEDs=Ring
 

--- a/data/intuos5-touch-m.tablet
+++ b/data/intuos5-touch-m.tablet
@@ -57,7 +57,6 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=9
 Ring=true
 StatusLEDs=Ring
 

--- a/data/intuos5-touch-s.tablet
+++ b/data/intuos5-touch-s.tablet
@@ -55,7 +55,6 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Buttons=7
 Ring=true
 StatusLEDs=Ring
 

--- a/data/isdv4-016c.tablet
+++ b/data/isdv4-016c.tablet
@@ -19,4 +19,3 @@ Styli=@generic-with-eraser;@generic-no-eraser
 [Features]
 Stylus=true
 Touch=false
-Buttons=0

--- a/data/isdv4-100.tablet
+++ b/data/isdv4-100.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=false
 Touch=true
-Buttons=0

--- a/data/isdv4-101.tablet
+++ b/data/isdv4-101.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-104.tablet
+++ b/data/isdv4-104.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=false
-Buttons=0

--- a/data/isdv4-10d.tablet
+++ b/data/isdv4-10d.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-10e.tablet
+++ b/data/isdv4-10e.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-10f.tablet
+++ b/data/isdv4-10f.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-114.tablet
+++ b/data/isdv4-114.tablet
@@ -12,4 +12,3 @@ Height=5
 [Features]
 Stylus=true
 Touch=false
-Buttons=0

--- a/data/isdv4-116.tablet
+++ b/data/isdv4-116.tablet
@@ -10,4 +10,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-117.tablet
+++ b/data/isdv4-117.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-121a.tablet
+++ b/data/isdv4-121a.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-124.tablet
+++ b/data/isdv4-124.tablet
@@ -13,4 +13,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=false
-Buttons=0

--- a/data/isdv4-12c.tablet
+++ b/data/isdv4-12c.tablet
@@ -9,4 +9,3 @@ IntegratedIn=Display;System
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/isdv4-149.tablet
+++ b/data/isdv4-149.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-2d1f-001e.tablet
+++ b/data/isdv4-2d1f-001e.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/isdv4-2d1f-002c.tablet
+++ b/data/isdv4-2d1f-002c.tablet
@@ -19,4 +19,3 @@ Styli=@generic-with-eraser;
 [Features]
 Stylus=true
 Touch=false
-Buttons=0

--- a/data/isdv4-2d1f-002e.tablet
+++ b/data/isdv4-2d1f-002e.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/isdv4-2d1f-0040.tablet
+++ b/data/isdv4-2d1f-0040.tablet
@@ -20,4 +20,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-2d1f-0066.tablet
+++ b/data/isdv4-2d1f-0066.tablet
@@ -19,4 +19,3 @@ Styli=@generic-with-eraser;
 [Features]
 Stylus=true
 Touch=false
-Buttons=0

--- a/data/isdv4-2d1f-0095.tablet
+++ b/data/isdv4-2d1f-0095.tablet
@@ -19,4 +19,3 @@ Styli=@generic-with-eraser;
 [Features]
 Stylus=true
 Touch=false
-Buttons=0

--- a/data/isdv4-2d1f-0114.tablet
+++ b/data/isdv4-2d1f-0114.tablet
@@ -20,4 +20,3 @@ Styli=@generic-with-eraser;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-2d1f-0136.tablet
+++ b/data/isdv4-2d1f-0136.tablet
@@ -20,4 +20,3 @@ Styli=@generic-with-eraser;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-2d1f-0163.tablet
+++ b/data/isdv4-2d1f-0163.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=false
-Buttons=0

--- a/data/isdv4-2d1f-524c.tablet
+++ b/data/isdv4-2d1f-524c.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4004.tablet
+++ b/data/isdv4-4004.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4800.tablet
+++ b/data/isdv4-4800.tablet
@@ -11,4 +11,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4804.tablet
+++ b/data/isdv4-4804.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4806.tablet
+++ b/data/isdv4-4806.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4807.tablet
+++ b/data/isdv4-4807.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4809.tablet
+++ b/data/isdv4-4809.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4814.tablet
+++ b/data/isdv4-4814.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-481a.tablet
+++ b/data/isdv4-481a.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4822.tablet
+++ b/data/isdv4-4822.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4824.tablet
+++ b/data/isdv4-4824.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4831.tablet
+++ b/data/isdv4-4831.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4834.tablet
+++ b/data/isdv4-4834.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4838.tablet
+++ b/data/isdv4-4838.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4841.tablet
+++ b/data/isdv4-4841.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-484c.tablet
+++ b/data/isdv4-484c.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-484d.tablet
+++ b/data/isdv4-484d.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-484e.tablet
+++ b/data/isdv4-484e.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4851.tablet
+++ b/data/isdv4-4851.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-485e.tablet
+++ b/data/isdv4-485e.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4865.tablet
+++ b/data/isdv4-4865.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-486a.tablet
+++ b/data/isdv4-486a.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4870.tablet
+++ b/data/isdv4-4870.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4875.tablet
+++ b/data/isdv4-4875.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-488f.tablet
+++ b/data/isdv4-488f.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4898.tablet
+++ b/data/isdv4-4898.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-48c9.tablet
+++ b/data/isdv4-48c9.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-48ca.tablet
+++ b/data/isdv4-48ca.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-48ce.tablet
+++ b/data/isdv4-48ce.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-48d6.tablet
+++ b/data/isdv4-48d6.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-48eb.tablet
+++ b/data/isdv4-48eb.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-48ec.tablet
+++ b/data/isdv4-48ec.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-48ed.tablet
+++ b/data/isdv4-48ed.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-48ee.tablet
+++ b/data/isdv4-48ee.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-48f6.tablet
+++ b/data/isdv4-48f6.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-490a.tablet
+++ b/data/isdv4-490a.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-490b.tablet
+++ b/data/isdv4-490b.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4957.tablet
+++ b/data/isdv4-4957.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-495f.tablet
+++ b/data/isdv4-495f.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-496c.tablet
+++ b/data/isdv4-496c.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4988.tablet
+++ b/data/isdv4-4988.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-4995.tablet
+++ b/data/isdv4-4995.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-49a3.tablet
+++ b/data/isdv4-49a3.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-49c8.tablet
+++ b/data/isdv4-49c8.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5000.tablet
+++ b/data/isdv4-5000.tablet
@@ -10,4 +10,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5002.tablet
+++ b/data/isdv4-5002.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5010.tablet
+++ b/data/isdv4-5010.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5013.tablet
+++ b/data/isdv4-5013.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5014.tablet
+++ b/data/isdv4-5014.tablet
@@ -14,4 +14,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5019.tablet
+++ b/data/isdv4-5019.tablet
@@ -19,4 +19,3 @@ Styli=@generic-with-eraser;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-502a.tablet
+++ b/data/isdv4-502a.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-503e.tablet
+++ b/data/isdv4-503e.tablet
@@ -15,4 +15,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-503f.tablet
+++ b/data/isdv4-503f.tablet
@@ -15,4 +15,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5040.tablet
+++ b/data/isdv4-5040.tablet
@@ -16,4 +16,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5044.tablet
+++ b/data/isdv4-5044.tablet
@@ -16,4 +16,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5048.tablet
+++ b/data/isdv4-5048.tablet
@@ -15,4 +15,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-504a.tablet
+++ b/data/isdv4-504a.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-504c.tablet
+++ b/data/isdv4-504c.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5072.tablet
+++ b/data/isdv4-5072.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5090.tablet
+++ b/data/isdv4-5090.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5093.tablet
+++ b/data/isdv4-5093.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5099.tablet
+++ b/data/isdv4-5099.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-509d.tablet
+++ b/data/isdv4-509d.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-509f.tablet
+++ b/data/isdv4-509f.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-50a9.tablet
+++ b/data/isdv4-50a9.tablet
@@ -14,5 +14,4 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0
 

--- a/data/isdv4-50b4.tablet
+++ b/data/isdv4-50b4.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-50b6.tablet
+++ b/data/isdv4-50b6.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-50b8.tablet
+++ b/data/isdv4-50b8.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-50db.tablet
+++ b/data/isdv4-50db.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-50e9.tablet
+++ b/data/isdv4-50e9.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-50ef.tablet
+++ b/data/isdv4-50ef.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-50f1.tablet
+++ b/data/isdv4-50f1.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-50f8.tablet
+++ b/data/isdv4-50f8.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-50fd.tablet
+++ b/data/isdv4-50fd.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-50fe.tablet
+++ b/data/isdv4-50fe.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5110.tablet
+++ b/data/isdv4-5110.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5115.tablet
+++ b/data/isdv4-5115.tablet
@@ -12,4 +12,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-511a.tablet
+++ b/data/isdv4-511a.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5122.tablet
+++ b/data/isdv4-5122.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5128.tablet
+++ b/data/isdv4-5128.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-513b.tablet
+++ b/data/isdv4-513b.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5144.tablet
+++ b/data/isdv4-5144.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5146.tablet
+++ b/data/isdv4-5146.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5147.tablet
+++ b/data/isdv4-5147.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5148.tablet
+++ b/data/isdv4-5148.tablet
@@ -16,4 +16,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5150.tablet
+++ b/data/isdv4-5150.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5155.tablet
+++ b/data/isdv4-5155.tablet
@@ -16,4 +16,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5157.tablet
+++ b/data/isdv4-5157.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5158.tablet
+++ b/data/isdv4-5158.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5159.tablet
+++ b/data/isdv4-5159.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-515a.tablet
+++ b/data/isdv4-515a.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5169.tablet
+++ b/data/isdv4-5169.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-516b.tablet
+++ b/data/isdv4-516b.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-517d.tablet
+++ b/data/isdv4-517d.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5196.tablet
+++ b/data/isdv4-5196.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51a0.tablet
+++ b/data/isdv4-51a0.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51af.tablet
+++ b/data/isdv4-51af.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51b0.tablet
+++ b/data/isdv4-51b0.tablet
@@ -20,4 +20,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51b1.tablet
+++ b/data/isdv4-51b1.tablet
@@ -20,4 +20,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51b2.tablet
+++ b/data/isdv4-51b2.tablet
@@ -20,4 +20,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51b3.tablet
+++ b/data/isdv4-51b3.tablet
@@ -20,4 +20,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51b6.tablet
+++ b/data/isdv4-51b6.tablet
@@ -20,4 +20,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51b7.tablet
+++ b/data/isdv4-51b7.tablet
@@ -20,4 +20,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51b8.tablet
+++ b/data/isdv4-51b8.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51b9.tablet
+++ b/data/isdv4-51b9.tablet
@@ -20,4 +20,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51ba.tablet
+++ b/data/isdv4-51ba.tablet
@@ -15,4 +15,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51bb.tablet
+++ b/data/isdv4-51bb.tablet
@@ -20,4 +20,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51bc.tablet
+++ b/data/isdv4-51bc.tablet
@@ -20,4 +20,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51bd.tablet
+++ b/data/isdv4-51bd.tablet
@@ -15,4 +15,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51be.tablet
+++ b/data/isdv4-51be.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51bf.tablet
+++ b/data/isdv4-51bf.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51c4.tablet
+++ b/data/isdv4-51c4.tablet
@@ -13,4 +13,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51c7.tablet
+++ b/data/isdv4-51c7.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51d0.tablet
+++ b/data/isdv4-51d0.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51e2.tablet
+++ b/data/isdv4-51e2.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51e9.tablet
+++ b/data/isdv4-51e9.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51ef.tablet
+++ b/data/isdv4-51ef.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51f5.tablet
+++ b/data/isdv4-51f5.tablet
@@ -14,4 +14,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51f6.tablet
+++ b/data/isdv4-51f6.tablet
@@ -14,4 +14,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-51f9.tablet
+++ b/data/isdv4-51f9.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5202.tablet
+++ b/data/isdv4-5202.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5204.tablet
+++ b/data/isdv4-5204.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5215.tablet
+++ b/data/isdv4-5215.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5216.tablet
+++ b/data/isdv4-5216.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5218.tablet
+++ b/data/isdv4-5218.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-521c.tablet
+++ b/data/isdv4-521c.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-521f.tablet
+++ b/data/isdv4-521f.tablet
@@ -20,4 +20,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5220.tablet
+++ b/data/isdv4-5220.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5221.tablet
+++ b/data/isdv4-5221.tablet
@@ -20,4 +20,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5222.tablet
+++ b/data/isdv4-5222.tablet
@@ -20,4 +20,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5229.tablet
+++ b/data/isdv4-5229.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-523a.tablet
+++ b/data/isdv4-523a.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-523e.tablet
+++ b/data/isdv4-523e.tablet
@@ -18,4 +18,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5256.tablet
+++ b/data/isdv4-5256.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-526c.tablet
+++ b/data/isdv4-526c.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5276.tablet
+++ b/data/isdv4-5276.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5277.tablet
+++ b/data/isdv4-5277.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5278.tablet
+++ b/data/isdv4-5278.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5279.tablet
+++ b/data/isdv4-5279.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-527a.tablet
+++ b/data/isdv4-527a.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-527e.tablet
+++ b/data/isdv4-527e.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-527f.tablet
+++ b/data/isdv4-527f.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5285.tablet
+++ b/data/isdv4-5285.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-5286.tablet
+++ b/data/isdv4-5286.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-528e.tablet
+++ b/data/isdv4-528e.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-52a2.tablet
+++ b/data/isdv4-52a2.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-52b0.tablet
+++ b/data/isdv4-52b0.tablet
@@ -19,4 +19,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-52d3.tablet
+++ b/data/isdv4-52d3.tablet
@@ -16,4 +16,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-52d5.tablet
+++ b/data/isdv4-52d5.tablet
@@ -17,5 +17,4 @@ Reversible=false
 Stylus=true
 Touch=true
 Ring=false
-Buttons=0
 BuiltIn=true

--- a/data/isdv4-90.tablet
+++ b/data/isdv4-90.tablet
@@ -16,4 +16,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=false
-Buttons=0

--- a/data/isdv4-93.tablet
+++ b/data/isdv4-93.tablet
@@ -16,4 +16,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-e2.tablet
+++ b/data/isdv4-e2.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=false
-Buttons=0

--- a/data/isdv4-e3.tablet
+++ b/data/isdv4-e3.tablet
@@ -10,4 +10,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-e5.tablet
+++ b/data/isdv4-e5.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=false
 Touch=true
-Buttons=0

--- a/data/isdv4-e6.tablet
+++ b/data/isdv4-e6.tablet
@@ -12,4 +12,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-ec.tablet
+++ b/data/isdv4-ec.tablet
@@ -12,4 +12,3 @@ PairedID=usb:04f3:0254
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-ed.tablet
+++ b/data/isdv4-ed.tablet
@@ -10,4 +10,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/isdv4-ef.tablet
+++ b/data/isdv4-ef.tablet
@@ -9,4 +9,3 @@ IntegratedIn=Display;System
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/kamvas-pro-13.tablet
+++ b/data/kamvas-pro-13.tablet
@@ -50,7 +50,6 @@ Stylus=true
 Reversible=false
 Touch=false
 Ring=false
-Buttons=5
 
 [Buttons]
 Left=A;B;C;D;E

--- a/data/letsketch-wp9620.tablet
+++ b/data/letsketch-wp9620.tablet
@@ -17,4 +17,3 @@ IntegratedIn=
 [Features]
 Stylus=true
 Reversible=true
-Buttons=0

--- a/data/mobilestudio-pro-13-2.tablet
+++ b/data/mobilestudio-pro-13-2.tablet
@@ -49,7 +49,6 @@ IntegratedIn=Display;System
 Stylus=true
 Touch=true
 Ring=true
-Buttons=11
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H;I;J;K

--- a/data/mobilestudio-pro-13.tablet
+++ b/data/mobilestudio-pro-13.tablet
@@ -49,7 +49,6 @@ IntegratedIn=Display;System
 Stylus=true
 Touch=true
 Ring=true
-Buttons=11
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H;I;J;K

--- a/data/mobilestudio-pro-16-2.tablet
+++ b/data/mobilestudio-pro-16-2.tablet
@@ -51,7 +51,6 @@ IntegratedIn=Display;System
 Stylus=true
 Touch=true
 Ring=true
-Buttons=13
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H;I;J;K;L;M

--- a/data/mobilestudio-pro-16-3.tablet
+++ b/data/mobilestudio-pro-16-3.tablet
@@ -51,7 +51,6 @@ IntegratedIn=Display;System
 Stylus=true
 Touch=true
 Ring=true
-Buttons=13
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H;I;J;K;L;M

--- a/data/mobilestudio-pro-16.tablet
+++ b/data/mobilestudio-pro-16.tablet
@@ -51,7 +51,6 @@ IntegratedIn=Display;System
 Stylus=true
 Touch=true
 Ring=true
-Buttons=13
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H;I;J;K;L;M

--- a/data/n-trig-pen.tablet
+++ b/data/n-trig-pen.tablet
@@ -17,4 +17,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/one-by-wacom-m-p.tablet
+++ b/data/one-by-wacom-m-p.tablet
@@ -21,4 +21,3 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=0

--- a/data/one-by-wacom-m-p2.tablet
+++ b/data/one-by-wacom-m-p2.tablet
@@ -21,4 +21,3 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=0

--- a/data/one-by-wacom-s-p.tablet
+++ b/data/one-by-wacom-s-p.tablet
@@ -21,4 +21,3 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=0

--- a/data/one-by-wacom-s-p2.tablet
+++ b/data/one-by-wacom-s-p2.tablet
@@ -21,4 +21,3 @@ IntegratedIn=
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=0

--- a/data/serial-wacf004.tablet
+++ b/data/serial-wacf004.tablet
@@ -8,4 +8,3 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Ring=false
-Buttons=0

--- a/data/surface-go-2.tablet
+++ b/data/surface-go-2.tablet
@@ -16,4 +16,3 @@ IntegratedIn=Display;System;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/surface-go.tablet
+++ b/data/surface-go.tablet
@@ -15,4 +15,3 @@ IntegratedIn=Display;System;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0

--- a/data/volito-4x5.tablet
+++ b/data/volito-4x5.tablet
@@ -13,4 +13,3 @@ Styli=@generic-no-eraser;
 
 [Features]
 Stylus=true
-Buttons=0

--- a/data/wacom-hid-52fa-pen.tablet
+++ b/data/wacom-hid-52fa-pen.tablet
@@ -20,4 +20,3 @@ Stylus=true
 Reversible=false
 Touch=true
 Ring=false
-Buttons=0

--- a/data/wacom-one-12.tablet
+++ b/data/wacom-one-12.tablet
@@ -20,4 +20,3 @@ Stylus=true
 Reversible=false
 Touch=false
 Ring=false
-Buttons=0

--- a/data/wacom-one-13.tablet
+++ b/data/wacom-one-13.tablet
@@ -20,4 +20,3 @@ Stylus=true
 Reversible=false
 Touch=true
 Ring=false
-Buttons=0

--- a/data/wacom-one-pen-m.tablet
+++ b/data/wacom-one-pen-m.tablet
@@ -28,4 +28,3 @@ IntegratedIn=
 Stylus=true
 Reversible=false
 Touch=false
-Buttons=0

--- a/data/wacom-one-pen-s.tablet
+++ b/data/wacom-one-pen-s.tablet
@@ -28,4 +28,3 @@ IntegratedIn=
 Stylus=true
 Reversible=false
 Touch=false
-Buttons=0

--- a/data/wacom-one.tablet
+++ b/data/wacom-one.tablet
@@ -17,4 +17,3 @@ Stylus=true
 Reversible=false
 Touch=false
 Ring=false
-Buttons=0

--- a/data/wacom.example
+++ b/data/wacom.example
@@ -166,7 +166,6 @@ Ring2=false
 NumStrips=1
 
 # Number of buttons on the tablet
-Buttons=9
 
 # Metadata about the buttons on the tablet
 # Buttons are "numbered" using upper-case letters

--- a/data/waltop-slim-tablet-12-1.tablet
+++ b/data/waltop-slim-tablet-12-1.tablet
@@ -20,4 +20,3 @@ Styli=@generic-no-eraser;
 Stylus=true
 Reversible=false
 Touch=false
-Buttons=0

--- a/data/xp-pen-artist12.tablet
+++ b/data/xp-pen-artist12.tablet
@@ -24,7 +24,6 @@ TouchSwitch=false
 Ring=false
 Ring2=false
 NumStrips=1
-Buttons=6
 
 [Buttons]
 Left=A;B;C;D;E;F

--- a/data/xp-pen-deco-l.tablet
+++ b/data/xp-pen-deco-l.tablet
@@ -24,7 +24,6 @@ TouchSwitch=false
 Ring=false
 Ring2=false
 NumStrips=0
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H

--- a/data/xp-pen-deco-mini7.tablet
+++ b/data/xp-pen-deco-mini7.tablet
@@ -18,7 +18,6 @@ Styli=@generic-no-eraser;
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H

--- a/data/xp-pen-deco-mw.tablet
+++ b/data/xp-pen-deco-mw.tablet
@@ -22,7 +22,6 @@ TouchSwitch=false
 Ring=false
 Ring2=false
 NumStrips=0
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H

--- a/data/xp-pen-deco-pro-mw.tablet
+++ b/data/xp-pen-deco-pro-mw.tablet
@@ -36,7 +36,6 @@ Touch=false
 Ring=true
 Ring2=false
 NumStrips=0
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H

--- a/data/xp-pen-deco-pro-sw.tablet
+++ b/data/xp-pen-deco-pro-sw.tablet
@@ -23,7 +23,6 @@ Touch=false
 Ring=true
 Ring2=false
 NumStrips=0
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H

--- a/data/xp-pen-deco01-v2.tablet
+++ b/data/xp-pen-deco01-v2.tablet
@@ -24,7 +24,6 @@ TouchSwitch=false
 Ring=false
 Ring2=false
 NumStrips=0
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H

--- a/data/xp-pen-g430.tablet
+++ b/data/xp-pen-g430.tablet
@@ -15,4 +15,3 @@ Styli=@generic-no-eraser;
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=0

--- a/data/xp-pen-g640.tablet
+++ b/data/xp-pen-g640.tablet
@@ -15,5 +15,4 @@ Styli=@generic-no-eraser;
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=0
 

--- a/data/xp-pen-star03.tablet
+++ b/data/xp-pen-star03.tablet
@@ -17,7 +17,6 @@ Styli=@generic-no-eraser;
 Stylus=true
 Reversible=true
 Touch=false
-Buttons=8
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -591,6 +591,9 @@ libwacom_parse_buttons(WacomDevice *device,
 {
 	guint i;
 
+	if (!g_key_file_has_group(keyfile, BUTTONS_GROUP))
+		return;
+
 	for (i = 0; i < G_N_ELEMENTS (options); i++)
 		libwacom_parse_buttons_key(device, keyfile, options[i].key, options[i].flag);
 
@@ -661,7 +664,6 @@ libwacom_parse_tablet_keyfile(WacomDeviceDatabase *db,
 	char *paired;
 	char **string_list;
 	bool success = FALSE;
-	int num_buttons;
 
 	keyfile = g_key_file_new();
 
@@ -799,17 +801,9 @@ libwacom_parse_tablet_keyfile(WacomDeviceDatabase *db,
 
 	device->num_strips = g_key_file_get_integer(keyfile, FEATURES_GROUP, "NumStrips", NULL);
 
-	num_buttons = g_key_file_get_integer(keyfile, FEATURES_GROUP, "Buttons", &error);
-	if (num_buttons == 0 &&
-	    g_error_matches (error, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
-		g_warning ("Tablet '%s' has no buttons defined, do something!", libwacom_get_match(device));
-		g_clear_error (&error);
-	}
-
 	device->buttons = g_hash_table_new_full(g_direct_hash, g_direct_equal,
 						NULL, g_free);
-	if (num_buttons > 0)
-		libwacom_parse_buttons(device, keyfile);
+	libwacom_parse_buttons(device, keyfile);
 
 	device->status_leds = g_array_new (FALSE, FALSE, sizeof(WacomStatusLEDs));
 	string_list = g_key_file_get_string_list(keyfile, FEATURES_GROUP, "StatusLEDs", NULL, NULL);

--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -886,7 +886,6 @@ libwacom_print_device_description(int fd, const WacomDevice *device)
 	print_supported_leds(fd, device);
 
 	dprintf(fd, "NumStrips=%d\n",	libwacom_get_num_strips(device));
-	dprintf(fd, "Buttons=%d\n",		libwacom_get_num_buttons(device));
 	dprintf(fd, "\n");
 
 	print_buttons_for_device(fd, device);
@@ -1354,7 +1353,6 @@ libwacom_print_stylus_description (int fd, const WacomStylus *stylus)
 
 	dprintf(fd, "[%#x]\n",		libwacom_stylus_get_id(stylus));
 	dprintf(fd, "Name=%s\n",	libwacom_stylus_get_name(stylus));
-	dprintf(fd, "Buttons=%d\n",	libwacom_stylus_get_num_buttons(stylus));
 	dprintf(fd, "PairedIds=");
 	paired_ids = libwacom_stylus_get_paired_ids(stylus, &count);
 	for (i = 0; i < count; i++) {

--- a/test/test_data_files.py
+++ b/test/test_data_files.py
@@ -87,7 +87,13 @@ def test_button_evcodes(tabletfile):
     config.read(tabletfile)
 
     try:
-        nbuttons = int(config["Features"]["Buttons"])
+        nbuttons = 0
+        for where in ["Top", "Bottom", "Left", "Right"]:
+            try:
+                buttons = config["Buttons"][where]
+                nbuttons += len([s for s in buttons.split(";") if s])
+            except KeyError:
+                pass
         str = config["Buttons"]["EvdevCodes"]
         codes = [
             c for c in str.split(";") if c

--- a/tools/libwacom-update-db.py
+++ b/tools/libwacom-update-db.py
@@ -147,10 +147,7 @@ class TabletDatabase:
                         )
                 except KeyError:
                     pass
-                try:
-                    t.has_pad = int(config["Features"]["Buttons"]) > 0
-                except KeyError:
-                    pass
+                t.has_pad = config.has_section("Buttons")
                 yield t
 
 


### PR DESCRIPTION
IIRC this entry dates back to very early versions before we added the separate `Buttons` section. It's superfluous though, the number of buttons can be inferred from that section.

Sits on top of #594 but it's technically unrelated to that.