### PR TITLE
data: Update ModelName for DTH134 and DTC121

### DIFF
--- a/data/dtc-121.tablet
+++ b/data/dtc-121.tablet
@@ -7,7 +7,7 @@
 
 [Device]
 Name=Wacom DTC121
-ModelName=DTC-121
+ModelName=DTC121
 Class=PenDisplay
 DeviceMatch=usb:056a:03ed
 Width=11

--- a/data/dth-134.tablet
+++ b/data/dth-134.tablet
@@ -7,7 +7,7 @@
 
 [Device]
 Name=Wacom DTH134
-ModelName=DTH-134
+ModelName=DTH134
 Class=PenDisplay
 DeviceMatch=usb:056a:03ec
 Width=13


### PR DESCRIPTION
The model numbers for these devices likely should not include a hyphen.