### PR TITLE
CI: fix the pages job for the new libevdev dependency

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 env:
-  UBUNTU_PACKAGES: libgudev-1.0-dev libxml++2.6-dev valgrind tree python3-pip python3-setuptools libevdev2 doxygen
+  UBUNTU_PACKAGES: libgudev-1.0-dev libxml++2.6-dev valgrind tree python3-pip python3-setuptools libevdev-dev doxygen
   PIP_PACKAGES: meson ninja libevdev pyudev pytest yq
 
 jobs:


### PR DESCRIPTION
Missing devel dependency added in cc7cc58714a2bf2a7e34e26dab7a6d2f1471c9d2