### PR TITLE
Update gaomon-s620.tablet

### DIFF
--- a/data/gaomon-s620.tablet
+++ b/data/gaomon-s620.tablet
@@ -11,7 +11,7 @@
 [Device]
 Name=GAOMON S620
 ModelName=
-DeviceMatch=usb:256c:006d:GAOMON Gaomon Tablet Pen;usb:256c:006d:GAOMON Gaomon Tablet Pad;
+DeviceMatch=usb:256c:006f:GAOMON Gaomon Tablet;usb:256c:006d:GAOMON Gaomon Tablet Pen;usb:256c:006d:GAOMON Gaomon Tablet Pad;
 Class=Bamboo
 Width=6
 Height=4


### PR DESCRIPTION
I updated the tablet firmware (through the windows tool) and now it displays as ' ID 256c:006f GAOMON Gaomon Tablet '
with lsusb, but the device is still not working on GNOME