### PR TITLE
data: Add XP-Pen Artist 13.3 Pro

### DIFF
--- a/data/layouts/xp-pen-artist13-3-pro.svg
+++ b/data/layouts/xp-pen-artist13-3-pro.svg
@@ -13,38 +13,38 @@
     <rect
        id="ButtonA"
        class="A Button"
-       x="26.0"
-       y="93.5"
+       x="25.0"
+       y="88.5"
        width="30.5"
        height="19.5" />
     <path
        id="LeaderA"
        class="A Leader"
-       d="M 61.0 109.413276H 90.0 Z" />
+       d="M 61.0 104.413276H 90.0 Z" />
     <text
        id="LabelA"
        class="A Label"
        x="90.5"
-       y="109.0"
+       y="104.0"
        style="text-anchor:start;">A</text>
   </g>
   <g>
     <rect
        id="ButtonB"
        class="B Button"
-       x="26.5"
-       y="119.0"
+       x="25.0"
+       y="112.0"
        width="30.5"
        height="19.5" />
     <path
        id="LeaderB"
        class="B Leader"
-       d="M 61.5 135.0217421H 90.0 Z" />
+       d="M 61.5 127.0217421H 90.0 Z" />
     <text
        id="LabelB"
        class="B Label"
        x="91.0"
-       y="134.5"
+       y="127.5"
        style="text-anchor:start;">B</text>
   </g>
   <g>
@@ -52,37 +52,37 @@
        id="ButtonC"
        class="C Button"
        x="25.0"
-       y="142.5"
+       y="135.5"
        width="30.5"
        height="19.5" />
     <path
        id="LeaderC"
        class="C Leader"
-       d="M 60.0 158.573682H 90.0 Z" />
+       d="M 60.0 151.573682H 90.0 Z" />
     <text
        id="LabelC"
        class="C Label"
-       x="89.5"
-       y="158.0"
+       x="90.5"
+       y="151.0"
        style="text-anchor:start;">C</text>
   </g>
   <g>
     <rect
        id="ButtonD"
        class="D Button"
-       x="26.0"
-       y="166.5"
+       x="25.0"
+       y="159.5"
        width="30.5"
        height="19.5" />
     <path
        id="LeaderD"
        class="D Leader"
-       d="M 61.0 182.377185H 90.0 Z" />
+       d="M 61.0 175.377185H 90.0 Z" />
     <text
        id="LabelD"
        class="D Label"
        x="90.5"
-       y="182.0"
+       y="175.0"
        style="text-anchor:start;">D</text>
   </g>
   <g>
@@ -99,7 +99,7 @@
     <path
        id="RingCCW"
        class="RingCCW Button"
-       d="m 35.5 206.5 4.0 -2.0 v 1.5 a 9.5 9.5 0.0 0.0 1.0 6.5 2.0 8.5 8.5 0.0 0.0 0.0 -6.5 -0.5 v 1.5 z" />
+       d="m 35.553343,206.65045 3.821656,-1.91083 v 1.27389 a 9.5541398,9.5541399 0 0 1 6.369426,1.91083 8.2802545,8.2802546 0 0 0 -6.369426,-0.63694 v 1.27388 z" />
     <path
        id="LeaderRingCW"
        class="RingCW Ring Leader"
@@ -107,13 +107,13 @@
     <path
        id="RingCW"
        class="RingCW Button"
-       d="m 35.5 242.5 4.0 -2.0 v 1.5 a 9.5 9.5 0.0 0.0 0.0 6.5 -1.5 8.5 8.5 0.0 0.0 1.0 -6.5 2.5 v 1.5 z" />
+       d="m 35.553343,242.31924 3.821656,-1.91082 v 1.27387 a 9.5541398,9.5541399 0 0 0 6.369426,-1.27387 8.2802545,8.2802546 0 0 1 -6.369426,2.54777 v 1.27388 z" />
     <text
        id="LabelRingCCW"
        class="RingCCW Ring Label"
        x="94.5"
        y="196.0"
-       style="text-anchor:start;">Ring</text>
+       style="text-anchor:start;">CCW</text>
     <text
        id="LabelRingCW"
        class="RingCW Ring Label"
@@ -164,37 +164,37 @@
        id="ButtonG"
        class="G Button"
        x="25.0"
-       y="142.5"
+       y="318"
        width="30.5"
        height="19.5" />
     <path
        id="LeaderG"
        class="G Leader"
-       d="M 60.0 158.573682H 90.0 Z" />
+       d="M 60.0 333.9004H 90.0 Z" />
     <text
        id="LabelG"
        class="G Label"
        x="89.5"
-       y="158.0"
+       y="333.0"
        style="text-anchor:start;">G</text>
   </g>
   <g>
     <rect
        id="ButtonH"
        class="H Button"
-       x="26.0"
-       y="166.5"
+       x="25.0"
+       y="342.5"
        width="30.5"
        height="19.5" />
     <path
        id="LeaderH"
        class="H Leader"
-       d="M 61.0 182.377185H 90.0 Z" />
+       d="M 61.0 358.2804H 90.0 Z" />
     <text
        id="LabelH"
        class="H Label"
        x="90.5"
-       y="182.0"
+       y="357.0"
        style="text-anchor:start;">H</text>
   </g>
 </svg>

--- a/data/layouts/xp-pen-artist13-3-pro.svg
+++ b/data/layouts/xp-pen-artist13-3-pro.svg
@@ -1,0 +1,200 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg
+   id="xp-pen-artist-13.3-pro"
+   width="623.0"
+   height="462.0"
+   style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
+   version="1.1"
+   xmlns="http://www.w3.org/2000/svg">
+   <title id="title">XP-Pen Artist 13.3 Pro</title>
+  <g>
+    <rect
+       id="ButtonA"
+       class="A Button"
+       x="26.0"
+       y="93.5"
+       width="30.5"
+       height="19.5" />
+    <path
+       id="LeaderA"
+       class="A Leader"
+       d="M 61.0 109.413276H 90.0 Z" />
+    <text
+       id="LabelA"
+       class="A Label"
+       x="90.5"
+       y="109.0"
+       style="text-anchor:start;">A</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonB"
+       class="B Button"
+       x="26.5"
+       y="119.0"
+       width="30.5"
+       height="19.5" />
+    <path
+       id="LeaderB"
+       class="B Leader"
+       d="M 61.5 135.0217421H 90.0 Z" />
+    <text
+       id="LabelB"
+       class="B Label"
+       x="91.0"
+       y="134.5"
+       style="text-anchor:start;">B</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonC"
+       class="C Button"
+       x="25.0"
+       y="142.5"
+       width="30.5"
+       height="19.5" />
+    <path
+       id="LeaderC"
+       class="C Leader"
+       d="M 60.0 158.573682H 90.0 Z" />
+    <text
+       id="LabelC"
+       class="C Label"
+       x="89.5"
+       y="158.0"
+       style="text-anchor:start;">C</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonD"
+       class="D Button"
+       x="26.0"
+       y="166.5"
+       width="30.5"
+       height="19.5" />
+    <path
+       id="LeaderD"
+       class="D Leader"
+       d="M 61.0 182.377185H 90.0 Z" />
+    <text
+       id="LabelD"
+       class="D Label"
+       x="90.5"
+       y="182.0"
+       style="text-anchor:start;">D</text>
+  </g>
+  <g>
+    <circle
+       id="Ring"
+       class="Ring TouchRing"
+       cx="39.5"
+       cy="224.5"
+       r="25.0" />
+    <path
+       id="LeaderRingCCW"
+       class="RingCCW Ring Leader"
+       d="M 40.5 198.0 V 193.5 h 49.5" />
+    <path
+       id="RingCCW"
+       class="RingCCW Button"
+       d="m 35.5 206.5 4.0 -2.0 v 1.5 a 9.5 9.5 0.0 0.0 1.0 6.5 2.0 8.5 8.5 0.0 0.0 0.0 -6.5 -0.5 v 1.5 z" />
+    <path
+       id="LeaderRingCW"
+       class="RingCW Ring Leader"
+       d="m 40.5 250.5 v 4.5 H 90.0" />
+    <path
+       id="RingCW"
+       class="RingCW Button"
+       d="m 35.5 242.5 4.0 -2.0 v 1.5 a 9.5 9.5 0.0 0.0 0.0 6.5 -1.5 8.5 8.5 0.0 0.0 1.0 -6.5 2.5 v 1.5 z" />
+    <text
+       id="LabelRingCCW"
+       class="RingCCW Ring Label"
+       x="94.5"
+       y="196.0"
+       style="text-anchor:start;">Ring</text>
+    <text
+       id="LabelRingCW"
+       class="RingCW Ring Label"
+       x="94.5"
+       y="258.0"
+       style="text-anchor:start;">CW</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonE"
+       class="E Button"
+       x="25.0"
+       y="269.0"
+       width="30.5"
+       height="19.5" />
+    <path
+       id="LeaderE"
+       class="E Leader"
+       d="M 60.0 285.26162999999997H 90.0 Z" />
+    <text
+       id="LabelE"
+       class="E Label"
+       x="89.5"
+       y="285.0"
+       style="text-anchor:start;">E</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonF"
+       class="F Button"
+       x="25.0"
+       y="293.5"
+       width="30.5"
+       height="19.5" />
+    <path
+       id="LeaderF"
+       class="F Leader"
+       d="M 60.0 309.58293000000003H 90.0 Z" />
+    <text
+       id="LabelF"
+       class="F Label"
+       x="89.5"
+       y="309.0"
+       style="text-anchor:start;">F</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonG"
+       class="G Button"
+       x="25.0"
+       y="142.5"
+       width="30.5"
+       height="19.5" />
+    <path
+       id="LeaderG"
+       class="G Leader"
+       d="M 60.0 158.573682H 90.0 Z" />
+    <text
+       id="LabelG"
+       class="G Label"
+       x="89.5"
+       y="158.0"
+       style="text-anchor:start;">G</text>
+  </g>
+  <g>
+    <rect
+       id="ButtonH"
+       class="H Button"
+       x="26.0"
+       y="166.5"
+       width="30.5"
+       height="19.5" />
+    <path
+       id="LeaderH"
+       class="H Leader"
+       d="M 61.0 182.377185H 90.0 Z" />
+    <text
+       id="LabelH"
+       class="H Label"
+       x="90.5"
+       y="182.0"
+       style="text-anchor:start;">H</text>
+  </g>
+</svg>

--- a/data/xp-pen-artist13-3-pro.tablet
+++ b/data/xp-pen-artist13-3-pro.tablet
@@ -1,0 +1,30 @@
+# XP-Pen
+# Artist 13.3 Pro
+#
+# sysinfo.WaL7UDEPSP
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/334
+
+[Device]
+Name=UGTABLET 13.3 inch PenDisplay
+ModelName=
+DeviceMatch= usb:28bd:092b
+PairedIDs=
+Class=Bamboo
+Width=11
+Height=6
+IntegratedIn=Display
+Layout=xp-pen-artist13-3-pro.svg
+Styli=@generic-no-eraser;
+
+[Features]
+Stylus=true
+Reversible=false
+Touch=false
+TouchSwitch=false
+Ring=true
+Ring2=false
+NumStrips=0
+
+[Buttons]
+Left=A;B;C;D;E;F;G;H
+EvdevCodes=0x100;0x101;0x102;0x103;0x104;0x105;0x106;0x107

--- a/data/xp-pen-artist13-3-pro.tablet
+++ b/data/xp-pen-artist13-3-pro.tablet
@@ -27,4 +27,4 @@ NumStrips=0
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H
-EvdevCodes=0x100;0x101;0x102;0x103;0x104;0x105;0x106;0x107
+EvdevCodes=BTN_0;BTN_1;BTN_2;BTN_3;BTN_4;BTN_5;BTN_6;BTN_7

--- a/data/xp-pen-artist13-3-pro.tablet
+++ b/data/xp-pen-artist13-3-pro.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=UGTABLET 13.3 inch PenDisplay
 ModelName=
-DeviceMatch= usb:28bd:092b
+DeviceMatch=usb:28bd:092b
 PairedIDs=
 Class=Bamboo
 Width=11


### PR DESCRIPTION
Hi! I've created a .tablet and layout file for the [XP-Pen Artist 13.3 Pro](https://www.xp-pen.com/product/artist-13-3-pro.html)

The HID Descriptor is here; [linuxwacom/wacom-hid-descriptors#334](https://github.com/linuxwacom/wacom-hid-descriptors/issues/334)

I tried to create the .tablet file based off of the existing Artist 12 and Deco Pro MW files since those tablets are similar, but I'm not sure if I've done everything right.

The tablet shows up in KDE Wayland's Tablet settings, and everything seems to work except that I can't map any of the tablet's buttons; only the stylus buttons seem to show up. (3 stylus buttons show up, when there are only 2 on the actual stylus)

When I run `libwacom-list-local-devices` I get the following:
```
devices:
- name: 'UGTABLET 13.3 inch PenDisplay'
  bus: 'usb'
  vid: '0x28bd'
  pid: '0x092b'
  nodes: 
  - /dev/input/event4: 'UGTABLET 13.3 inch PenDisplay'
  - /dev/input/event2: 'UGTABLET 13.3 inch PenDisplay Mouse' 
```

When I run `evtest` I also see a `/dev/input/event3` which shows up as UGTABLET 13.3 inch PenDisplay Keyboard, which seems to be where the buttons on the tablet are registering input

I was hoping for a bit of help with this.

Thanks
