### PR TITLE
github: Minimize permissions granted to automated workflows / jobs

### DIFF
--- a/.github/workflows/check-for-sysinfo.yml
+++ b/.github/workflows/check-for-sysinfo.yml
@@ -2,6 +2,9 @@ name: "Check for sysinfo in data files"
 
 on: [ pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   checksysinfo:
     runs-on: ubuntu-22.04

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -2,6 +2,9 @@ name: "FreeBSD build and test"
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 jobs:
   ###
   #

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: "Build and test"
 
 on: [ push, pull_request ]
 
+permissions:
+  contents: read
+
 env:
   CFLAGS: "-Werror -Wno-error=missing-field-initializers"
   UBUNTU_PACKAGES: libgudev-1.0-dev libxml++2.6-dev valgrind tree python3-pip python3-setuptools libevdev-dev

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 env:
   UBUNTU_PACKAGES: libgudev-1.0-dev libxml++2.6-dev valgrind tree python3-pip python3-setuptools libevdev-dev doxygen
   PIP_PACKAGES: meson ninja libevdev pyudev pytest yq
@@ -12,6 +15,8 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pkginstall


### PR DESCRIPTION
Jobs that use the GITHUB_TOKEN to perform sensitive actions on behalf of a real user may be granted a range of permissions. Instead of granting blanket permissions to read and write "all" APIs, we should really limit the permissions what any individual workflow or job can do.

This commit sets the default permissions for each workflow to "contents: read", which allows jobs to only read from the repository. The one job that requires additional permission is our "deploy" job which additionally requires write access.

Link: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions