### PR TITLE
data: Add Wacom HID-5362

### DIFF
--- a/data/wacom-hid-5362.tablet
+++ b/data/wacom-hid-5362.tablet
@@ -1,0 +1,20 @@
+# Wacom
+# Wacom HID 5362
+#
+# sysinfo.oMdWcZJ918
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/325
+
+[Device]
+Name=Wacom HID 5362 Pen,Wacom HID 5362 Finger
+ModelName=
+Class=ISDV4
+DeviceMatch=i2c:056a:5362
+Width=14
+Height=9
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Reversible=false
+Touch=true
+


### PR DESCRIPTION
Add laptop Lenovo Yoga 7 which uses Wacom HID 5362 Pen and Wacom HID 5362 Finger (vid: '0x056a', pid: '0x5362')