### PR TITLE
libwacom: only memcmp the led data if we have leds

### DIFF
--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -495,7 +495,8 @@ libwacom_compare(const WacomDevice *a, const WacomDevice *b, WacomCompareFlags f
 	if (a->status_leds->len != b->status_leds->len)
 		return 1;
 
-	if (memcmp(a->status_leds->data, b->status_leds->data,
+	if (a->status_leds->len > 0 &&
+	    memcmp(a->status_leds->data, b->status_leds->data,
 		   sizeof(WacomStatusLEDs) * a->status_leds->len) != 0)
 		return 1;
 


### PR DESCRIPTION
../libwacom/libwacom.c:498:13: runtime error: null pointer passed as argument 1, which is declared to never be null
/usr/include/string.h:65:33: note: nonnull attribute specified here


Found in #604 