### PR TITLE
data: Add isdv-48b7

### DIFF
--- a/data/isdv4-48b7.tablet
+++ b/data/isdv4-48b7.tablet
@@ -1,4 +1,7 @@
 # Active electrostatic (AES) sensor used by the HP EliteBook x360 1040 G5
+#
+# sysinfo.XkevsUVUax.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/338
 
 [Device]
 Name=Wacom ISDv4 48b7

--- a/data/isdv4-48b7.tablet
+++ b/data/isdv4-48b7.tablet
@@ -1,0 +1,16 @@
+# Active electrostatic (AES) sensor used by the HP EliteBook x360 1040 G5
+
+[Device]
+Name=Wacom ISDv4 48b7
+ModelName=
+DeviceMatch=i2c:056a:48b7
+Class=ISDV4
+Width=12
+Height=7
+IntegratedIn=Display;System
+Styli=@isdv4-aes;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0

--- a/data/isdv4-48b7.tablet
+++ b/data/isdv4-48b7.tablet
@@ -16,4 +16,3 @@ Styli=@isdv4-aes;
 [Features]
 Stylus=true
 Touch=true
-Buttons=0


### PR DESCRIPTION
Add tablet of HP EliteBook x360 1040 G5

The file `isdv4-48b7.tablet` is a copy with small modifications of `isdv4-48c9.tablet` that is already in the database.