### PR TITLE
Add support for firmware versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,7 +171,7 @@ jobs:
       - name: copy and modify tablet files to override another one
         run: |
           sed -e 's/27QHD/27QHD MODIFIED/' data/cintiq-27hd.tablet | sudo tee /etc/libwacom/modified-cintiq.tablet
-          sed -e 's/Pro L/Pro L MODIFIED/' -e 's/usb:056a:0358;//' data/intuos-pro-2-l.tablet | sudo tee /etc/libwacom/modified-intuos.tablet
+          sed -e 's/Pro L/Pro L MODIFIED/' -e 's/usb|056a|0358;//' data/intuos-pro-2-l.tablet | sudo tee /etc/libwacom/modified-intuos.tablet
       - name: list all devices for debugging
         run: libwacom-list-devices --format=yaml
 

--- a/data/bamboo-0fg-m-p-alt.tablet
+++ b/data/bamboo-0fg-m-p-alt.tablet
@@ -41,7 +41,7 @@
 [Device]
 Name=Wacom Bamboo Fun medium
 ModelName=CTE-650
-DeviceMatch=usb:056a:0018
+DeviceMatch=usb|056a|0018
 Class=Bamboo
 Width=9
 Height=5

--- a/data/bamboo-0fg-s-p-alt.tablet
+++ b/data/bamboo-0fg-s-p-alt.tablet
@@ -42,7 +42,7 @@
 [Device]
 Name=Wacom Bamboo Fun small
 ModelName=CTE-450
-DeviceMatch=usb:056a:0017
+DeviceMatch=usb|056a|0017
 Class=Bamboo
 Width=6
 Height=4

--- a/data/bamboo-0fg-s-p.tablet
+++ b/data/bamboo-0fg-s-p.tablet
@@ -42,7 +42,7 @@
 [Device]
 Name=Wacom Bamboo Pen
 ModelName=MTE-450
-DeviceMatch=usb:056a:0065
+DeviceMatch=usb|056a|0065
 Class=Bamboo
 Width=6
 Height=4

--- a/data/bamboo-16fg-m-pt.tablet
+++ b/data/bamboo-16fg-m-pt.tablet
@@ -11,7 +11,7 @@
 [Device]
 Name=Wacom Bamboo Create
 ModelName=CTH-670
-DeviceMatch=usb:056a:00df
+DeviceMatch=usb|056a|00df
 Class=Bamboo
 Width=6
 Height=4

--- a/data/bamboo-16fg-s-p.tablet
+++ b/data/bamboo-16fg-s-p.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=Wacom Bamboo Connect
 ModelName=CTL-470
-DeviceMatch=usb:056a:00dd
+DeviceMatch=usb|056a|00dd
 Class=Bamboo
 Width=6
 Height=4

--- a/data/bamboo-16fg-s-pt.tablet
+++ b/data/bamboo-16fg-s-pt.tablet
@@ -11,7 +11,7 @@
 [Device]
 Name=Wacom Bamboo Capture
 ModelName=CTH-470
-DeviceMatch=usb:056a:00de
+DeviceMatch=usb|056a|00de
 Class=Bamboo
 Width=6
 Height=4

--- a/data/bamboo-16fg-s-t.tablet
+++ b/data/bamboo-16fg-s-t.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=Wacom Bamboo 16FG 4x5
 ModelName=CTT-470
-DeviceMatch=usb:056a:00dc
+DeviceMatch=usb|056a|00dc
 Class=Bamboo
 Width=6
 Height=4

--- a/data/bamboo-2fg-fun-m-pt.tablet
+++ b/data/bamboo-2fg-fun-m-pt.tablet
@@ -23,7 +23,7 @@
 [Device]
 Name=Wacom Bamboo Fun medium (2FG)
 ModelName=CTH-661
-DeviceMatch=usb:056a:00d3
+DeviceMatch=usb|056a|00d3
 Class=Bamboo
 Width=9
 Height=5

--- a/data/bamboo-2fg-fun-s-pt.tablet
+++ b/data/bamboo-2fg-fun-s-pt.tablet
@@ -23,7 +23,7 @@
 [Device]
 Name=Wacom Bamboo Fun small (2FG)
 ModelName=CTH-461
-DeviceMatch=usb:056a:00d2
+DeviceMatch=usb|056a|00d2
 Class=Bamboo
 Width=6
 Height=4

--- a/data/bamboo-2fg-m-p.tablet
+++ b/data/bamboo-2fg-m-p.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=Wacom Bamboo Pen medium
 ModelName=CTL-660
-DeviceMatch=usb:056a:00d5
+DeviceMatch=usb|056a|00d5
 Class=Bamboo
 Width=6
 Height=4

--- a/data/bamboo-2fg-s-p.tablet
+++ b/data/bamboo-2fg-s-p.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=Wacom Bamboo Pen small
 ModelName=CTL-460
-DeviceMatch=usb:056a:00d4
+DeviceMatch=usb|056a|00d4
 Class=Bamboo
 Width=6
 Height=4

--- a/data/bamboo-2fg-s-pt.tablet
+++ b/data/bamboo-2fg-s-pt.tablet
@@ -23,7 +23,7 @@
 [Device]
 Name=Wacom Bamboo (2FG)
 ModelName=CTH-460
-DeviceMatch=usb:056a:00d1
+DeviceMatch=usb|056a|00d1
 Class=Bamboo
 Width=6
 Height=4

--- a/data/bamboo-2fg-s-t.tablet
+++ b/data/bamboo-2fg-s-t.tablet
@@ -22,7 +22,7 @@
 [Device]
 Name=Wacom Bamboo Touch (2FG)
 ModelName=CTT-460
-DeviceMatch=usb:056a:00d0
+DeviceMatch=usb|056a|00d0
 Class=Bamboo
 Width=5
 Height=3

--- a/data/bamboo-4fg-fun-m.tablet
+++ b/data/bamboo-4fg-fun-m.tablet
@@ -11,7 +11,7 @@
 [Device]
 Name=Wacom Bamboo Fun medium (2+FG)
 ModelName=CTH-661(A)
-DeviceMatch=usb:056a:00d8
+DeviceMatch=usb|056a|00d8
 Class=Bamboo
 Width=9
 Height=5

--- a/data/bamboo-4fg-fun-s.tablet
+++ b/data/bamboo-4fg-fun-s.tablet
@@ -11,7 +11,7 @@
 [Device]
 Name=Wacom Bamboo Fun small (2+FG)
 ModelName=CTH-461(A)
-DeviceMatch=usb:056a:00d7
+DeviceMatch=usb|056a|00d7
 Class=Bamboo
 Width=6
 Height=4

--- a/data/bamboo-4fg-s-pt.tablet
+++ b/data/bamboo-4fg-s-pt.tablet
@@ -11,7 +11,7 @@
 [Device]
 Name=Wacom Bamboo Pen & Touch (2+FG)
 ModelName=CTH-460(A)
-DeviceMatch=usb:056a:00d6
+DeviceMatch=usb|056a|00d6
 Class=Bamboo
 Width=6
 Height=4

--- a/data/bamboo-4fg-s-t.tablet
+++ b/data/bamboo-4fg-s-t.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=Wacom Bamboo (2+FG)
 ModelName=CTT-460(A)
-DeviceMatch=usb:056a:00d9
+DeviceMatch=usb|056a|00d9
 Class=Bamboo
 Width=5
 Height=3

--- a/data/bamboo-4fg-se-m-pt.tablet
+++ b/data/bamboo-4fg-se-m-pt.tablet
@@ -11,7 +11,7 @@
 [Device]
 Name=Wacom Bamboo Special Edition Pen & Touch medium
 ModelName=CTH-661SE
-DeviceMatch=usb:056a:00db
+DeviceMatch=usb|056a|00db
 Class=Bamboo
 Width=9
 Height=5

--- a/data/bamboo-4fg-se-s-pt.tablet
+++ b/data/bamboo-4fg-se-s-pt.tablet
@@ -11,7 +11,7 @@
 [Device]
 Name=Wacom Bamboo Special Edition Pen & Touch small
 ModelName=CTH-461SE
-DeviceMatch=usb:056a:00da
+DeviceMatch=usb|056a|00da
 Class=Bamboo
 Width=6
 Height=4

--- a/data/bamboo-one-m-p.tablet
+++ b/data/bamboo-one-m-p.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=Wacom Bamboo1 5x8 Pen
 ModelName=CTE-660
-DeviceMatch=usb:056a:006b
+DeviceMatch=usb|056a|006b
 Class=Bamboo
 Width=8
 Height=5

--- a/data/bamboo-one.tablet
+++ b/data/bamboo-one.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Bamboo One
 ModelName=CTF-430
-DeviceMatch=usb:056a:0069
+DeviceMatch=usb|056a|0069
 Class=Bamboo
 Width=5
 Height=4

--- a/data/bamboo-pad-wireless.tablet
+++ b/data/bamboo-pad-wireless.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=Wacom Bamboo Pad Wireless
 ModelName=CTH-300
-DeviceMatch=usb:056a:0319
+DeviceMatch=usb|056a|0319
 Class=Bamboo
 Width=4
 Height=3

--- a/data/bamboo-pad.tablet
+++ b/data/bamboo-pad.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=Wacom Bamboo Pad
 ModelName=CTH-301
-DeviceMatch=usb:056a:0318
+DeviceMatch=usb|056a|0318
 Class=Bamboo
 Width=4
 Height=3

--- a/data/chuwi-minibookx.tablet
+++ b/data/chuwi-minibookx.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=Chuwi Minibook X
 Class=ISDV4
-DeviceMatch=i2c:27c6:011a
+DeviceMatch=i2c|27c6|011a
 Width=9
 Height=6
 IntegratedIn=Display;System;

--- a/data/cintiq-12wx.tablet
+++ b/data/cintiq-12wx.tablet
@@ -34,7 +34,7 @@
 Name=Wacom Cintiq 12WX
 ModelName=DTZ-1200W
 Class=Cintiq
-DeviceMatch=usb:056a:00c6
+DeviceMatch=usb|056a|00c6
 Width=10
 Height=7
 Layout=cintiq-12wx.svg

--- a/data/cintiq-13hd.tablet
+++ b/data/cintiq-13hd.tablet
@@ -25,7 +25,7 @@
 Name=Wacom Cintiq 13HD
 ModelName=DTK-1300
 Class=Cintiq
-DeviceMatch=usb:056a:0304
+DeviceMatch=usb|056a|0304
 Width=12
 Height=7
 Layout=cintiq-13hd.svg

--- a/data/cintiq-13hdt.tablet
+++ b/data/cintiq-13hdt.tablet
@@ -20,14 +20,14 @@
 #          *-----------------------*
 #
 # Note: Buttons F, G, H, I are on a circle
-#       touch data comes through the usb:056a:0335 interface
+#       touch data comes through the usb|056a|0335 interface
 
 [Device]
 Name=Wacom Cintiq 13HD touch
 ModelName=DTH-1300
 Class=Cintiq
-DeviceMatch=usb:056a:0333
-PairedID=usb:056a:0335
+DeviceMatch=usb|056a|0333
+PairedID=usb|056a|0335
 Width=12
 Height=7
 Layout=cintiq-13hd.svg

--- a/data/cintiq-16-2.tablet
+++ b/data/cintiq-16-2.tablet
@@ -6,7 +6,7 @@
 Name=Wacom Cintiq 16
 ModelName=DTK-1660
 Class=Cintiq
-DeviceMatch=usb:056a:03ae
+DeviceMatch=usb|056a|03ae
 Width=14
 Height=8
 # No pad buttons, so no layout

--- a/data/cintiq-16.tablet
+++ b/data/cintiq-16.tablet
@@ -6,7 +6,7 @@
 Name=Wacom Cintiq 16
 ModelName=DTK-1660
 Class=Cintiq
-DeviceMatch=usb:056a:0390
+DeviceMatch=usb|056a|0390
 Width=14
 Height=8
 # No pad buttons, so no layout

--- a/data/cintiq-20wsx.tablet
+++ b/data/cintiq-20wsx.tablet
@@ -36,7 +36,7 @@
 [Device]
 Name=Wacom Cintiq 20WSX
 ModelName=DTZ-2000W
-DeviceMatch=usb:056a:00c5
+DeviceMatch=usb|056a|00c5
 Class=Cintiq
 Width=17
 Height=11

--- a/data/cintiq-21ux.tablet
+++ b/data/cintiq-21ux.tablet
@@ -29,7 +29,7 @@
 [Device]
 Name=Wacom Cintiq 21UX
 ModelName=DTZ-2100
-DeviceMatch=usb:056a:003f
+DeviceMatch=usb|056a|003f
 Class=Cintiq
 Width=17
 Height=13

--- a/data/cintiq-21ux2.tablet
+++ b/data/cintiq-21ux2.tablet
@@ -45,7 +45,7 @@
 [Device]
 Name=Wacom Cintiq 21UX2
 ModelName=DTK-2100
-DeviceMatch=usb:056a:00cc
+DeviceMatch=usb|056a|00cc
 Class=Cintiq
 Width=17
 Height=13

--- a/data/cintiq-22.tablet
+++ b/data/cintiq-22.tablet
@@ -6,7 +6,7 @@
 Name=Wacom Cintiq 22
 ModelName=DTK-2260
 Class=Cintiq
-DeviceMatch=usb:056a:0391
+DeviceMatch=usb|056a|0391
 Width=19
 Height=10
 # No pad buttons, so no layout

--- a/data/cintiq-22hd.tablet
+++ b/data/cintiq-22hd.tablet
@@ -33,7 +33,7 @@
 [Device]
 Name=Wacom Cintiq 22HD
 ModelName=DTK-2200
-DeviceMatch=usb:056a:00fa
+DeviceMatch=usb|056a|00fa
 Class=Cintiq
 Width=19
 Height=11

--- a/data/cintiq-22hdt.tablet
+++ b/data/cintiq-22hdt.tablet
@@ -29,13 +29,13 @@
 #    |                       |
 #    @-----------------------@
 #
-# Note: touch data comes through the usb:056a:005e interface
+# Note: touch data comes through the usb|056a|005e interface
 
 [Device]
 Name=Wacom Cintiq 22HD touch
 ModelName=DTH-2200
-DeviceMatch=usb:056a:005b
-PairedID=usb:056a:005e
+DeviceMatch=usb|056a|005b
+PairedID=usb|056a|005e
 Class=Cintiq
 Width=19
 Height=11

--- a/data/cintiq-24hd-touch.tablet
+++ b/data/cintiq-24hd-touch.tablet
@@ -37,13 +37,13 @@
 #     |                       |
 #     *-----------------------*
 #
-# Note: touch data comes through the usb:056a:00f6 interface
+# Note: touch data comes through the usb|056a|00f6 interface
 
 [Device]
 Name=Wacom Cintiq 24HD touch
 ModelName=DTH-2400
-DeviceMatch=usb:056a:00f8
-PairedID=usb:056a:00f6
+DeviceMatch=usb|056a|00f8
+PairedID=usb|056a|00f6
 Class=Cintiq
 Width=21
 Height=13

--- a/data/cintiq-24hd.tablet
+++ b/data/cintiq-24hd.tablet
@@ -41,7 +41,7 @@
 [Device]
 Name=Wacom Cintiq 24HD
 ModelName=DTK-2400
-DeviceMatch=usb:056a:00f4
+DeviceMatch=usb|056a|00f4
 Class=Cintiq
 Width=21
 Height=13

--- a/data/cintiq-27hd.tablet
+++ b/data/cintiq-27hd.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=Wacom Cintiq 27QHD
 ModelName=DTK-2700
-DeviceMatch=usb:056a:032a
+DeviceMatch=usb|056a|032a
 Class=Cintiq
 Width=24
 Height=12

--- a/data/cintiq-27hdt.tablet
+++ b/data/cintiq-27hdt.tablet
@@ -2,13 +2,13 @@
 # Cintiq 27QHD touch
 # DTH-2700
 #
-# Note: touch data comes through the usb:056a:032c interface
+# Note: touch data comes through the usb|056a|032c interface
 
 [Device]
 Name=Wacom Cintiq 27QHD touch
 ModelName=DTH-2700
-DeviceMatch=usb:056a:032b
-PairedID=usb:056a:032c
+DeviceMatch=usb|056a|032b
+PairedID=usb|056a|032c
 Class=Cintiq
 Width=24
 Height=12

--- a/data/cintiq-companion-2.tablet
+++ b/data/cintiq-companion-2.tablet
@@ -23,15 +23,15 @@
 #
 # Note: Buttons H, I, J, K are on a circle
 #
-# Note: touch data comes through the usb:056a:0326 interface
+# Note: touch data comes through the usb|056a|0326 interface
 #
 
 [Device]
 Name=Wacom Cintiq Companion 2
 ModelName=DTH-W1310
 Class=Cintiq
-DeviceMatch=usb:056a:0325
-PairedID=usb:056a:0326
+DeviceMatch=usb|056a|0325
+PairedID=usb|056a|0326
 Width=12
 Height=7
 Layout=cintiq-companion-2.svg

--- a/data/cintiq-companion-hybrid.tablet
+++ b/data/cintiq-companion-hybrid.tablet
@@ -21,15 +21,15 @@
 #
 # Note: Buttons F, G, H, I are on a circle
 #
-# Note: touch data comes through the usb:056a:0309 interface
+# Note: touch data comes through the usb|056a|0309 interface
 #
 
 [Device]
 Name=Wacom Cintiq Companion Hybrid
 ModelName=DTH-A1300
 Class=Cintiq
-DeviceMatch=usb:056a:0307
-PairedID=usb:056a:0309
+DeviceMatch=usb|056a|0307
+PairedID=usb|056a|0309
 Width=12
 Height=7
 Layout=cintiq-companion-hybrid.svg

--- a/data/cintiq-companion.tablet
+++ b/data/cintiq-companion.tablet
@@ -21,15 +21,15 @@
 #
 # Note: Buttons F, G, H, I are on a circle
 #
-# Note: touch data comes through the usb:056a:030c interface
+# Note: touch data comes through the usb|056a|030c interface
 #
 
 [Device]
 Name=Wacom Cintiq Companion
 ModelName=DTH-W1300
 Class=Cintiq
-DeviceMatch=usb:056a:030a
-PairedID=usb:056a:030c
+DeviceMatch=usb|056a|030a
+PairedID=usb|056a|030c
 Width=12
 Height=7
 Layout=cintiq-companion.svg

--- a/data/cintiq-pro-13.tablet
+++ b/data/cintiq-pro-13.tablet
@@ -30,8 +30,8 @@
 Name=Wacom Cintiq Pro 13
 ModelName=DTH-1320
 Class=Cintiq
-DeviceMatch=usb:056a:034f
-PairedID=usb:056a:0353
+DeviceMatch=usb|056a|034f
+PairedID=usb|056a|0353
 Width=12
 Height=7
 # No pad buttons, so no layout

--- a/data/cintiq-pro-16-2.tablet
+++ b/data/cintiq-pro-16-2.tablet
@@ -27,8 +27,8 @@
 Name=Wacom Cintiq Pro 16
 ModelName=DTH167
 Class=Cintiq
-DeviceMatch=usb:056a:03b2
-PairedID=usb:056a:03b3
+DeviceMatch=usb|056a|03b2
+PairedID=usb|056a|03b3
 Width=14
 Height=8
 Layout=cintiq-pro-16-2.svg

--- a/data/cintiq-pro-16.tablet
+++ b/data/cintiq-pro-16.tablet
@@ -30,8 +30,8 @@
 Name=Wacom Cintiq Pro 16
 ModelName=DTH-1620
 Class=Cintiq
-DeviceMatch=usb:056a:0350
-PairedID=usb:056a:0354
+DeviceMatch=usb|056a|0350
+PairedID=usb|056a|0354
 Width=14
 Height=8
 # No pad buttons, so no layout

--- a/data/cintiq-pro-17.tablet
+++ b/data/cintiq-pro-17.tablet
@@ -29,7 +29,7 @@
 Name=Wacom Cintiq Pro 17
 ModelName=DTH172
 Class=Cintiq
-DeviceMatch=usb:056a:03c4
+DeviceMatch=usb|056a|03c4
 Width=15
 Height=8
 Layout=cintiq-pro-17.svg

--- a/data/cintiq-pro-22.tablet
+++ b/data/cintiq-pro-22.tablet
@@ -29,7 +29,7 @@
 Name=Wacom Cintiq Pro 22
 ModelName=DTH227
 Class=Cintiq
-DeviceMatch=usb:056a:03d0
+DeviceMatch=usb|056a|03d0
 Width=18
 Height=10
 Layout=cintiq-pro-22.svg

--- a/data/cintiq-pro-24-p.tablet
+++ b/data/cintiq-pro-24-p.tablet
@@ -30,7 +30,7 @@
 Name=Wacom Cintiq Pro 24
 ModelName=DTK-2420
 Class=Cintiq
-DeviceMatch=usb:056a:037c
+DeviceMatch=usb|056a|037c
 Width=20
 Height=12
 # No pad buttons, so no layout

--- a/data/cintiq-pro-24-pt.tablet
+++ b/data/cintiq-pro-24-pt.tablet
@@ -30,8 +30,8 @@
 Name=Wacom Cintiq Pro 24
 ModelName=DTH-2420
 Class=Cintiq
-DeviceMatch=usb:056a:0351
-PairedID=usb:056a:0355
+DeviceMatch=usb|056a|0351
+PairedID=usb|056a|0355
 Width=20
 Height=12
 # No pad buttons, so no layout

--- a/data/cintiq-pro-27.tablet
+++ b/data/cintiq-pro-27.tablet
@@ -29,7 +29,7 @@
 Name=Wacom Cintiq Pro 27
 ModelName=DTH271
 Class=Cintiq
-DeviceMatch=usb:056a:03c0
+DeviceMatch=usb|056a|03c0
 Width=24
 Height=13
 Layout=cintiq-pro-27.svg

--- a/data/cintiq-pro-32.tablet
+++ b/data/cintiq-pro-32.tablet
@@ -30,8 +30,8 @@
 Name=Wacom Cintiq Pro 32
 ModelName=DTH-3220
 Class=Cintiq
-DeviceMatch=usb:056a:0352
-PairedID=usb:056a:0356
+DeviceMatch=usb|056a|0352
+PairedID=usb|056a|0356
 Width=27
 Height=15
 # No pad buttons, so no layout

--- a/data/dell-canvas-27.tablet
+++ b/data/dell-canvas-27.tablet
@@ -22,8 +22,8 @@
 Name=Dell Canvas 27
 ModelName=
 Class=Cintiq
-DeviceMatch=usb:056a:4200
-PairedID=usb:2575:0204
+DeviceMatch=usb|056a|4200
+PairedID=usb|2575|0204
 Width=23
 Height=13
 # No pad buttons, so no layout

--- a/data/dtc-121.tablet
+++ b/data/dtc-121.tablet
@@ -9,7 +9,7 @@
 Name=Wacom DTC121
 ModelName=DTC121
 Class=PenDisplay
-DeviceMatch=usb:056a:03ed
+DeviceMatch=usb|056a|03ed
 Width=11
 Height=6
 # No pad buttons, so no layout

--- a/data/dtf-720.tablet
+++ b/data/dtf-720.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=Wacom DTF-720
 ModelName=DTF-720
-DeviceMatch=usb:056a:00c0
+DeviceMatch=usb|056a|00c0
 Width=13
 Height=11
 Class=PenDisplay

--- a/data/dth-1152.tablet
+++ b/data/dth-1152.tablet
@@ -6,8 +6,8 @@
 [Device]
 Name=Wacom DTH1152
 ModelName=DTH-1152
-DeviceMatch=usb:056a:035a
-PairedID=usb:056a:0368
+DeviceMatch=usb|056a|035a
+PairedID=usb|056a|0368
 Class=PenDisplay
 Width=9
 Height=5

--- a/data/dth-134.tablet
+++ b/data/dth-134.tablet
@@ -9,7 +9,7 @@
 Name=Wacom DTH134
 ModelName=DTH134
 Class=PenDisplay
-DeviceMatch=usb:056a:03ec
+DeviceMatch=usb|056a|03ec
 Width=13
 Height=7
 # No pad buttons, so no layout

--- a/data/dth-2242.tablet
+++ b/data/dth-2242.tablet
@@ -11,13 +11,13 @@
 #      |                 |
 #      *-----------------*
 #
-# Note: touch data comes through the usb:056a:005d interface
+# Note: touch data comes through the usb|056a|005d interface
 
 [Device]
 Name=Wacom DTH2242
 ModelName=DTH-2242
-DeviceMatch=usb:056a:0059
-PairedID=usb:056a:005d
+DeviceMatch=usb|056a|0059
+PairedID=usb|056a|005d
 Class=PenDisplay
 Width=19
 Height=11

--- a/data/dth-2452.tablet
+++ b/data/dth-2452.tablet
@@ -16,8 +16,8 @@
 [Device]
 Name=Wacom DTH2452
 ModelName=DTH-2452
-DeviceMatch=usb:056a:037d
-PairedID=usb:056a:037e
+DeviceMatch=usb|056a|037d
+PairedID=usb|056a|037e
 Class=PenDisplay
 Width=20
 Height=12

--- a/data/dti-520.tablet
+++ b/data/dti-520.tablet
@@ -17,7 +17,7 @@
 [Device]
 Name=Wacom DTI520UB/L
 ModelName=DTI-520
-DeviceMatch=usb:056a:003a
+DeviceMatch=usb|056a|003a
 Class=PenDisplay
 Width=14
 Height=12

--- a/data/dtk-1651.tablet
+++ b/data/dtk-1651.tablet
@@ -15,7 +15,7 @@
 [Device]
 Name=Wacom DTK1651
 ModelName=DTK-1651
-DeviceMatch=usb:056a:0343
+DeviceMatch=usb|056a|0343
 Class=PenDisplay
 Width=14
 Height=8

--- a/data/dtk-1660e-2.tablet
+++ b/data/dtk-1660e-2.tablet
@@ -5,7 +5,7 @@
 Name=Wacom DTK-1660E
 ModelName=DTK-1660E
 Class=Cintiq
-DeviceMatch=usb:056a:03b0
+DeviceMatch=usb|056a|03b0
 Width=14
 Height=8
 # No pad buttons, so no layout

--- a/data/dtk-1660e.tablet
+++ b/data/dtk-1660e.tablet
@@ -5,7 +5,7 @@
 Name=Wacom DTK-1660E
 ModelName=DTK-1660E
 Class=Cintiq
-DeviceMatch=usb:056a:0396
+DeviceMatch=usb|056a|0396
 Width=14
 Height=8
 # No pad buttons, so no layout

--- a/data/dtk-2241.tablet
+++ b/data/dtk-2241.tablet
@@ -15,7 +15,7 @@
 [Device]
 Name=Wacom DTK2241
 ModelName=DTK-2241
-DeviceMatch=usb:056a:0057
+DeviceMatch=usb|056a|0057
 Class=PenDisplay
 Width=19
 Height=11

--- a/data/dtk-2451.tablet
+++ b/data/dtk-2451.tablet
@@ -16,7 +16,7 @@
 [Device]
 Name=Wacom DTK2451
 ModelName=DTK-2451
-DeviceMatch=usb:056a:0382
+DeviceMatch=usb|056a|0382
 Class=PenDisplay
 Width=20
 Height=12

--- a/data/dtu-1031.tablet
+++ b/data/dtu-1031.tablet
@@ -16,7 +16,7 @@
 [Device]
 Name=Wacom DTU1031
 ModelName=DTU-1031
-DeviceMatch=usb:056a:00fb
+DeviceMatch=usb|056a|00fb
 Class=PenDisplay
 Width=9
 Height=5

--- a/data/dtu-1031x.tablet
+++ b/data/dtu-1031x.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Wacom DTU1031X
 ModelName=DTU-1031X
-DeviceMatch=usb:056a:032f
+DeviceMatch=usb|056a|032f
 Class=PenDisplay
 Width=9
 Height=5

--- a/data/dtu-1141.tablet
+++ b/data/dtu-1141.tablet
@@ -16,7 +16,7 @@
 [Device]
 Name=Wacom DTU1141
 ModelName=DTU-1141
-DeviceMatch=usb:056a:0336
+DeviceMatch=usb|056a|0336
 Class=PenDisplay
 Width=9
 Height=5

--- a/data/dtu-1141b.tablet
+++ b/data/dtu-1141b.tablet
@@ -16,7 +16,7 @@
 [Device]
 Name=Wacom DTU1141B
 ModelName=DTU-1141B
-DeviceMatch=usb:056a:0359
+DeviceMatch=usb|056a|0359
 Class=PenDisplay
 Width=9
 Height=5

--- a/data/dtu-1631.tablet
+++ b/data/dtu-1631.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=Wacom DTU-1631
 ModelName=DTU-1631
-DeviceMatch=usb:056a:00f0
+DeviceMatch=usb|056a|00f0
 Width=14
 Height=8
 Class=PenDisplay

--- a/data/dtu-1931.tablet
+++ b/data/dtu-1931.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Wacom DTU-1931
 ModelName=DTU-1931
-DeviceMatch=usb:056a:00c7
+DeviceMatch=usb|056a|00c7
 Width=15
 Height=12
 Class=PenDisplay

--- a/data/dtu-2231.tablet
+++ b/data/dtu-2231.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Wacom DTU-2231
 ModelName=DTU-2231
-DeviceMatch=usb:056a:00ce
+DeviceMatch=usb|056a|00ce
 Class=PenDisplay
 Width=19
 Height=11

--- a/data/ek-remote.tablet
+++ b/data/ek-remote.tablet
@@ -14,7 +14,7 @@
 [Device]
 Name=Wacom ExpressKey Remote
 ModelName=ACK-411050
-DeviceMatch=usb:056a:0331
+DeviceMatch=usb|056a|0331
 Layout=ek-remote.svg
 Class=Remote
 

--- a/data/elan-0732.tablet
+++ b/data/elan-0732.tablet
@@ -2,7 +2,7 @@
 [Device]
 Name=ELAN 0732
 ModelName=
-DeviceMatch=i2c:04f3:271c
+DeviceMatch=i2c|04f3|271c
 Class=ISDV4
 Width=12
 Height=7

--- a/data/elan-2072.tablet
+++ b/data/elan-2072.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=ELAN 2072
 ModelName=
-DeviceMatch=usb:04f3:2072
+DeviceMatch=usb|04f3|2072
 Width=12
 Height=7
 Class=PenDisplay

--- a/data/elan-22e2.tablet
+++ b/data/elan-22e2.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=ELAN 22E2
 ModelName=
-DeviceMatch=i2c:04f3:22e2
+DeviceMatch=i2c|04f3|22e2
 Class=ISDV4
 IntegratedIn=Display;System
 Styli=@generic-with-eraser;

--- a/data/elan-22f7.tablet
+++ b/data/elan-22f7.tablet
@@ -8,7 +8,7 @@
 [Device]
 Name=Nuvision Solo 10 Draw
 ModelName=
-DeviceMatch=i2c:04f3:22f7
+DeviceMatch=i2c|04f3|22f7
 Class=ISDV4
 Width=10
 Height=6

--- a/data/elan-24d8.tablet
+++ b/data/elan-24d8.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=ELAN 24D8
 ModelName=
-DeviceMatch=i2c:04f3:2ad8;
+DeviceMatch=i2c|04f3|2ad8;
 Class=ISDV4
 Width=12
 Height=7

--- a/data/elan-24db.tablet
+++ b/data/elan-24db.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=ELAN 24DB
 ModelName=
-DeviceMatch=i2c:04f3:24db
+DeviceMatch=i2c|04f3|24db
 Class=ISDV4
 Width=12
 Height=7

--- a/data/elan-2513.tablet
+++ b/data/elan-2513.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=ELAN 2513
 ModelName=
-DeviceMatch=i2c:04f3:2b5f
+DeviceMatch=i2c|04f3|2b5f
 Class=ISDV4
 Width=12
 Height=7

--- a/data/elan-2514-alt.tablet
+++ b/data/elan-2514-alt.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=ELAN 2514
 ModelName=
-DeviceMatch=i2c:004f3:23db
+DeviceMatch=i2c|004f3|23db
 Class=ISDV4
 Width=12
 Height=7

--- a/data/elan-2514-alt2.tablet
+++ b/data/elan-2514-alt2.tablet
@@ -2,12 +2,12 @@
 #
 # HP Envy x360 Converti0ble 15-dr1xxx
 #
-# i2c:04f3:29cf
+# i2c|04f3|29cf
 # sysinfo.uFNKtCProZ
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/102
 #
 #
-# i2c:04f3:25bf
+# i2c|04f3|25bf
 # HP Spectre x360 Convertible 15t-ch000
 # sysinfo.xibMWZk1d9
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/128
@@ -15,7 +15,7 @@
 [Device]
 Name=ELAN 2514
 ModelName=
-DeviceMatch=i2c:04f3:29cf;i2c:04f3:25bf;
+DeviceMatch=i2c|04f3|29cf;i2c|04f3|25bf;
 Class=ISDV4
 Width=14
 Height=8

--- a/data/elan-2514.tablet
+++ b/data/elan-2514.tablet
@@ -1,39 +1,39 @@
 # ELAN touchscreen/pen sensor
 
-# i2c:04f3:29f5
+# i2c|04f3|29f5
 #
 # HP Spectre x360 Convertible 13-aw0xxx
 
-# i2c:04f3:2af4
+# i2c|04f3|2af4
 #
 # HP Envy x360 Convertible 13-ay0xxx
 #
 # sysinfo.L1vXaj9Wcz
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/110
 
-# i2c:04f3:2813
+# i2c|04f3|2813
 #
 # HP Spectre x360 Convertible 13-ap0xxx
 #
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/127
 
-# i2c:04f3:2817
+# i2c|04f3|2817
 #
 # HP Spectre x360 Convertible 15-df0xxx
 #
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/70
 
-# i2c:04f3:2b0a
+# i2c|04f3|2b0a
 #
 # HP Envy x360 Convertible 15z-ee000
 
-# i2c:04f3:23f3
+# i2c|04f3|23f3
 #
 # HP Envy x360 Convertible 15-dr1xxx
 #
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/140
 
-# i2c:04f3:2718
+# i2c|04f3|2718
 #
 # HP Envy x360 Convertible 14-cd0xxx
 #
@@ -47,7 +47,7 @@
 [Device]
 Name=ELAN 2514
 ModelName=
-DeviceMatch=i2c:04f3:29f5;i2c:04f3:2af4;i2c:04f3:2813;i2c:04f3:2817;i2c:04f3:2b0a;i2c:04f3:23f3;i2c:04f3:2718;i2c:04f3:2beb;i2c:04f3:23b9;i2c:04f3:29d4
+DeviceMatch=i2c|04f3|29f5;i2c|04f3|2af4;i2c|04f3|2813;i2c|04f3|2817;i2c|04f3|2b0a;i2c|04f3|23f3;i2c|04f3|2718;i2c|04f3|2beb;i2c|04f3|23b9;i2c|04f3|29d4
 Class=ISDV4
 Width=12
 Height=7

--- a/data/elan-2537.tablet
+++ b/data/elan-2537.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=ELAN 2537
 ModelName=
-DeviceMatch=i2c:04f3:2537
+DeviceMatch=i2c|04f3|2537
 Class=ISDV4
 Width=14
 Height=8

--- a/data/elan-2627.tablet
+++ b/data/elan-2627.tablet
@@ -2,7 +2,7 @@
 [Device]
 Name=ELAN 2627
 ModelName=
-DeviceMatch=i2c:04f3:2627
+DeviceMatch=i2c|04f3|2627
 Class=ISDV4
 Width=12
 Height=7

--- a/data/elan-2628.tablet
+++ b/data/elan-2628.tablet
@@ -2,7 +2,7 @@
 [Device]
 Name=ELAN 2628
 ModelName=
-DeviceMatch=i2c:04f3:2628
+DeviceMatch=i2c|04f3|2628
 Class=ISDV4
 Width=12
 Height=7

--- a/data/elan-262b.tablet
+++ b/data/elan-262b.tablet
@@ -2,7 +2,7 @@
 [Device]
 Name=ELAN 262b
 ModelName=
-DeviceMatch=i2c:04f3:262b
+DeviceMatch=i2c|04f3|262b
 Class=ISDV4
 Width=12
 Height=7

--- a/data/elan-264c.tablet
+++ b/data/elan-264c.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=ELAN touchscreen/pen sensor
 ModelName=ELAN-264C
-DeviceMatch=i2c:04f3:264c
+DeviceMatch=i2c|04f3|264c
 Class=ISDV4
 Width=14
 Height=8

--- a/data/elan-29a1.tablet
+++ b/data/elan-29a1.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=ELAN 29A1
 ModelName=
-DeviceMatch=i2c:04f3:29a1
+DeviceMatch=i2c|04f3|29a1
 Class=ISDV4
 Width=14
 Height=4

--- a/data/elan-29b6.tablet
+++ b/data/elan-29b6.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=ELAN 29B6
 ModelName=
-DeviceMatch=i2c:04f3:29b6
+DeviceMatch=i2c|04f3|29b6
 Class=ISDV4
 Width=14
 Height=8

--- a/data/elan-2a70.tablet
+++ b/data/elan-2a70.tablet
@@ -4,7 +4,7 @@
 
 [Device]
 Name=ELAN1001
-DeviceMatch=i2c:04f3:2a70
+DeviceMatch=i2c|04f3|2a70
 Class=ISDV4
 Width=10
 Height=6

--- a/data/elan-2ad9.tablet
+++ b/data/elan-2ad9.tablet
@@ -5,7 +5,7 @@
 
 [Device]
 Name=ELAN 2AD9
-DeviceMatch=i2c:04f3:2ad9
+DeviceMatch=i2c|04f3|2ad9
 Class=ISDV4
 Width=14
 Height=8

--- a/data/elan-2bb3.tablet
+++ b/data/elan-2bb3.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=ELAN 2BB3
 ModelName=
-DeviceMatch=i2c:04f3:2bb3
+DeviceMatch=i2c|04f3|2bb3
 Class=ISDV4
 IntegratedIn=Display;System
 

--- a/data/elan-2bd6.tablet
+++ b/data/elan-2bd6.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=Elan 2BD6
 ModelName=
-DeviceMatch=i2c:04f3:2bd6
+DeviceMatch=i2c|04f3|2bd6
 Class=ISDV4
 IntegratedIn=Display;System
 Styli=@generic-with-eraser

--- a/data/elan-2c1b.tablet
+++ b/data/elan-2c1b.tablet
@@ -8,7 +8,7 @@
 [Device]
 Name=ELAN 2C1B
 ModelName=
-DeviceMatch=i2c:04f3:2c1b
+DeviceMatch=i2c|04f3|2c1b
 Class=ISDV4
 Width=14
 Height=4

--- a/data/elan-2d55.tablet
+++ b/data/elan-2d55.tablet
@@ -8,7 +8,7 @@
 [Device]
 Name=ELAN 2D55
 ModelName=
-DeviceMatch=i2c:04f3:2d55
+DeviceMatch=i2c|04f3|2d55
 Class=ISDV4
 Width=14
 Height=4

--- a/data/elan-2fc2.tablet
+++ b/data/elan-2fc2.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=ELAN 2FC2
 ModelName=
-DeviceMatch=i2c:04f3:2fc2
+DeviceMatch=i2c|04f3|2fc2
 Class=ISDV4
 Width=14
 Height=8

--- a/data/elan-425a.tablet
+++ b/data/elan-425a.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ELAN9009:00
 ModelName=
-DeviceMatch=i2c:04f3:425a
+DeviceMatch=i2c|04f3|425a
 Class=ISDV4
 Width=14
 Height=4

--- a/data/elan-425b.tablet
+++ b/data/elan-425b.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=ELAN9008:00
 ModelName=
-DeviceMatch=i2c:04f3:425b
+DeviceMatch=i2c|04f3|425b
 Class=ISDV4
 Width=14
 Height=4

--- a/data/elan-5515.tablet
+++ b/data/elan-5515.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=ELAN 5515
 ModelName=
-DeviceMatch=i2c:04f3:2339
+DeviceMatch=i2c|04f3|2339
 Class=ISDV4
 IntegratedIn=Display
 

--- a/data/gaomon-s620.tablet
+++ b/data/gaomon-s620.tablet
@@ -11,7 +11,7 @@
 [Device]
 Name=GAOMON S620
 ModelName=
-DeviceMatch=usb:256c:006d:GAOMON Gaomon Tablet Pen;usb:256c:006d:GAOMON Gaomon Tablet Pad;
+DeviceMatch=usb|256c|006d|GAOMON Gaomon Tablet Pen;usb|256c|006d|GAOMON Gaomon Tablet Pad;
 Class=Bamboo
 Width=6
 Height=4

--- a/data/graphire-usb.tablet
+++ b/data/graphire-usb.tablet
@@ -19,7 +19,7 @@
 [Device]
 Name=Wacom Graphire
 ModelName=ET-0405
-DeviceMatch=usb:056a:0010
+DeviceMatch=usb|056a|0010
 Class=Graphire
 Width=5
 Height=4

--- a/data/graphire-wireless-8x6.tablet
+++ b/data/graphire-wireless-8x6.tablet
@@ -17,7 +17,7 @@
 [Device]
 Name=Wacom Graphire Wireless
 ModelName=CTE-630BT
-DeviceMatch=bluetooth:056a:0081
+DeviceMatch=bluetooth|056a|0081
 Class=Graphire
 Width=8
 Height=6

--- a/data/graphire2-4x5.tablet
+++ b/data/graphire2-4x5.tablet
@@ -19,7 +19,7 @@
 [Device]
 Name=Wacom Graphire2 4x5
 ModelName=ET-0405A
-DeviceMatch=usb:056a:0011
+DeviceMatch=usb|056a|0011
 Class=Graphire
 Width=5
 Height=4

--- a/data/graphire2-5x7.tablet
+++ b/data/graphire2-5x7.tablet
@@ -19,7 +19,7 @@
 [Device]
 Name=Wacom Graphire2 5x7
 ModelName=ET-0507A
-DeviceMatch=usb:056a:0012
+DeviceMatch=usb|056a|0012
 Class=Graphire
 Width=7
 Height=5

--- a/data/graphire3-4x5.tablet
+++ b/data/graphire3-4x5.tablet
@@ -4,7 +4,7 @@
 Name=Wacom Graphire3 4x5
 ModelName=CTE-430
 
-DeviceMatch=usb:056a:0013
+DeviceMatch=usb|056a|0013
 
 Class=Graphire
 

--- a/data/graphire3-6x8.tablet
+++ b/data/graphire3-6x8.tablet
@@ -4,7 +4,7 @@
 Name=Wacom Graphire3 6x8
 ModelName=CTE-630
 
-DeviceMatch=usb:056a:0014
+DeviceMatch=usb|056a|0014
 
 Class=Graphire
 

--- a/data/graphire4-4x5.tablet
+++ b/data/graphire4-4x5.tablet
@@ -19,7 +19,7 @@
 [Device]
 Name=Wacom Graphire4 4x5
 ModelName=CTE-440
-DeviceMatch=usb:056a:0015
+DeviceMatch=usb|056a|0015
 Class=Graphire
 Width=5
 Height=4

--- a/data/graphire4-6x8.tablet
+++ b/data/graphire4-6x8.tablet
@@ -19,7 +19,7 @@
 [Device]
 Name=Wacom Graphire4 6x8
 ModelName=CTE-640
-DeviceMatch=usb:056a:0016
+DeviceMatch=usb|056a|0016
 Class=Graphire
 Width=8
 Height=6

--- a/data/hp-pro-tablet-408.tablet
+++ b/data/hp-pro-tablet-408.tablet
@@ -8,7 +8,7 @@
 [Device]
 Name=HP Pro Tablet 408
 Class=ISDV4
-DeviceMatch=i2c:06cb:125d
+DeviceMatch=i2c|06cb|125d
 Width=4
 Height=7
 IntegratedIn=Display;System;

--- a/data/huion-420.tablet
+++ b/data/huion-420.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Huion 420
 ModelName=
-DeviceMatch=usb:256c:006e:HUION 420 Pen;usb:256c:006e:HUION 420 Pad;
+DeviceMatch=usb|256c|006e|HUION 420 Pen;usb|256c|006e|HUION 420 Pad;
 Class=Bamboo
 Width=4
 Height=2

--- a/data/huion-h1060p.tablet
+++ b/data/huion-h1060p.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=HUION H1060P Tablet
 ModelName=
-DeviceMatch=usb:256c:006d:HUION Huion Tablet Pad;usb:256c:006d:HUION Huion Tablet Pen
+DeviceMatch=usb|256c|006d|HUION Huion Tablet Pad;usb|256c|006d|HUION Huion Tablet Pen
 Class=Bamboo
 Width=10
 Height=6

--- a/data/huion-h420.tablet
+++ b/data/huion-h420.tablet
@@ -15,7 +15,7 @@
 [Device]
 Name=Huion H420
 ModelName=
-DeviceMatch=usb:256c:006e:HUION H420 Pen;usb:256c:006e:HUION H420 Pad;
+DeviceMatch=usb|256c|006e|HUION H420 Pen;usb|256c|006e|HUION H420 Pad;
 Class=Bamboo
 Width=4
 Height=2

--- a/data/huion-h610-pro.tablet
+++ b/data/huion-h610-pro.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Huion H610 Pro
 ModelName=
-DeviceMatch=usb:256c:006e:HUION PenTablet Pen;usb:256c:006e:HUION PenTablet Pad;usb:256c:006e:Turcom TS-6610 Pen;usb:256c:006e:Turcom TS-6610 Pad;usb:256c:006e:HUION Huion Tablet Pen;usb:256c:006e:HUION Huion Tablet Pad;usb:256c:006e:HUION H610 Pen;usb:256c:006e:HUION H610 Pad
+DeviceMatch=usb|256c|006e|HUION PenTablet Pen;usb|256c|006e|HUION PenTablet Pad;usb|256c|006e|Turcom TS-6610 Pen;usb|256c|006e|Turcom TS-6610 Pad;usb|256c|006e|HUION Huion Tablet Pen;usb|256c|006e|HUION Huion Tablet Pad;usb|256c|006e|HUION H610 Pen;usb|256c|006e|HUION H610 Pad
 Class=Bamboo
 Width=10
 Height=6

--- a/data/huion-h640p.tablet
+++ b/data/huion-h640p.tablet
@@ -16,7 +16,7 @@
 [Device]
 Name=Huion H640P
 ModelName=
-DeviceMatch=usb:256c:006d:HUION Huion Tablet_H640P Pad;usb:256c:006d:HUION Huion Tablet_H640P Pen
+DeviceMatch=usb|256c|006d|HUION Huion Tablet_H640P Pad;usb|256c|006d|HUION Huion Tablet_H640P Pen
 Class=Bamboo
 Width=6
 Height=4

--- a/data/huion-h950p.tablet
+++ b/data/huion-h950p.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=Huion H950P
 ModelName=
-DeviceMatch=usb:256c:006d:HID 256c:006d Pen;usb:256c:006d:HID 256c:006d Pad;usb:256c:006d:HUION Huion Tablet_H950P;usb:256c:006d:HUION Huion Tablet_H950P Pad;
+DeviceMatch=usb|256c|006d|HID 256c:006d Pen;usb|256c|006d|HID 256c:006d Pad;usb|256c|006d|HUION Huion Tablet_H950P;usb|256c|006d|HUION Huion Tablet_H950P Pad;
 Class=Bamboo
 Width=9
 Height=5

--- a/data/huion-hs611.tablet
+++ b/data/huion-hs611.tablet
@@ -36,7 +36,7 @@
 
 [Device]
 Name=Huion HS611
-DeviceMatch=usb:256c:006d:HUION Huion Tablet_HS611 Pad;usb:256c:006d:HUION Huion Tablet_HS611 Touch Strip;usb:256c:006d:HUION Huion Tablet_HS611 Pen
+DeviceMatch=usb|256c|006d|HUION Huion Tablet_HS611 Pad;usb|256c|006d|HUION Huion Tablet_HS611 Touch Strip;usb|256c|006d|HUION Huion Tablet_HS611 Pen
 Class=Bamboo
 Width=10
 Height=6

--- a/data/huion-kamvas-13.tablet
+++ b/data/huion-kamvas-13.tablet
@@ -24,7 +24,7 @@
 [Device]
 Name=Huion Kamvas 13
 ModelName=GS1331
-DeviceMatch=usb:256c:006d:HUION Huion Tablet_GS1331 Pad;usb:256c:006d:HUION Huion Tablet_GS1331 Pen
+DeviceMatch=usb|256c|006d|HUION Huion Tablet_GS1331 Pad;usb|256c|006d|HUION Huion Tablet_GS1331 Pen
 Class=Cintiq
 Width=12
 Height=7

--- a/data/huion-new-1060-plus.tablet
+++ b/data/huion-new-1060-plus.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Huion New 1060 Plus
 ModelName=
-DeviceMatch=usb:256c:006e:HID 256c:006e Pen;usb:256c:006e:HID 256c:006e Pad
+DeviceMatch=usb|256c|006e|HID 256c:006e Pen;usb|256c|006e|HID 256c:006e Pad
 Class=Bamboo
 Width=10
 Height=6

--- a/data/ingenic-6161.tablet
+++ b/data/ingenic-6161.tablet
@@ -1,6 +1,6 @@
 # Ingenic Touch/Pen Display
 # Integrated into the Lenovo Yoga Book 9i (13IRU8)
-# 
+#
 # sysinfo.zpUboT0IUG.tar.gz
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/346
 
@@ -8,7 +8,7 @@
 Name=Ingenic Touch/Pen display
 ModelName=
 Class=PenDisplay
-DeviceMatch=usb:17ef:6161
+DeviceMatch=usb|17ef|6161
 Width=11
 Height=6
 # No pad buttons, so no layout

--- a/data/intuos-12x12.tablet
+++ b/data/intuos-12x12.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Wacom Intuos 12x12
 ModelName=GD-1212
-DeviceMatch=usb:056a:0023
+DeviceMatch=usb|056a|0023
 Class=Intuos
 Width=12
 Height=12

--- a/data/intuos-12x18.tablet
+++ b/data/intuos-12x18.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Wacom Intuos 12x18
 ModelName=GD-1218
-DeviceMatch=usb:056a:0024
+DeviceMatch=usb|056a|0024
 Class=Intuos
 Width=18
 Height=12

--- a/data/intuos-4x5.tablet
+++ b/data/intuos-4x5.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Wacom Intuos 4x5
 ModelName=GD-0405
-DeviceMatch=usb:056a:0020
+DeviceMatch=usb|056a|0020
 Class=Intuos
 Width=5
 Height=4

--- a/data/intuos-6x8.tablet
+++ b/data/intuos-6x8.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Wacom Intuos 6x8
 ModelName=GD-0608
-DeviceMatch=usb:056a:0021
+DeviceMatch=usb|056a|0021
 Class=Intuos
 Width=8
 Height=6

--- a/data/intuos-9x12.tablet
+++ b/data/intuos-9x12.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Wacom Intuos 9x12
 ModelName=GD-0912
-DeviceMatch=usb:056a:0022
+DeviceMatch=usb|056a|0022
 Class=Intuos
 Width=12
 Height=9

--- a/data/intuos-m-p.tablet
+++ b/data/intuos-m-p.tablet
@@ -23,7 +23,7 @@
 [Device]
 Name=Intuos Pen Medium
 ModelName=CTL-680
-DeviceMatch=usb:056a:0323
+DeviceMatch=usb|056a|0323
 Class=Bamboo
 Width=9
 Height=5

--- a/data/intuos-m-p2.tablet
+++ b/data/intuos-m-p2.tablet
@@ -24,7 +24,7 @@
 [Device]
 Name=Intuos Pen Medium
 ModelName=CTL-690
-DeviceMatch=usb:056a:033d
+DeviceMatch=usb|056a|033d
 Class=Bamboo
 Width=9
 Height=5

--- a/data/intuos-m-p3-android.tablet
+++ b/data/intuos-m-p3-android.tablet
@@ -25,7 +25,7 @@
 [Device]
 Name=Wacom Intuos M (Android Mode)
 ModelName=CTL-6100
-DeviceMatch=usb:2d1f:0375
+DeviceMatch=usb|2d1f|0375
 Class=Bamboo
 Width=3
 Height=5

--- a/data/intuos-m-p3-wl-android.tablet
+++ b/data/intuos-m-p3-wl-android.tablet
@@ -25,7 +25,7 @@
 [Device]
 Name=Wacom Intuos BT M (Android Mode)
 ModelName=CTL-6100WL
-DeviceMatch=usb:2d1f:0378;usb:2d1f:03c7
+DeviceMatch=usb|2d1f|0378;usb|2d1f|03c7
 Class=Bamboo
 Width=3
 Height=5

--- a/data/intuos-m-p3-wl.tablet
+++ b/data/intuos-m-p3-wl.tablet
@@ -20,7 +20,7 @@
 [Device]
 Name=Wacom Intuos BT M
 ModelName=CTL-6100WL
-DeviceMatch=usb:056a:0378;bluetooth:056a:0379;usb:056a:03c7;bluetooth:056a:03c8
+DeviceMatch=usb|056a|0378;bluetooth|056a|0379;usb|056a|03c7;bluetooth|056a|03c8
 Class=Bamboo
 Width=9
 Height=5

--- a/data/intuos-m-p3.tablet
+++ b/data/intuos-m-p3.tablet
@@ -20,7 +20,7 @@
 [Device]
 Name=Wacom Intuos M
 ModelName=CTL-6100
-DeviceMatch=usb:056a:0375
+DeviceMatch=usb|056a|0375
 Class=Bamboo
 Width=9
 Height=5

--- a/data/intuos-m-pt.tablet
+++ b/data/intuos-m-pt.tablet
@@ -36,7 +36,7 @@
 [Device]
 Name=Intuos Pen & Touch Medium
 ModelName=CTH-680
-DeviceMatch=usb:056a:0303
+DeviceMatch=usb|056a|0303
 Class=Bamboo
 Width=9
 Height=5

--- a/data/intuos-m-pt2.tablet
+++ b/data/intuos-m-pt2.tablet
@@ -37,7 +37,7 @@
 [Device]
 Name=Intuos Pen & Touch Medium
 ModelName=CTH-690
-DeviceMatch=usb:056a:033e
+DeviceMatch=usb|056a|033e
 Class=Bamboo
 Width=9
 Height=5

--- a/data/intuos-pro-2-l.tablet
+++ b/data/intuos-pro-2-l.tablet
@@ -45,7 +45,7 @@
 [Device]
 Name=Wacom Intuos Pro L
 ModelName=PTH-860
-DeviceMatch=usb:056a:0358;bluetooth:056a:0361;
+DeviceMatch=usb|056a|0358;bluetooth|056a|0361;
 Class=Intuos5
 Width=12
 Height=8

--- a/data/intuos-pro-2-m.tablet
+++ b/data/intuos-pro-2-m.tablet
@@ -45,7 +45,7 @@
 [Device]
 Name=Wacom Intuos Pro M
 ModelName=PTH-660
-DeviceMatch=usb:056a:0357;bluetooth:056a:0360;
+DeviceMatch=usb|056a|0357;bluetooth|056a|0360;
 Class=Intuos5
 Width=9
 Height=6

--- a/data/intuos-pro-2-s.tablet
+++ b/data/intuos-pro-2-s.tablet
@@ -32,7 +32,7 @@
 [Device]
 Name=Wacom Intuos Pro S
 ModelName=PTH-460
-DeviceMatch=usb:056a:0392;bluetooth:056a:0393;usb:056a:03dc;bluetooth:056a:03dd;
+DeviceMatch=usb|056a|0392;bluetooth|056a|0393;usb|056a|03dc;bluetooth|056a|03dd;
 Class=Intuos5
 Width=6
 Height=4

--- a/data/intuos-pro-l.tablet
+++ b/data/intuos-pro-l.tablet
@@ -45,7 +45,7 @@
 [Device]
 Name=Wacom Intuos Pro L
 ModelName=PTH-851
-DeviceMatch=usb:056a:0317
+DeviceMatch=usb|056a|0317
 Class=Intuos5
 Width=13
 Height=8

--- a/data/intuos-pro-m.tablet
+++ b/data/intuos-pro-m.tablet
@@ -45,7 +45,7 @@
 [Device]
 Name=Wacom Intuos Pro M
 ModelName=PTH-651
-DeviceMatch=usb:056a:0315
+DeviceMatch=usb|056a|0315
 Class=Intuos5
 Width=9
 Height=6

--- a/data/intuos-pro-s.tablet
+++ b/data/intuos-pro-s.tablet
@@ -43,7 +43,7 @@
 [Device]
 Name=Wacom Intuos Pro S
 ModelName=PTH-451
-DeviceMatch=usb:056a:0314
+DeviceMatch=usb|056a|0314
 Class=Intuos5
 Width=6
 Height=4

--- a/data/intuos-s-p.tablet
+++ b/data/intuos-s-p.tablet
@@ -21,7 +21,7 @@
 [Device]
 Name=Intuos Pen Small
 ModelName=CTL-480
-DeviceMatch=usb:056a:030e
+DeviceMatch=usb|056a|030e
 Class=Bamboo
 Width=6
 Height=4

--- a/data/intuos-s-p2.tablet
+++ b/data/intuos-s-p2.tablet
@@ -22,7 +22,7 @@
 [Device]
 Name=Intuos Pen Small
 ModelName=CTL-490
-DeviceMatch=usb:056a:033b
+DeviceMatch=usb|056a|033b
 Class=Bamboo
 Width=6
 Height=4

--- a/data/intuos-s-p3-android.tablet
+++ b/data/intuos-s-p3-android.tablet
@@ -25,7 +25,7 @@
 [Device]
 Name=Wacom Intuos S (Android Mode)
 ModelName=CTL-4100
-DeviceMatch=usb:2d1f:0374
+DeviceMatch=usb|2d1f|0374
 Class=Bamboo
 Width=2
 Height=4

--- a/data/intuos-s-p3-wl-android.tablet
+++ b/data/intuos-s-p3-wl-android.tablet
@@ -25,7 +25,7 @@
 [Device]
 Name=Wacom Intuos BT S (Android Mode)
 ModelName=CTL-4100WL
-DeviceMatch=usb:2d1f:0376;usb:2d1f:03c5
+DeviceMatch=usb|2d1f|0376;usb|2d1f|03c5
 Class=Bamboo
 Width=2
 Height=4

--- a/data/intuos-s-p3-wl.tablet
+++ b/data/intuos-s-p3-wl.tablet
@@ -20,7 +20,7 @@
 [Device]
 Name=Wacom Intuos BT S
 ModelName=CTL-4100WL
-DeviceMatch=usb:056a:0376;bluetooth:056a:0377;usb:056a:03c5;bluetooth:056a:03c6
+DeviceMatch=usb|056a|0376;bluetooth|056a|0377;usb|056a|03c5;bluetooth|056a|03c6
 Class=Bamboo
 Width=6
 Height=4

--- a/data/intuos-s-p3.tablet
+++ b/data/intuos-s-p3.tablet
@@ -20,7 +20,7 @@
 [Device]
 Name=Wacom Intuos S
 ModelName=CTL-4100
-DeviceMatch=usb:056a:0374
+DeviceMatch=usb|056a|0374
 Class=Bamboo
 Width=6
 Height=4

--- a/data/intuos-s-pt.tablet
+++ b/data/intuos-s-pt.tablet
@@ -36,7 +36,7 @@
 [Device]
 Name=Intuos Pen & Touch Small
 ModelName=CTH-480
-DeviceMatch=usb:056a:0302
+DeviceMatch=usb|056a|0302
 Class=Bamboo
 Width=6
 Height=4

--- a/data/intuos-s-pt2.tablet
+++ b/data/intuos-s-pt2.tablet
@@ -36,7 +36,7 @@
 [Device]
 Name=Intuos Pen & Touch Small
 ModelName=CTH-490
-DeviceMatch=usb:056a:033c
+DeviceMatch=usb|056a|033c
 Class=Bamboo
 Width=6
 Height=4

--- a/data/intuos2-12x12.tablet
+++ b/data/intuos2-12x12.tablet
@@ -1,7 +1,7 @@
 [Device]
 Name=Wacom Intuos2 12x12
 ModelName=
-DeviceMatch=usb:056a:0044
+DeviceMatch=usb|056a|0044
 Class=Intuos2
 Width=12
 Height=12

--- a/data/intuos2-12x18.tablet
+++ b/data/intuos2-12x18.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Wacom Intuos2 12x18
 ModelName=XD-1218
-DeviceMatch=usb:056a:0045
+DeviceMatch=usb|056a|0045
 Class=Intuos2
 Width=18
 Height=12

--- a/data/intuos2-4x5.tablet
+++ b/data/intuos2-4x5.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Wacom Intuos2 4x5
 ModelName=XD-0405
-DeviceMatch=usb:056a:0041
+DeviceMatch=usb|056a|0041
 Class=Intuos2
 Width=5
 Height=4

--- a/data/intuos2-6x8.tablet
+++ b/data/intuos2-6x8.tablet
@@ -5,8 +5,8 @@
 [Device]
 Name=Wacom Intuos2 6x8
 ModelName=XD-0608
-# FIXME add missing usb:0056a:0047 match
-DeviceMatch=usb:056a:0042
+# FIXME add missing usb|0056a|0047 match
+DeviceMatch=usb|056a|0042
 Class=Intuos2
 Width=8
 Height=6

--- a/data/intuos2-9x12.tablet
+++ b/data/intuos2-9x12.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Wacom Intuos2 9x12
 ModelName=XD-0912
-DeviceMatch=usb:056a:0043
+DeviceMatch=usb|056a|0043
 Class=Intuos2
 Width=12
 Height=9

--- a/data/intuos3-12x12.tablet
+++ b/data/intuos3-12x12.tablet
@@ -32,7 +32,7 @@
 [Device]
 Name=Wacom Intuos3 12x12
 ModelName=PTZ-1230
-DeviceMatch=usb:056a:00b3
+DeviceMatch=usb|056a|00b3
 Class=Intuos3
 Width=12
 Height=12

--- a/data/intuos3-12x19.tablet
+++ b/data/intuos3-12x19.tablet
@@ -32,7 +32,7 @@
 [Device]
 Name=Wacom Intuos3 12x19
 ModelName=PTZ-1231W
-DeviceMatch=usb:056a:00b4
+DeviceMatch=usb|056a|00b4
 Class=Intuos3
 Width=19
 Height=12

--- a/data/intuos3-4x5.tablet
+++ b/data/intuos3-4x5.tablet
@@ -32,7 +32,7 @@
 [Device]
 Name=Wacom Intuos3 4x5
 ModelName=PTZ-430
-DeviceMatch=usb:056a:00b0
+DeviceMatch=usb|056a|00b0
 Class=Intuos3
 Width=5
 Height=4

--- a/data/intuos3-4x6.tablet
+++ b/data/intuos3-4x6.tablet
@@ -31,7 +31,7 @@
 [Device]
 Name=Wacom Intuos3 4x6
 ModelName=PTZ-431W
-DeviceMatch=usb:056a:00b7
+DeviceMatch=usb|056a|00b7
 Class=Intuos3
 Width=6
 Height=4

--- a/data/intuos3-6x11.tablet
+++ b/data/intuos3-6x11.tablet
@@ -31,7 +31,7 @@
 [Device]
 Name=Wacom Intuos3 6x11
 ModelName=PTZ-631W
-DeviceMatch=usb:056a:00b5
+DeviceMatch=usb|056a|00b5
 Class=Intuos3
 Width=11
 Height=6

--- a/data/intuos3-6x8.tablet
+++ b/data/intuos3-6x8.tablet
@@ -31,7 +31,7 @@
 [Device]
 Name=Wacom Intuos3 6x8
 ModelName=PTZ-630
-DeviceMatch=usb:056a:00b1
+DeviceMatch=usb|056a|00b1
 Class=Intuos3
 Width=8
 Height=6

--- a/data/intuos3-9x12.tablet
+++ b/data/intuos3-9x12.tablet
@@ -31,7 +31,7 @@
 [Device]
 Name=Wacom Intuos3 9x12
 ModelName=PTZ-930
-DeviceMatch=usb:056a:00b2
+DeviceMatch=usb|056a|00b2
 Class=Intuos3
 Width=12
 Height=9

--- a/data/intuos4-12x19.tablet
+++ b/data/intuos4-12x19.tablet
@@ -35,7 +35,7 @@
 [Device]
 Name=Wacom Intuos4 12x19
 ModelName=PTK-1240
-DeviceMatch=usb:056a:00bb
+DeviceMatch=usb|056a|00bb
 Class=Intuos4
 Width=19
 Height=12

--- a/data/intuos4-4x6.tablet
+++ b/data/intuos4-4x6.tablet
@@ -36,7 +36,7 @@
 [Device]
 Name=Wacom Intuos4 4x6
 ModelName=PTK-440
-DeviceMatch=usb:056a:00b8
+DeviceMatch=usb|056a|00b8
 Class=Intuos4
 Width=6
 Height=4

--- a/data/intuos4-6x9-wl.tablet
+++ b/data/intuos4-6x9-wl.tablet
@@ -35,7 +35,7 @@
 [Device]
 Name=Wacom Intuos4 WL
 ModelName=PTK-540WL
-DeviceMatch=usb:056a:00bc;bluetooth:056a:00bd
+DeviceMatch=usb|056a|00bc;bluetooth|056a|00bd
 Class=Intuos4
 Width=8
 Height=5

--- a/data/intuos4-6x9.tablet
+++ b/data/intuos4-6x9.tablet
@@ -35,7 +35,7 @@
 [Device]
 Name=Wacom Intuos4 6x9
 ModelName=PTK-640
-DeviceMatch=usb:056a:00b9
+DeviceMatch=usb|056a|00b9
 Class=Intuos4
 Width=9
 Height=6

--- a/data/intuos4-8x13.tablet
+++ b/data/intuos4-8x13.tablet
@@ -35,7 +35,7 @@
 [Device]
 Name=Wacom Intuos4 8x13
 ModelName=PTK-840
-DeviceMatch=usb:056a:00ba
+DeviceMatch=usb|056a|00ba
 Class=Intuos4
 Width=13
 Height=8

--- a/data/intuos5-m.tablet
+++ b/data/intuos5-m.tablet
@@ -45,7 +45,7 @@
 [Device]
 Name=Wacom Intuos5 M
 ModelName=PTK-650
-DeviceMatch=usb:056a:002a
+DeviceMatch=usb|056a|002a
 Class=Intuos5
 Width=9
 Height=6

--- a/data/intuos5-s.tablet
+++ b/data/intuos5-s.tablet
@@ -43,7 +43,7 @@
 [Device]
 Name=Wacom Intuos5 S
 ModelName=PTK-450
-DeviceMatch=usb:056a:0029
+DeviceMatch=usb|056a|0029
 Class=Intuos5
 Width=6
 Height=4

--- a/data/intuos5-touch-l.tablet
+++ b/data/intuos5-touch-l.tablet
@@ -45,7 +45,7 @@
 [Device]
 Name=Wacom Intuos5 touch L
 ModelName=PTH-850
-DeviceMatch=usb:056a:0028
+DeviceMatch=usb|056a|0028
 Class=Intuos5
 Width=13
 Height=8

--- a/data/intuos5-touch-m.tablet
+++ b/data/intuos5-touch-m.tablet
@@ -45,7 +45,7 @@
 [Device]
 Name=Wacom Intuos5 touch M
 ModelName=PTH-650
-DeviceMatch=usb:056a:0027
+DeviceMatch=usb|056a|0027
 Class=Intuos5
 Width=9
 Height=6

--- a/data/intuos5-touch-s.tablet
+++ b/data/intuos5-touch-s.tablet
@@ -43,7 +43,7 @@
 [Device]
 Name=Wacom Intuos5 touch S
 ModelName=PTH-450
-DeviceMatch=usb:056a:0026
+DeviceMatch=usb|056a|0026
 Class=Intuos5
 Width=6
 Height=4

--- a/data/isdv4-016c.tablet
+++ b/data/isdv4-016c.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 016c
 ModelName=
-DeviceMatch=i2c:056a:016c
+DeviceMatch=i2c|056a|016c
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-100.tablet
+++ b/data/isdv4-100.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 100
 ModelName=
-DeviceMatch=usb:056a:0100
+DeviceMatch=usb|056a|0100
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-101.tablet
+++ b/data/isdv4-101.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 101
 ModelName=
-DeviceMatch=usb:056a:0101
+DeviceMatch=usb|056a|0101
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-104.tablet
+++ b/data/isdv4-104.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 104
 ModelName=
-DeviceMatch=i2c:056a:0104
+DeviceMatch=i2c|056a|0104
 Class=ISDV4
 Width=9
 Height=5

--- a/data/isdv4-10d.tablet
+++ b/data/isdv4-10d.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 10D
 ModelName=
-DeviceMatch=usb:056a:010d
+DeviceMatch=usb|056a|010d
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-10e.tablet
+++ b/data/isdv4-10e.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 10E
 ModelName=
-DeviceMatch=usb:056a:010e
+DeviceMatch=usb|056a|010e
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-10f.tablet
+++ b/data/isdv4-10f.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 10F
 ModelName=
-DeviceMatch=usb:056a:010f
+DeviceMatch=usb|056a|010f
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-114.tablet
+++ b/data/isdv4-114.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 114
 ModelName=
-DeviceMatch=i2c:056a:0114
+DeviceMatch=i2c|056a|0114
 Class=ISDV4
 IntegratedIn=Display;System
 Width=9

--- a/data/isdv4-116.tablet
+++ b/data/isdv4-116.tablet
@@ -1,7 +1,7 @@
 [Device]
 Name=Wacom ISDv4 116
 ModelName=
-DeviceMatch=usb:056a:0116
+DeviceMatch=usb|056a|0116
 Class=ISDV4
 Width=8
 Height=6

--- a/data/isdv4-117.tablet
+++ b/data/isdv4-117.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 117
 ModelName=
-DeviceMatch=usb:056a:0117
+DeviceMatch=usb|056a|0117
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-121a.tablet
+++ b/data/isdv4-121a.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 121a
 ModelName=
-DeviceMatch=i2c:4858:121a
+DeviceMatch=i2c|4858|121a
 Class=ISDV4
 Width=10
 Height=6

--- a/data/isdv4-124.tablet
+++ b/data/isdv4-124.tablet
@@ -3,7 +3,7 @@
 
 [Device]
 Name=Wacom ISDv4 124
-DeviceMatch=i2c:056a:0124
+DeviceMatch=i2c|056a|0124
 ModelName=
 Class=ISDV4
 Width=9

--- a/data/isdv4-12c.tablet
+++ b/data/isdv4-12c.tablet
@@ -1,7 +1,7 @@
 [Device]
 Name=Wacom ISDv4 12C
 ModelName=
-DeviceMatch=usb:056a:012c
+DeviceMatch=usb|056a|012c
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-149.tablet
+++ b/data/isdv4-149.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 149
 ModelName=
-DeviceMatch=usb:056a:0149
+DeviceMatch=usb|056a|0149
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-2d1f-001e.tablet
+++ b/data/isdv4-2d1f-001e.tablet
@@ -4,7 +4,7 @@
 [Device]
 Name=Wacom ISDv4 1E
 ModelName=
-DeviceMatch=i2c:2d1f:001e
+DeviceMatch=i2c|2d1f|001e
 Class=ISDV4
 Width=13
 Height=7

--- a/data/isdv4-2d1f-002c.tablet
+++ b/data/isdv4-2d1f-002c.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 002c
 ModelName=
-DeviceMatch=i2c:2d1f:002c
+DeviceMatch=i2c|2d1f|002c
 Class=ISDV4
 Width=10
 Height=6

--- a/data/isdv4-2d1f-002e.tablet
+++ b/data/isdv4-2d1f-002e.tablet
@@ -4,7 +4,7 @@
 [Device]
 Name=Wacom ISDv4 2E
 ModelName=
-DeviceMatch=i2c:2d1f:002e
+DeviceMatch=i2c|2d1f|002e
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-2d1f-0040.tablet
+++ b/data/isdv4-2d1f-0040.tablet
@@ -9,8 +9,8 @@
 [Device]
 Name=Samsung Chromebook Plus v2
 ModelName=
-DeviceMatch=i2c:2d1f:0040:ACPI0C50:00 2D1F:0040 Stylus
-PairedIDs=i2c:06cB:7813
+DeviceMatch=i2c|2d1f|0040|ACPI0C50:00 2D1F:0040 Stylus
+PairedIDs=i2c|06cB|7813
 Class=ISDV4
 Width=12
 Height=8

--- a/data/isdv4-2d1f-0066.tablet
+++ b/data/isdv4-2d1f-0066.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 0066
 ModelName=
-DeviceMatch=i2c:2d1f:0066
+DeviceMatch=i2c|2d1f|0066
 Class=ISDV4
 Width=11
 Height=7

--- a/data/isdv4-2d1f-0095.tablet
+++ b/data/isdv4-2d1f-0095.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 0095
 ModelName=
-DeviceMatch=i2c:2d1f:0095
+DeviceMatch=i2c|2d1f|0095
 Class=ISDV4
 Width=8
 Height=6

--- a/data/isdv4-2d1f-0114.tablet
+++ b/data/isdv4-2d1f-0114.tablet
@@ -9,8 +9,8 @@
 [Device]
 Name=ISDv4 0114
 ModelName=
-DeviceMatch=i2c:2d1f:0114
-PairedID=i2c:04f3:2c86
+DeviceMatch=i2c|2d1f|0114
+PairedID=i2c|04f3|2c86
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-2d1f-0136.tablet
+++ b/data/isdv4-2d1f-0136.tablet
@@ -9,8 +9,8 @@
 [Device]
 Name=ISDv4 0136
 ModelName=
-DeviceMatch=i2c:2d1f:0136
-PairedID=i2c:27c6:0123
+DeviceMatch=i2c|2d1f|0136
+PairedID=i2c|27c6|0123
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-2d1f-0163.tablet
+++ b/data/isdv4-2d1f-0163.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 0163
 ModelName=
-DeviceMatch=i2c:2d1f:0163
+DeviceMatch=i2c|2d1f|0163
 Class=ISDV4
 Width=10
 Height=7

--- a/data/isdv4-2d1f-524c.tablet
+++ b/data/isdv4-2d1f-524c.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=Lenovo ThinkVision M14t
 ModelName=
-DeviceMatch=usb:2d1f:524c
+DeviceMatch=usb|2d1f|524c
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-4004.tablet
+++ b/data/isdv4-4004.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 4004
 ModelName=
-DeviceMatch=usb:056a:4004
+DeviceMatch=usb|056a|4004
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-4800.tablet
+++ b/data/isdv4-4800.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 4800
 ModelName=
-DeviceMatch=i2c:056a:4800
+DeviceMatch=i2c|056a|4800
 Class=ISDV4
 IntegratedIn=Display;System
 Styli=@isdv4-aes;

--- a/data/isdv4-4804.tablet
+++ b/data/isdv4-4804.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=Dell Latitude 7275
 ModelName=
-DeviceMatch=i2c:056a:4804
+DeviceMatch=i2c|056a|4804
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-4806.tablet
+++ b/data/isdv4-4806.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 4806
 ModelName=
-DeviceMatch=i2c:056a:4806
+DeviceMatch=i2c|056a|4806
 Class=ISDV4
 Width=9
 Height=5

--- a/data/isdv4-4807.tablet
+++ b/data/isdv4-4807.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 4807
 ModelName=
-DeviceMatch=i2c:056a:4807
+DeviceMatch=i2c|056a|4807
 Class=ISDV4
 Width=9
 Height=5

--- a/data/isdv4-4809.tablet
+++ b/data/isdv4-4809.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 4809
 ModelName=
-DeviceMatch=i2c:056a:4809
+DeviceMatch=i2c|056a|4809
 Class=ISDV4
 Width=4
 Height=7

--- a/data/isdv4-4814.tablet
+++ b/data/isdv4-4814.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 4814
 ModelName=
-DeviceMatch=i2c:056a:4814
+DeviceMatch=i2c|056a|4814
 Class=ISDV4
 Width=10
 Height=7

--- a/data/isdv4-481a.tablet
+++ b/data/isdv4-481a.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 481a
 ModelName=
-DeviceMatch=i2c:056a:481a
+DeviceMatch=i2c|056a|481a
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-4822.tablet
+++ b/data/isdv4-4822.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 4822
 ModelName=
-DeviceMatch=i2c:056a:4822
+DeviceMatch=i2c|056a|4822
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-4824.tablet
+++ b/data/isdv4-4824.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 4824
 ModelName=
-DeviceMatch=i2c:056a:4824
+DeviceMatch=i2c|056a|4824
 Class=ISDV4
 Width=4
 Height=7

--- a/data/isdv4-4831.tablet
+++ b/data/isdv4-4831.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 4831
 ModelName=
-DeviceMatch=i2c:056a:4831
+DeviceMatch=i2c|056a|4831
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-4834.tablet
+++ b/data/isdv4-4834.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 4834
 ModelName=
-DeviceMatch=i2c:056a:4834
+DeviceMatch=i2c|056a|4834
 Class=ISDV4
 Width=10
 Height=7

--- a/data/isdv4-4838.tablet
+++ b/data/isdv4-4838.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 4838
 ModelName=
-DeviceMatch=i2c:056a:4838
+DeviceMatch=i2c|056a|4838
 Class=ISDV4
 Width=10
 Height=7

--- a/data/isdv4-4841.tablet
+++ b/data/isdv4-4841.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 4841
 ModelName=
-DeviceMatch=i2c:056a:4841
+DeviceMatch=i2c|056a|4841
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-484c.tablet
+++ b/data/isdv4-484c.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 484c
 ModelName=
-DeviceMatch=i2c:056a:484c
+DeviceMatch=i2c|056a|484c
 Class=ISDV4
 Width=10
 Height=7

--- a/data/isdv4-484d.tablet
+++ b/data/isdv4-484d.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 484d
 ModelName=
-DeviceMatch=i2c:056a:484d
+DeviceMatch=i2c|056a|484d
 Class=ISDV4
 Width=10
 Height=7

--- a/data/isdv4-484e.tablet
+++ b/data/isdv4-484e.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 484e
 ModelName=
-DeviceMatch=i2c:056a:484e
+DeviceMatch=i2c|056a|484e
 Class=ISDV4
 Width=10
 Height=7

--- a/data/isdv4-4851.tablet
+++ b/data/isdv4-4851.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 4851
 ModelName=
-DeviceMatch=i2c:056a:4851
+DeviceMatch=i2c|056a|4851
 Class=ISDV4
 Width=10
 Height=7

--- a/data/isdv4-485e.tablet
+++ b/data/isdv4-485e.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 485e
 ModelName=
-DeviceMatch=i2c:056a:485e
+DeviceMatch=i2c|056a|485e
 Class=ISDV4
 Width=10
 Height=7

--- a/data/isdv4-4865.tablet
+++ b/data/isdv4-4865.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 4865
 ModelName=
-DeviceMatch=i2c:056a:4865
+DeviceMatch=i2c|056a|4865
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-486a.tablet
+++ b/data/isdv4-486a.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 486a
 ModelName=
-DeviceMatch=i2c:056a:486a
+DeviceMatch=i2c|056a|486a
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-4870.tablet
+++ b/data/isdv4-4870.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 4870
 ModelName=
-DeviceMatch=i2c:056a:4870
+DeviceMatch=i2c|056a|4870
 Class=ISDV4
 Width=11
 Height=7

--- a/data/isdv4-4875.tablet
+++ b/data/isdv4-4875.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 4875
 ModelName=
-DeviceMatch=i2c:056a:4875
+DeviceMatch=i2c|056a|4875
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-488f.tablet
+++ b/data/isdv4-488f.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 488f
 ModelName=
-DeviceMatch=i2c:056a:488f
+DeviceMatch=i2c|056a|488f
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-4898.tablet
+++ b/data/isdv4-4898.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 4898
 ModelName=
-DeviceMatch=i2c:056a:4898
+DeviceMatch=i2c|056a|4898
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-48b7.tablet
+++ b/data/isdv4-48b7.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=Wacom ISDv4 48b7
 ModelName=
-DeviceMatch=i2c:056a:48b7
+DeviceMatch=i2c|056a|48b7
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-48c9.tablet
+++ b/data/isdv4-48c9.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 48c9
 ModelName=
-DeviceMatch=i2c:056a:48c9
+DeviceMatch=i2c|056a|48c9
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-48ca.tablet
+++ b/data/isdv4-48ca.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 48CA
 ModelName=
-DeviceMatch=i2c:056a:48ca
+DeviceMatch=i2c|056a|48ca
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-48ce.tablet
+++ b/data/isdv4-48ce.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 48CE
 ModelName=
-DeviceMatch=i2c:056a:48ce
+DeviceMatch=i2c|056a|48ce
 Class=ISDV4
 Width=10
 Height=7

--- a/data/isdv4-48d6.tablet
+++ b/data/isdv4-48d6.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 48d6
 ModelName=
-DeviceMatch=i2c:056a:48d6
+DeviceMatch=i2c|056a|48d6
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-48eb.tablet
+++ b/data/isdv4-48eb.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 48eb
 ModelName=
-DeviceMatch=i2c:056a:48eb
+DeviceMatch=i2c|056a|48eb
 Class=ISDV4
 Width=11
 Height=7

--- a/data/isdv4-48ec.tablet
+++ b/data/isdv4-48ec.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom HID 48EC
 ModelName=
-DeviceMatch=i2c:056a:48ec
+DeviceMatch=i2c|056a|48ec
 Class=ISDV4
 Width=11
 Height=7

--- a/data/isdv4-48ed.tablet
+++ b/data/isdv4-48ed.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 48ed
 ModelName=
-DeviceMatch=i2c:056a:48ed
+DeviceMatch=i2c|056a|48ed
 Class=ISDV4
 Width=11
 Height=7

--- a/data/isdv4-48ee.tablet
+++ b/data/isdv4-48ee.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 48ee
 ModelName=
-DeviceMatch=i2c:056a:48ee
+DeviceMatch=i2c|056a|48ee
 Class=ISDV4
 Width=11
 Height=7

--- a/data/isdv4-48f6.tablet
+++ b/data/isdv4-48f6.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 48f6
 ModelName=
-DeviceMatch=i2c:056a:48f6
+DeviceMatch=i2c|056a|48f6
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-490a.tablet
+++ b/data/isdv4-490a.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 490a
 ModelName=
-DeviceMatch=i2c:056a:490a
+DeviceMatch=i2c|056a|490a
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-490b.tablet
+++ b/data/isdv4-490b.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 490b
 ModelName=
-DeviceMatch=i2c:056a:490b
+DeviceMatch=i2c|056a|490b
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-4957.tablet
+++ b/data/isdv4-4957.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 4957
 ModelName=
-DeviceMatch=i2c:056a:4957
+DeviceMatch=i2c|056a|4957
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-495f.tablet
+++ b/data/isdv4-495f.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 495F
 ModelName=
-DeviceMatch=i2c:056a:495f
+DeviceMatch=i2c|056a|495f
 Class=ISDV4
 Width=11
 Height=7

--- a/data/isdv4-496c.tablet
+++ b/data/isdv4-496c.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 496c
 ModelName=
-DeviceMatch=i2c:056a:496c
+DeviceMatch=i2c|056a|496c
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-4988.tablet
+++ b/data/isdv4-4988.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 4988
 ModelName=
-DeviceMatch=i2c:056a:4988
+DeviceMatch=i2c|056a|4988
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-4995.tablet
+++ b/data/isdv4-4995.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 4995
 ModelName=
-DeviceMatch=i2c:056a:4995
+DeviceMatch=i2c|056a|4995
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-49a3.tablet
+++ b/data/isdv4-49a3.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 49a3
 ModelName=
-DeviceMatch=i2c:056a:49a3
+DeviceMatch=i2c|056a|49a3
 Class=ISDV4
 Width=11
 Height=7

--- a/data/isdv4-49c8.tablet
+++ b/data/isdv4-49c8.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=Wacom HID 49C8
 ModelName=
-DeviceMatch=i2c:056a:49c8
+DeviceMatch=i2c|056a|49c8
 Class=ISDV4
 Width=11
 Height=7

--- a/data/isdv4-5000.tablet
+++ b/data/isdv4-5000.tablet
@@ -1,7 +1,7 @@
 [Device]
 Name=Wacom ISDv4 5000
 ModelName=
-DeviceMatch=usb:056a:5000
+DeviceMatch=usb|056a|5000
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-5002.tablet
+++ b/data/isdv4-5002.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 5002
 ModelName=
-DeviceMatch=usb:056a:5002
+DeviceMatch=usb|056a|5002
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-5010.tablet
+++ b/data/isdv4-5010.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 5010
 ModelName=
-DeviceMatch=usb:056a:5010
+DeviceMatch=usb|056a|5010
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-5013.tablet
+++ b/data/isdv4-5013.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 5013
 ModelName=
-DeviceMatch=i2c:056a:5013
+DeviceMatch=i2c|056a|5013
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5014.tablet
+++ b/data/isdv4-5014.tablet
@@ -4,7 +4,7 @@
 [Device]
 Name=Wacom ISDv4 5014
 ModelName=
-DeviceMatch=i2c:056a:5014
+DeviceMatch=i2c|056a|5014
 Class=ISDV4
 Width=10
 Height=6

--- a/data/isdv4-5019.tablet
+++ b/data/isdv4-5019.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5019
 ModelName=
-DeviceMatch=usb:056a:5019
+DeviceMatch=usb|056a|5019
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-502a.tablet
+++ b/data/isdv4-502a.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 50a2
 ModelName=
-DeviceMatch=usb:056a:50a2
+DeviceMatch=usb|056a|50a2
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-503e.tablet
+++ b/data/isdv4-503e.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Wacom ISDv4 503E
 ModelName=
-DeviceMatch=usb:056a:503e
+DeviceMatch=usb|056a|503e
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-503f.tablet
+++ b/data/isdv4-503f.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Wacom ISDv4 503F
 ModelName=
-DeviceMatch=usb:056a:503f
+DeviceMatch=usb|056a|503f
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5040.tablet
+++ b/data/isdv4-5040.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=Wacom ISDv4 5040
 ModelName=
-DeviceMatch=usb:056a:5040
+DeviceMatch=usb|056a|5040
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5044.tablet
+++ b/data/isdv4-5044.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=Wacom ISDv4 5044
 ModelName=
-DeviceMatch=usb:056a:5044
+DeviceMatch=usb|056a|5044
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-5048.tablet
+++ b/data/isdv4-5048.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Wacom ISDv4 5048
 ModelName=
-DeviceMatch=usb:056a:5048
+DeviceMatch=usb|056a|5048
 Class=ISDV4
 Width=10
 Height=6

--- a/data/isdv4-504a.tablet
+++ b/data/isdv4-504a.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 504a
 ModelName=
-DeviceMatch=usb:056a:504a
+DeviceMatch=usb|056a|504a
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-504c.tablet
+++ b/data/isdv4-504c.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 504c
 ModelName=
-DeviceMatch=usb:056a:504c
+DeviceMatch=usb|056a|504c
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5072.tablet
+++ b/data/isdv4-5072.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5072
 ModelName=
-DeviceMatch=i2c:056a:5072
+DeviceMatch=i2c|056a|5072
 Class=ISDV4
 Width=10
 Height=6

--- a/data/isdv4-5090.tablet
+++ b/data/isdv4-5090.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 5090
 ModelName=
-DeviceMatch=usb:056a:5090
+DeviceMatch=usb|056a|5090
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-5093.tablet
+++ b/data/isdv4-5093.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5093
 ModelName=
-DeviceMatch=usb:056a:5093
+DeviceMatch=usb|056a|5093
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5099.tablet
+++ b/data/isdv4-5099.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 5099
 ModelName=
-DeviceMatch=i2c:056a:5099
+DeviceMatch=i2c|056a|5099
 Class=ISDV4
 Width=10
 Height=7

--- a/data/isdv4-509d.tablet
+++ b/data/isdv4-509d.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 509D
 ModelName=
-DeviceMatch=usb:056a:509d
+DeviceMatch=usb|056a|509d
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-509f.tablet
+++ b/data/isdv4-509f.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 509F
 ModelName=
-DeviceMatch=usb:056a:509f
+DeviceMatch=usb|056a|509f
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-50a0.tablet
+++ b/data/isdv4-50a0.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=Wacom ISDv4 50A0
 ModelName=
-DeviceMatch=usb:056a:50a0
+DeviceMatch=usb|056a|50a0
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-50a9.tablet
+++ b/data/isdv4-50a9.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Wacom Pen and multitouch sensor Pen
 ModelName=
-DeviceMatch=usb:056a:50a9
+DeviceMatch=usb|056a|50a9
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-50b4.tablet
+++ b/data/isdv4-50b4.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 50b4
 ModelName=
-DeviceMatch=usb:056a:50b4
+DeviceMatch=usb|056a|50b4
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-50b6.tablet
+++ b/data/isdv4-50b6.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 50b6
 ModelName=
-DeviceMatch=usb:056a:50b6
+DeviceMatch=usb|056a|50b6
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-50b8.tablet
+++ b/data/isdv4-50b8.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 50b8
 ModelName=
-DeviceMatch=usb:056a:50b8
+DeviceMatch=usb|056a|50b8
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-50db.tablet
+++ b/data/isdv4-50db.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 50db
 ModelName=
-DeviceMatch=i2c:056a:50db
+DeviceMatch=i2c|056a|50db
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-50e9.tablet
+++ b/data/isdv4-50e9.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 50e9
 ModelName=
-DeviceMatch=i2c:056a:50e9
+DeviceMatch=i2c|056a|50e9
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-50ef.tablet
+++ b/data/isdv4-50ef.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 50ef
 ModelName=
-DeviceMatch=i2c:056a:50ef
+DeviceMatch=i2c|056a|50ef
 Class=ISDV4
 Width=12
 Height=6

--- a/data/isdv4-50f1.tablet
+++ b/data/isdv4-50f1.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 50f1
 ModelName=
-DeviceMatch=i2c:056a:50f1
+DeviceMatch=i2c|056a|50f1
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-50f8.tablet
+++ b/data/isdv4-50f8.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 50f8
 ModelName=
-DeviceMatch=i2c:056a:50f8
+DeviceMatch=i2c|056a|50f8
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-50fd.tablet
+++ b/data/isdv4-50fd.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 50fd
 ModelName=
-DeviceMatch=i2c:056a:50fd
+DeviceMatch=i2c|056a|50fd
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-50fe.tablet
+++ b/data/isdv4-50fe.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 50fe
 ModelName=
-DeviceMatch=i2c:056a:50fe
+DeviceMatch=i2c|056a|50fe
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-5110.tablet
+++ b/data/isdv4-5110.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 5110
 ModelName=
-DeviceMatch=i2c:056a:5110
+DeviceMatch=i2c|056a|5110
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5115.tablet
+++ b/data/isdv4-5115.tablet
@@ -2,7 +2,7 @@
 
 [Device]
 Name=Wacom HID 5115
-DeviceMatch=i2c:056a:5115
+DeviceMatch=i2c|056a|5115
 Class=ISDV4
 Width=10
 Height=7

--- a/data/isdv4-511a.tablet
+++ b/data/isdv4-511a.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 511a
 ModelName=
-DeviceMatch=i2c:056a:511a
+DeviceMatch=i2c|056a|511a
 Class=ISDV4
 Width=11
 Height=7

--- a/data/isdv4-5122.tablet
+++ b/data/isdv4-5122.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 5122
 ModelName=
-DeviceMatch=i2c:056a:5122
+DeviceMatch=i2c|056a|5122
 Class=ISDV4
 Width=10
 Height=6

--- a/data/isdv4-5128.tablet
+++ b/data/isdv4-5128.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 5128
 ModelName=
-DeviceMatch=i2c:056a:5128
+DeviceMatch=i2c|056a|5128
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-513b.tablet
+++ b/data/isdv4-513b.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 513B
 ModelName=
-DeviceMatch=i2c:056a:513b
+DeviceMatch=i2c|056a|513b
 Class=ISDV4
 Width=10
 Height=6

--- a/data/isdv4-5144.tablet
+++ b/data/isdv4-5144.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5144
 ModelName=
-DeviceMatch=usb:056a:5144
+DeviceMatch=usb|056a|5144
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5146.tablet
+++ b/data/isdv4-5146.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 5146
 ModelName=
-DeviceMatch=usb:056a:5146
+DeviceMatch=usb|056a|5146
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5147.tablet
+++ b/data/isdv4-5147.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 5147
 ModelName=
-DeviceMatch=usb:056a:5147
+DeviceMatch=usb|056a|5147
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5148.tablet
+++ b/data/isdv4-5148.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=Wacom ISDv4 5148
 ModelName=
-DeviceMatch=usb:056a:5148
+DeviceMatch=usb|056a|5148
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5150.tablet
+++ b/data/isdv4-5150.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 5150
 ModelName=
-DeviceMatch=usb:056a:5150
+DeviceMatch=usb|056a|5150
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5155.tablet
+++ b/data/isdv4-5155.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=Wacom ISDv4 5155
 ModelName=
-DeviceMatch=usb:056a:5155
+DeviceMatch=usb|056a|5155
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5157.tablet
+++ b/data/isdv4-5157.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 5157
 ModelName=
-DeviceMatch=usb:056a:5157;
+DeviceMatch=usb|056a|5157;
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5158.tablet
+++ b/data/isdv4-5158.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 5158
 ModelName=
-DeviceMatch=usb:056a:5158
+DeviceMatch=usb|056a|5158
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5159.tablet
+++ b/data/isdv4-5159.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5159
 ModelName=
-DeviceMatch=usb:056a:5159
+DeviceMatch=usb|056a|5159
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-515a.tablet
+++ b/data/isdv4-515a.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 515a
 ModelName=
-DeviceMatch=usb:056a:515a;
+DeviceMatch=usb|056a|515a;
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5169.tablet
+++ b/data/isdv4-5169.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 5169
 ModelName=
-DeviceMatch=i2c:056a:5169
+DeviceMatch=i2c|056a|5169
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-516b.tablet
+++ b/data/isdv4-516b.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 516B
 ModelName=
-DeviceMatch=i2c:056a:516b
+DeviceMatch=i2c|056a|516b
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-517d.tablet
+++ b/data/isdv4-517d.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 517D
 ModelName=
-DeviceMatch=i2c:056a:517d
+DeviceMatch=i2c|056a|517d
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5196.tablet
+++ b/data/isdv4-5196.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 5196
 ModelName=
-DeviceMatch=i2c:056a:5196
+DeviceMatch=i2c|056a|5196
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51a0.tablet
+++ b/data/isdv4-51a0.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 51a0
 ModelName=
-DeviceMatch=usb:056a:51a0
+DeviceMatch=usb|056a|51a0
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-51af.tablet
+++ b/data/isdv4-51af.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 51af
 ModelName=
-DeviceMatch=usb:056a:51af
+DeviceMatch=usb|056a|51af
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51b0.tablet
+++ b/data/isdv4-51b0.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=ISDv4 51B0
 ModelName=
-DeviceMatch=usb:056a:51b0
+DeviceMatch=usb|056a|51b0
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51b1.tablet
+++ b/data/isdv4-51b1.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=ISDv4 51B1
 ModelName=
-DeviceMatch=usb:056a:51b1
+DeviceMatch=usb|056a|51b1
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51b2.tablet
+++ b/data/isdv4-51b2.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=ISDv4 51B2
 ModelName=
-DeviceMatch=usb:056a:51b2
+DeviceMatch=usb|056a|51b2
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51b3.tablet
+++ b/data/isdv4-51b3.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=ISDv4 51B3
 ModelName=
-DeviceMatch=usb:056a:51b3
+DeviceMatch=usb|056a|51b3
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51b6.tablet
+++ b/data/isdv4-51b6.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=ISDv4 51B6
 ModelName=
-DeviceMatch=usb:056a:51b6
+DeviceMatch=usb|056a|51b6
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51b7.tablet
+++ b/data/isdv4-51b7.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=ISDv4 51B7
 ModelName=
-DeviceMatch=usb:056a:51b7
+DeviceMatch=usb|056a|51b7
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51b8.tablet
+++ b/data/isdv4-51b8.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 51B8
 ModelName=
-DeviceMatch=usb:056a:51b8
+DeviceMatch=usb|056a|51b8
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51b9.tablet
+++ b/data/isdv4-51b9.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=ISDv4 51B9
 ModelName=
-DeviceMatch=usb:056a:51b9
+DeviceMatch=usb|056a|51b9
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51ba.tablet
+++ b/data/isdv4-51ba.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=ISDv4 51BA
 ModelName=
-DeviceMatch=usb:056a:51ba
+DeviceMatch=usb|056a|51ba
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51bb.tablet
+++ b/data/isdv4-51bb.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=ISDv4 51BB
 ModelName=
-DeviceMatch=usb:056a:51bb
+DeviceMatch=usb|056a|51bb
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51bc.tablet
+++ b/data/isdv4-51bc.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=ISDv4 51BC
 ModelName=
-DeviceMatch=usb:056a:51bc
+DeviceMatch=usb|056a|51bc
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51bd.tablet
+++ b/data/isdv4-51bd.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=ISDv4 51BD
 ModelName=
-DeviceMatch=usb:056a:51bd
+DeviceMatch=usb|056a|51bd
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51be.tablet
+++ b/data/isdv4-51be.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 51BE
 ModelName=
-DeviceMatch=usb:056a:51be
+DeviceMatch=usb|056a|51be
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51bf.tablet
+++ b/data/isdv4-51bf.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 51BF
 ModelName=
-DeviceMatch=usb:056a:51bf
+DeviceMatch=usb|056a|51bf
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51c4.tablet
+++ b/data/isdv4-51c4.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 51C4
 ModelName=
-DeviceMatch=i2c:056a:51c4
+DeviceMatch=i2c|056a|51c4
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51c7.tablet
+++ b/data/isdv4-51c7.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 51C7
 ModelName=
-DeviceMatch=i2c:056a:51c7
+DeviceMatch=i2c|056a|51c7
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51d0.tablet
+++ b/data/isdv4-51d0.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 51d0
 ModelName=
-DeviceMatch=usb:056a:51d0
+DeviceMatch=usb|056a|51d0
 Class=ISDV4
 Width=11
 Height=7

--- a/data/isdv4-51e2.tablet
+++ b/data/isdv4-51e2.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 51e2
 ModelName=
-DeviceMatch=i2c:056a:51e2
+DeviceMatch=i2c|056a|51e2
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51e9.tablet
+++ b/data/isdv4-51e9.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 51e9
 ModelName=
-DeviceMatch=usb:056a:51e9
+DeviceMatch=usb|056a|51e9
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-51ef.tablet
+++ b/data/isdv4-51ef.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 51ef
 ModelName=
-DeviceMatch=i2c:056a:51ef
+DeviceMatch=i2c|056a|51ef
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51f5.tablet
+++ b/data/isdv4-51f5.tablet
@@ -4,7 +4,7 @@
 [Device]
 Name=Wacom ISDv4 F1F5
 ModelName=
-DeviceMatch=usb:056a:51f5
+DeviceMatch=usb|056a|51f5
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51f6.tablet
+++ b/data/isdv4-51f6.tablet
@@ -4,7 +4,7 @@
 [Device]
 Name=Wacom ISDv4 51F6
 ModelName=
-DeviceMatch=usb:056a:51f6
+DeviceMatch=usb|056a|51f6
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-51f9.tablet
+++ b/data/isdv4-51f9.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 51f9
 ModelName=
-DeviceMatch=usb:056a:51f9
+DeviceMatch=usb|056a|51f9
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5202.tablet
+++ b/data/isdv4-5202.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5202
 ModelName=
-DeviceMatch=i2c:056a:5202
+DeviceMatch=i2c|056a|5202
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5204.tablet
+++ b/data/isdv4-5204.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5204
 ModelName=
-DeviceMatch=i2c:056a:5204
+DeviceMatch=i2c|056a|5204
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5215.tablet
+++ b/data/isdv4-5215.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5215
 ModelName=
-DeviceMatch=i2c:056a:5215
+DeviceMatch=i2c|056a|5215
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5216.tablet
+++ b/data/isdv4-5216.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5216
 ModelName=
-DeviceMatch=i2c:056a:5216
+DeviceMatch=i2c|056a|5216
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5218.tablet
+++ b/data/isdv4-5218.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5218
 ModelName=
-DeviceMatch=i2c:056a:5218
+DeviceMatch=i2c|056a|5218
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-521c.tablet
+++ b/data/isdv4-521c.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 521c
 ModelName=
-DeviceMatch=i2c:056a:521c
+DeviceMatch=i2c|056a|521c
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-521f.tablet
+++ b/data/isdv4-521f.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=ISDv4 521F
 ModelName=
-DeviceMatch=usb:056a:521f
+DeviceMatch=usb|056a|521f
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5220.tablet
+++ b/data/isdv4-5220.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5220
 ModelName=
-DeviceMatch=usb:056a:5220
+DeviceMatch=usb|056a|5220
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5221.tablet
+++ b/data/isdv4-5221.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=ISDv4 5221
 ModelName=
-DeviceMatch=usb:056a:5221
+DeviceMatch=usb|056a|5221
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5222.tablet
+++ b/data/isdv4-5222.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=ISDv4 5222
 ModelName=
-DeviceMatch=usb:056a:5222
+DeviceMatch=usb|056a|5222
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5229.tablet
+++ b/data/isdv4-5229.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5229
 ModelName=
-DeviceMatch=usb:056a:5229;usb:056a:522a
+DeviceMatch=usb|056a|5229;usb|056a|522a
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-523a.tablet
+++ b/data/isdv4-523a.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 523a
 ModelName=
-DeviceMatch=i2c:056a:523a
+DeviceMatch=i2c|056a|523a
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-523e.tablet
+++ b/data/isdv4-523e.tablet
@@ -8,7 +8,7 @@
 [Device]
 Name=ISDv4 523e
 ModelName=
-DeviceMatch=i2c:056a:523e
+DeviceMatch=i2c|056a|523e
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5256.tablet
+++ b/data/isdv4-5256.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5256
 ModelName=
-DeviceMatch=i2c:056a:5256
+DeviceMatch=i2c|056a|5256
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-526c.tablet
+++ b/data/isdv4-526c.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 526c
 ModelName=
-DeviceMatch=i2c:056a:526c
+DeviceMatch=i2c|056a|526c
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5276.tablet
+++ b/data/isdv4-5276.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5276
 ModelName=
-DeviceMatch=i2c:056a:5276
+DeviceMatch=i2c|056a|5276
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5277.tablet
+++ b/data/isdv4-5277.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5277
 ModelName=
-DeviceMatch=i2c:056a:5277
+DeviceMatch=i2c|056a|5277
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5278.tablet
+++ b/data/isdv4-5278.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5278
 ModelName=
-DeviceMatch=i2c:056a:5278
+DeviceMatch=i2c|056a|5278
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5279.tablet
+++ b/data/isdv4-5279.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5279
 ModelName=
-DeviceMatch=i2c:056a:5279
+DeviceMatch=i2c|056a|5279
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-527a.tablet
+++ b/data/isdv4-527a.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 527a
 ModelName=
-DeviceMatch=i2c:056a:527a
+DeviceMatch=i2c|056a|527a
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-527e.tablet
+++ b/data/isdv4-527e.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 527e
 ModelName=
-DeviceMatch=i2c:056a:527e
+DeviceMatch=i2c|056a|527e
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-527f.tablet
+++ b/data/isdv4-527f.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 527f
 ModelName=
-DeviceMatch=i2c:056a:527f
+DeviceMatch=i2c|056a|527f
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-5285.tablet
+++ b/data/isdv4-5285.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5285
 ModelName=
-DeviceMatch=i2c:056a:5285
+DeviceMatch=i2c|056a|5285
 Class=ISDV4
 Width=11
 Height=7

--- a/data/isdv4-5286.tablet
+++ b/data/isdv4-5286.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5286
 ModelName=
-DeviceMatch=i2c:056a:5286
+DeviceMatch=i2c|056a|5286
 Class=ISDV4
 Width=11
 Height=7

--- a/data/isdv4-528e.tablet
+++ b/data/isdv4-528e.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 528e
 ModelName=
-DeviceMatch=i2c:056a:528e
+DeviceMatch=i2c|056a|528e
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-52a2.tablet
+++ b/data/isdv4-52a2.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 52a2
 ModelName=
-DeviceMatch=i2c:056a:52a2
+DeviceMatch=i2c|056a|52a2
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-52b0.tablet
+++ b/data/isdv4-52b0.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 52b0
 ModelName=
-DeviceMatch=i2c:056a:52b0
+DeviceMatch=i2c|056a|52b0
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-52d3.tablet
+++ b/data/isdv4-52d3.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=Wacom HID 52D3
 ModelName=WACF2200
-DeviceMatch=i2c:056a:52d3
+DeviceMatch=i2c|056a|52d3
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-52d5.tablet
+++ b/data/isdv4-52d5.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=Wacom HID 52D5
 ModelName=WACF2200
-DeviceMatch=i2c:056a:52d5
+DeviceMatch=i2c|056a|52d5
 Class=ISDV4
 IntegratedIn=Display;System
 Width=12

--- a/data/isdv4-5309.tablet
+++ b/data/isdv4-5309.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5309
 ModelName=
-DeviceMatch=i2c:056a:5309
+DeviceMatch=i2c|056a|5309
 Class=ISDV4
 Width=12
 Height=7

--- a/data/isdv4-90.tablet
+++ b/data/isdv4-90.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=Wacom ISDv4 90
 ModelName=
-DeviceMatch=usb:056a:0090;serial:056a:0090
+DeviceMatch=usb|056a|0090;serial|056a|0090
 Class=ISDV4
 Width=12
 Height=8

--- a/data/isdv4-93.tablet
+++ b/data/isdv4-93.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=Wacom ISDv4 93
 ModelName=
-DeviceMatch=usb:056a:0093;serial:056a:0093
+DeviceMatch=usb|056a|0093;serial|056a|0093
 Class=ISDV4
 Width=10
 Height=6

--- a/data/isdv4-e2.tablet
+++ b/data/isdv4-e2.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 E2
 ModelName=
-DeviceMatch=usb:056a:00e2
+DeviceMatch=usb|056a|00e2
 Class=ISDV4
 Width=14
 Height=8

--- a/data/isdv4-e3.tablet
+++ b/data/isdv4-e3.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 E3
 ModelName=
-DeviceMatch=usb:056a:00e3;serial:056a:00e3
+DeviceMatch=usb|056a|00e3;serial|056a|00e3
 Class=ISDV4
 IntegratedIn=Display;System
 

--- a/data/isdv4-e5.tablet
+++ b/data/isdv4-e5.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 E5
 ModelName=
-DeviceMatch=usb:056a:00e5
+DeviceMatch=usb|056a|00e5
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-e6.tablet
+++ b/data/isdv4-e6.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 E6
 ModelName=
-DeviceMatch=usb:056a:00e6
+DeviceMatch=usb|056a|00e6
 Class=ISDV4
 Width=11
 Height=6

--- a/data/isdv4-ec.tablet
+++ b/data/isdv4-ec.tablet
@@ -4,10 +4,10 @@
 [Device]
 Name=Wacom ISDv4 EC
 ModelName=
-DeviceMatch=usb:056a:00ec
+DeviceMatch=usb|056a|00ec
 Class=ISDV4
 IntegratedIn=Display;System
-PairedID=usb:04f3:0254
+PairedID=usb|04f3|0254
 
 [Features]
 Stylus=true

--- a/data/isdv4-ed.tablet
+++ b/data/isdv4-ed.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 ED
 ModelName=
-DeviceMatch=usb:056a:00ed
+DeviceMatch=usb|056a|00ed
 Class=ISDV4
 IntegratedIn=Display;System
 

--- a/data/isdv4-ef.tablet
+++ b/data/isdv4-ef.tablet
@@ -3,7 +3,7 @@
 [Device]
 Name=Wacom ISDv4 EF
 ModelName=
-DeviceMatch=usb:056a:00ef
+DeviceMatch=usb|056a|00ef
 Class=ISDV4
 IntegratedIn=Display;System
 

--- a/data/kamvas-pro-13.tablet
+++ b/data/kamvas-pro-13.tablet
@@ -38,7 +38,7 @@
 Name=Huion Kamvas Pro 13
 ModelName=GT-133
 Class=Cintiq
-DeviceMatch=usb:256c:006e:Tablet Monitor Pen;usb:256c:006e:Tablet Monitor Pad;
+DeviceMatch=usb|256c|006e|Tablet Monitor Pen;usb|256c|006e|Tablet Monitor Pad;
 Width=12
 Height=7
 Layout=kamvas-pro-13.svg

--- a/data/lenovo-ideapad-duet.tablet
+++ b/data/lenovo-ideapad-duet.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=Lenovo Ideapad Duet
 Class=ISDV4
-DeviceMatch=i2c:27c6:0e30
+DeviceMatch=i2c|27c6|0e30
 Width=9
 Height=5
 IntegratedIn=Display;System

--- a/data/letsketch-wp9620.tablet
+++ b/data/letsketch-wp9620.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=LetSketch LetSketch
 ModelName=WP9620
-DeviceMatch=usb:6161:4d15
+DeviceMatch=usb|6161|4d15
 PairedIDs=
 Class=Bamboo
 Width=8

--- a/data/mobilestudio-pro-13-2.tablet
+++ b/data/mobilestudio-pro-13-2.tablet
@@ -37,8 +37,8 @@
 Name=Wacom MobileStudio Pro 13
 ModelName=DTH-W1321
 Class=Cintiq
-DeviceMatch=usb:056a:0398
-PairedID=usb:056a:039a
+DeviceMatch=usb|056a|0398
+PairedID=usb|056a|039a
 Width=12
 Height=7
 Layout=mobilestudio-pro-13.svg

--- a/data/mobilestudio-pro-13.tablet
+++ b/data/mobilestudio-pro-13.tablet
@@ -37,8 +37,8 @@
 Name=Wacom MobileStudio Pro 13
 ModelName=DTH-W1320
 Class=Cintiq
-DeviceMatch=usb:056a:034d
-PairedID=usb:056a:034a
+DeviceMatch=usb|056a|034d
+PairedID=usb|056a|034a
 Width=12
 Height=7
 Layout=mobilestudio-pro-13.svg

--- a/data/mobilestudio-pro-16-2.tablet
+++ b/data/mobilestudio-pro-16-2.tablet
@@ -39,8 +39,8 @@
 Name=Wacom MobileStudio Pro 16
 ModelName=DTH-W1621
 Class=Cintiq
-DeviceMatch=usb:056a:0399
-PairedID=usb:056a:039b
+DeviceMatch=usb|056a|0399
+PairedID=usb|056a|039b
 Width=14
 Height=8
 Layout=mobilestudio-pro-16.svg

--- a/data/mobilestudio-pro-16-3.tablet
+++ b/data/mobilestudio-pro-16-3.tablet
@@ -39,8 +39,8 @@
 Name=Wacom MobileStudio Pro 16
 ModelName=DTH-W1620
 Class=Cintiq
-DeviceMatch=usb:056a:03aa
-PairedID=usb:056a:03ac
+DeviceMatch=usb|056a|03aa
+PairedID=usb|056a|03ac
 Width=14
 Height=8
 Layout=mobilestudio-pro-16.svg

--- a/data/mobilestudio-pro-16.tablet
+++ b/data/mobilestudio-pro-16.tablet
@@ -39,8 +39,8 @@
 Name=Wacom MobileStudio Pro 16
 ModelName=DTH-W1620
 Class=Cintiq
-DeviceMatch=usb:056a:034e
-PairedID=usb:056a:034b
+DeviceMatch=usb|056a|034e
+PairedID=usb|056a|034b
 Width=14
 Height=8
 Layout=mobilestudio-pro-16.svg

--- a/data/n-trig-pen.tablet
+++ b/data/n-trig-pen.tablet
@@ -8,7 +8,7 @@
 [Device]
 Name=N-Trig Pen
 ModelName=
-DeviceMatch=usb:1b96:0001
+DeviceMatch=usb|1b96|0001
 Class=ISDV4
 Width=10
 Height=6

--- a/data/one-by-wacom-m-p.tablet
+++ b/data/one-by-wacom-m-p.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=One by Wacom (medium)
 ModelName=CTL-671
-DeviceMatch=usb:056a:0301
+DeviceMatch=usb|056a|0301
 Class=Bamboo
 Width=9
 Height=5

--- a/data/one-by-wacom-m-p2.tablet
+++ b/data/one-by-wacom-m-p2.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=One by Wacom (medium)
 ModelName=CTL-672
-DeviceMatch=usb:056a:037b
+DeviceMatch=usb|056a|037b
 Class=Bamboo
 Width=9
 Height=5

--- a/data/one-by-wacom-s-p.tablet
+++ b/data/one-by-wacom-s-p.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=One by Wacom (small)
 ModelName=CTL-471
-DeviceMatch=usb:056a:0300
+DeviceMatch=usb|056a|0300
 Class=Bamboo
 Width=6
 Height=4

--- a/data/one-by-wacom-s-p2.tablet
+++ b/data/one-by-wacom-s-p2.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=One by Wacom (small)
 ModelName=CTL-472
-DeviceMatch=usb:056a:037a
+DeviceMatch=usb|056a|037a
 Class=Bamboo
 Width=6
 Height=4

--- a/data/serial-wacf004.tablet
+++ b/data/serial-wacf004.tablet
@@ -1,7 +1,7 @@
 [Device]
 Name=Wacom Serial Tablet WACf004
 ModelName=
-DeviceMatch=serial:0000:0000
+DeviceMatch=serial|0000|0000
 Class=ISDV4
 IntegratedIn=Display;System
 

--- a/data/surface-go-2.tablet
+++ b/data/surface-go-2.tablet
@@ -8,7 +8,7 @@
 [Device]
 Name=Microsoft Surface Go 2
 Class=ISDV4
-DeviceMatch=i2c:04f3:2a1c
+DeviceMatch=i2c|04f3|2a1c
 Width=10
 Height=7
 IntegratedIn=Display;System;

--- a/data/surface-go.tablet
+++ b/data/surface-go.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=Microsoft Surface Go
 Class=ISDV4
-DeviceMatch=i2c:04f3:261a
+DeviceMatch=i2c|04f3|261a
 Width=8
 Height=5
 IntegratedIn=Display;System;

--- a/data/volito-4x5.tablet
+++ b/data/volito-4x5.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Wacom Volito 4x5
 ModelName=FT-0405
-DeviceMatch=usb:056a:0060
+DeviceMatch=usb|056a|0060
 Class=Graphire
 Width=5
 Height=4

--- a/data/wacom-hid-52fa-pen.tablet
+++ b/data/wacom-hid-52fa-pen.tablet
@@ -9,7 +9,7 @@
 Name=Wacom HID 52FA Pen
 ModelName=WACF2200
 Class=ISDV4
-DeviceMatch=i2c:056a:52fa;
+DeviceMatch=i2c|056a|52fa;
 # Width=11
 # Height=6
 # No pad buttons, so no layout

--- a/data/wacom-hid-5362.tablet
+++ b/data/wacom-hid-5362.tablet
@@ -8,7 +8,7 @@
 Name=Wacom HID 5362 Pen,Wacom HID 5362 Finger
 ModelName=
 Class=ISDV4
-DeviceMatch=i2c:056a:5362
+DeviceMatch=i2c|056a|5362
 Width=14
 Height=9
 IntegratedIn=Display;System

--- a/data/wacom-one-12.tablet
+++ b/data/wacom-one-12.tablet
@@ -9,7 +9,7 @@
 Name=Wacom One Pen Display 12
 ModelName=DTC121
 Class=PenDisplay
-DeviceMatch=usb:056a:03ce
+DeviceMatch=usb|056a|03ce
 Width=11
 Height=6
 # No pad buttons, so no layout

--- a/data/wacom-one-13.tablet
+++ b/data/wacom-one-13.tablet
@@ -9,7 +9,7 @@
 Name=Wacom One Pen Display 13
 ModelName=DTH134
 Class=PenDisplay
-DeviceMatch=usb:056a:03cb
+DeviceMatch=usb|056a|03cb
 Width=13
 Height=7
 # No pad buttons, so no layout

--- a/data/wacom-one-pen-m.tablet
+++ b/data/wacom-one-pen-m.tablet
@@ -17,7 +17,7 @@
 [Device]
 Name=Wacom One Pen tablet medium
 ModelName=CTC6110WL
-DeviceMatch=usb:0531:0102;bluetooth:0531:0103;usb:0531:0105
+DeviceMatch=usb|0531|0102;bluetooth|0531|0103;usb|0531|0105
 Class=Bamboo
 Width=9
 Height=5

--- a/data/wacom-one-pen-s.tablet
+++ b/data/wacom-one-pen-s.tablet
@@ -17,7 +17,7 @@
 [Device]
 Name=Wacom One Pen tablet small
 ModelName=CTC4110WL
-DeviceMatch=usb:0531:0100;bluetooth:0531:0101;usb:0531:0104
+DeviceMatch=usb|0531|0100;bluetooth|0531|0101;usb|0531|0104
 Class=Bamboo
 Width=6
 Height=4

--- a/data/wacom-one.tablet
+++ b/data/wacom-one.tablet
@@ -6,7 +6,7 @@
 Name=Wacom One Pen Display 13
 ModelName=DTC133
 Class=PenDisplay
-DeviceMatch=usb:056a:03a6;usb:056a:03bd
+DeviceMatch=usb|056a|03a6;usb|056a|03bd
 Width=11
 Height=6
 # No pad buttons, so no layout

--- a/data/wacom.example
+++ b/data/wacom.example
@@ -81,7 +81,11 @@ DeviceMatch=usb|056a|00bc;bluetooth|056a|00bc;
 # (common for HUION, GAOMON, UCLogic, XP-Pen), use the device name
 # as fourth element in the match string.
 # DeviceMatch=usb|1234|abcd:SomeDevice Name;
-
+#
+# Optionally after the device name (which may be empty) the
+# the remainer of that substring is the firmware version to match against.
+# DeviceMatch=usb|1234|abcd||ABC_1234;
+# DeviceMatch=usb|1234|abcd|SomeDevice Name|ABC_1234;
 
 # Paired PID includes the match line of any device that share the same
 # physical device but has different product or vendor ids (e.g. the touch

--- a/data/wacom.example
+++ b/data/wacom.example
@@ -76,11 +76,11 @@ ModelName=
 # so it has exactly 4 digits. hex letters must be lowercase.
 #
 # Multiple matches are joined by a semicolon
-DeviceMatch=usb:056a:00bc;bluetooth:056a:00bc;
+DeviceMatch=usb|056a|00bc;bluetooth|056a|00bc;
 # If the vendor/product ID is not sufficient to distinguish the name
 # (common for HUION, GAOMON, UCLogic, XP-Pen), use the device name
 # as fourth element in the match string.
-# DeviceMatch=usb:1234:abcd:SomeDevice Name;
+# DeviceMatch=usb|1234|abcd:SomeDevice Name;
 
 
 # Paired PID includes the match line of any device that share the same
@@ -88,7 +88,7 @@ DeviceMatch=usb:056a:00bc;bluetooth:056a:00bc;
 # device on the 24HDT). The format of the match line is identical to
 # DeviceMatch but only one value is permitted.
 # Note: the PIDs listed may not be libwacom devices themselves.
-PairedIDs=usb:056a:0335
+PairedIDs=usb|056a|0335
 
 # Class of the tablet. Valid classes include Intuos3, Intuos4, Graphire, Bamboo, Cintiq
 # If unsure, or not applicable (the tablet isn't stand-alone for example).

--- a/data/wacom.example
+++ b/data/wacom.example
@@ -60,9 +60,9 @@ Name=Wacom Intuos4 6x9
 ModelName=
 
 # DeviceMatch includes the bus (usb, bluetooth, serial), the vendor ID and
-# product ID. This is the connector used, not whatever name the kernel
-# might give it, so some "Wacom Serial" builtin devices will be USB
-# as that's how they're connected.
+# product ID and optionally the device name. This is the connector used,
+# not whatever name the kernel might give it, so some "Wacom Serial" builtin
+# devices will be USB as that's how they're connected.
 #
 # For example:
 # $ lsusb | grep Wacom
@@ -74,7 +74,14 @@ ModelName=
 #
 # Do not add 0x in front of the hex numbers, make sure to pad each ID
 # so it has exactly 4 digits. hex letters must be lowercase.
-DeviceMatch=usb:056a:00bc
+#
+# Multiple matches are joined by a semicolon
+DeviceMatch=usb:056a:00bc;bluetooth:056a:00bc;
+# If the vendor/product ID is not sufficient to distinguish the name
+# (common for HUION, GAOMON, UCLogic, XP-Pen), use the device name
+# as fourth element in the match string.
+# DeviceMatch=usb:1234:abcd:SomeDevice Name;
+
 
 # Paired PID includes the match line of any device that share the same
 # physical device but has different product or vendor ids (e.g. the touch

--- a/data/waltop-slim-tablet-12-1.tablet
+++ b/data/waltop-slim-tablet-12-1.tablet
@@ -10,7 +10,7 @@
 [Device]
 Name=Waltop Slim Tablet 12.1"
 ModelName=
-DeviceMatch=usb:172f:0031
+DeviceMatch=usb|172f|0031
 Class=Bamboo
 Width=10
 Height=6

--- a/data/xp-pen-artist10s.tablet
+++ b/data/xp-pen-artist10s.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=UGEE 10.1 Tablet Monitor
 ModelName=
-DeviceMatch=usb:5543:004a:UGEE 10.1 Tablet Monitor;usb:5543:004a:UGEE 10.1 Tablet Monitor Pad;usb:5543:004a:UGEE 10.1 Tablet Monitor Mouse
+DeviceMatch=usb|5543|004a|UGEE 10.1 Tablet Monitor;usb|5543|004a|UGEE 10.1 Tablet Monitor Pad;usb|5543|004a|UGEE 10.1 Tablet Monitor Mouse
 PairedIDs=
 Class=Bamboo
 Width=9

--- a/data/xp-pen-artist12.tablet
+++ b/data/xp-pen-artist12.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=XP-Pen Artist 12
 ModelName=
-DeviceMatch=usb:28bd:080a:UGTABLET 11.6 inch PenDisplay Mouse;usb:28bd:080a:UGTABLET 11.6 inch PenDisplay;usb:28bd:080a:UGTABLET 11.6 inch PenDisplay;usb:28bd:080a:UGTABLET 11.6 inch PenDisplay Keyboard
+DeviceMatch=usb|28bd|080a|UGTABLET 11.6 inch PenDisplay Mouse;usb|28bd|080a|UGTABLET 11.6 inch PenDisplay;usb|28bd|080a|UGTABLET 11.6 inch PenDisplay;usb|28bd|080a|UGTABLET 11.6 inch PenDisplay Keyboard
 PairedIDs=
 Class=Bamboo
 Width=10

--- a/data/xp-pen-artist13-3-pro.tablet
+++ b/data/xp-pen-artist13-3-pro.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=UGTABLET 13.3 inch PenDisplay
 ModelName=
-DeviceMatch=usb:28bd:092b
+DeviceMatch=usb|28bd|092b
 PairedIDs=
 Class=Bamboo
 Width=11

--- a/data/xp-pen-deco-l.tablet
+++ b/data/xp-pen-deco-l.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=Hanvon Ugee Technology Co.,Ltd Deco L
 ModelName=
-DeviceMatch=usb:28bd:0935
+DeviceMatch=usb|28bd|0935
 PairedIDs=
 Class=Bamboo
 Width=10

--- a/data/xp-pen-deco-mini7.tablet
+++ b/data/xp-pen-deco-mini7.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=XP-Pen Deco mini7
 ModelName=
-DeviceMatch=usb:28bd:0928:UGTABLET 6 inch PenTablet
+DeviceMatch=usb|28bd|0928|UGTABLET 6 inch PenTablet
 Class=Bamboo
 Width=7
 Height=4

--- a/data/xp-pen-deco-mw.tablet
+++ b/data/xp-pen-deco-mw.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=XP-Pen Deco MW
 ModelName=Deco_MW
-DeviceMatch=usb:28bd:0936
+DeviceMatch=usb|28bd|0936
 Class=Bamboo
 Width=8
 Height=5

--- a/data/xp-pen-deco-pro-mw.tablet
+++ b/data/xp-pen-deco-pro-mw.tablet
@@ -20,7 +20,7 @@
 [Device]
 Name=Hanvon Ugee Technology Co.,Ltd Deco Pro MW
 ModelName=
-DeviceMatch=usb:28bd:0934
+DeviceMatch=usb|28bd|0934
 PairedIDs=
 Class=Bamboo
 Width=11

--- a/data/xp-pen-deco-pro-sw.tablet
+++ b/data/xp-pen-deco-pro-sw.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=UGTABLET Deco Pro SW
 ModelName=
-DeviceMatch=usb:28bd:0933
+DeviceMatch=usb|28bd|0933
 PairedIDs=
 Class=Bamboo
 Width=9

--- a/data/xp-pen-deco01-v2.tablet
+++ b/data/xp-pen-deco01-v2.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=UGTABLET 10 inch PenTablet Pad
 ModelName=
-DeviceMatch=usb:28bd:0905
+DeviceMatch=usb|28bd|0905
 PairedIDs=
 Class=Bamboo
 Width=10

--- a/data/xp-pen-g430.tablet
+++ b/data/xp-pen-g430.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=XP-Pen G430
 ModelName=
-DeviceMatch=usb:28bd:0075
+DeviceMatch=usb|28bd|0075
 Class=Bamboo
 Width=4
 Height=3

--- a/data/xp-pen-g430s.tablet
+++ b/data/xp-pen-g430s.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=XP-Pen G430S
 ModelName=
-DeviceMatch=usb:28bd:0913
+DeviceMatch=usb|28bd|0913
 Class=Bamboo
 Width=4
 Height=3

--- a/data/xp-pen-g640.tablet
+++ b/data/xp-pen-g640.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=XP-Pen Star G640
 ModelName=
-DeviceMatch=usb:28bd:0914;usb:28bd:0094
+DeviceMatch=usb|28bd|0914;usb|28bd|0094
 Class=Bamboo
 Width=6
 Height=4

--- a/data/xp-pen-star03.tablet
+++ b/data/xp-pen-star03.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=XP-Pen Star 03
 ModelName=
-DeviceMatch=usb:5543:0081:UC-Logic TABLET 1060N Pen;usb:5543:0081:UC-Logic TABLET 1060N Pad;usb:28bd:0907:UGTABLET 10 inch PenTablet;usb:5543:0081:UC-LOIC TABLET 1060 Pad;usb:5543:0081:UC-LOIC TABLET 1060
+DeviceMatch=usb|5543|0081|UC-Logic TABLET 1060N Pen;usb|5543|0081|UC-Logic TABLET 1060N Pad;usb|28bd|0907|UGTABLET 10 inch PenTablet;usb|5543|0081|UC-LOIC TABLET 1060 Pad;usb|5543|0081|UC-LOIC TABLET 1060
 Class=Bamboo
 Width=10
 Height=6

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -155,10 +155,10 @@ bus_to_str (WacomBusType bus)
 char *
 make_match_string (const char *name, WacomBusType bus, int vendor_id, int product_id)
 {
-	return g_strdup_printf("%s:%04x:%04x%s%s",
+	return g_strdup_printf("%s|%04x|%04x%s%s",
 				bus_to_str (bus),
 				vendor_id, product_id,
-				name ? ":" : "",
+				name ? "|" : "",
 				name ? name : "");
 }
 
@@ -168,7 +168,7 @@ match_from_string(const char *str, WacomBusType *bus, int *vendor_id, int *produ
 	int rc = 1, len = 0;
 	char busstr[64];
 
-	rc = sscanf(str, "%63[^:]:%x:%x:%n", busstr, vendor_id, product_id, &len);
+	rc = sscanf(str, "%63[^|]|%x|%x|%n", busstr, vendor_id, product_id, &len);
 	if (len > 0) {
 		/* Grumble grumble scanf handling of %n */
 		*name = g_strdup(str+len);

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -276,7 +276,7 @@ libwacom_parse_stylus_keyfile(WacomDeviceDatabase *db, const char *path)
 				if (safe_atoi_base (string_list[j], &val, 16)) {
 					g_array_append_val (stylus->paired_ids, val);
 				} else {
-					g_warning ("Stylus %s (%s) Ignoring invalid PairedId value\n", stylus->name, groups[i]);
+					g_warning ("Stylus %s (%s) Ignoring invalid PairedStylusIds value\n", stylus->name, groups[i]);
 				}
 			}
 

--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -829,9 +829,9 @@ static void print_match(int fd, const WacomMatch *match)
 		case WBUSTYPE_UNKNOWN:		bus_name = "unknown";	break;
 		default:			g_assert_not_reached(); break;
 	}
-	dprintf(fd, "%s:%04x:%04x", bus_name, vendor, product);
+	dprintf(fd, "%s|%04x|%04x", bus_name, vendor, product);
 	if (name)
-		dprintf(fd, ":%s", name);
+		dprintf(fd, "|%s", name);
 	dprintf(fd, ";");
 }
 

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -876,6 +876,7 @@ void libwacom_print_stylus_description (int fd, const WacomStylus *stylus);
 /** @addtogroup devices
  * @{ */
 const char *libwacom_match_get_name(const WacomMatch *match);
+const char *libwacom_match_get_firmware_string(const WacomMatch *match);
 WacomBusType libwacom_match_get_bustype(const WacomMatch *match);
 uint32_t libwacom_match_get_product_id(const WacomMatch *match);
 uint32_t libwacom_match_get_vendor_id(const WacomMatch *match);

--- a/libwacom/libwacom.sym
+++ b/libwacom/libwacom.sym
@@ -72,3 +72,7 @@ local:
 LIBWACOM_2.9 {
     libwacom_get_num_keys;
 } LIBWACOM_2.0;
+
+LIBWACOM_2.11 {
+    libwacom_match_get_firmware_string;
+} LIBWACOM_2.9;

--- a/libwacom/libwacomint.h
+++ b/libwacom/libwacomint.h
@@ -56,6 +56,7 @@ struct _WacomMatch {
 	gint refcnt;
 	char *match;
 	char *name;
+	char *fw;
 	WacomBusType bus;
 	uint32_t vendor_id;
 	uint32_t product_id;
@@ -143,12 +144,13 @@ void libwacom_error_set(WacomError *error, enum WacomErrorCode code, const char 
 void libwacom_add_match(WacomDevice *device, WacomMatch *newmatch);
 void libwacom_set_default_match(WacomDevice *device, WacomMatch *newmatch);
 void libwacom_remove_match(WacomDevice *device, WacomMatch *newmatch);
-WacomMatch* libwacom_match_new(const char *name, WacomBusType bus,
+WacomMatch* libwacom_match_new(const char *name, const char *fw,
+			       WacomBusType bus,
 			       int vendor_id, int product_id);
 
 WacomBusType  bus_from_str (const char *str);
 const char   *bus_to_str   (WacomBusType bus);
-char *make_match_string(const char *name, WacomBusType bus, int vendor_id, int product_id);
+char *make_match_string(const char *name, const char *fw, WacomBusType bus, int vendor_id, int product_id);
 
 #endif /* _LIBWACOMINT_H_ */
 

--- a/test/test_data_files.py
+++ b/test/test_data_files.py
@@ -40,7 +40,7 @@ def test_device_match(tabletfile):
         if not match or match == "generic":
             continue
 
-        bus, vid, pid = match.split(":")[:3]  # skip the name part of the match
+        bus, vid, pid = match.split("|")[:3]  # skip the name part of the match
         assert bus in [
             "usb",
             "bluetooth",
@@ -61,7 +61,7 @@ def test_no_receiver_id(tabletfile):
     config.optionxform = lambda option: option
     config.read(tabletfile)
 
-    receivers = ["usb:{:04x}:{:04x}".format(*r) for r in WACOM_RECEIVER_USBIDS]
+    receivers = ["usb|{:04x}|{:04x}".format(*r) for r in WACOM_RECEIVER_USBIDS]
     for match in config["Device"]["DeviceMatch"].split(";"):
         assert match not in receivers
 

--- a/test/test_udev_rules.py
+++ b/test/test_udev_rules.py
@@ -57,8 +57,13 @@ def pytest_generate_tests(metafunc):
                 if bus not in ['usb', 'bluetooth']:
                     continue
 
-                vid = int(vid, 16)
-                pid = int(pid, 16)
+                try:
+                    vid = int(vid, 16)
+                    pid = int(pid, 16)
+                except ValueError as e:
+                    print(f"Invalid vid/pid in {match} in {f}", file=sys.stderr)
+                    raise e
+
                 if bus == 'usb':
                     bus = 0x3
                 elif bus == 'bluetooth':

--- a/test/test_udev_rules.py
+++ b/test/test_udev_rules.py
@@ -53,7 +53,7 @@ def pytest_generate_tests(metafunc):
                 if not match or match == 'generic':
                     continue
 
-                bus, vid, pid = match.split(':')[:3]  # skip the name part of the match
+                bus, vid, pid = match.split('|')[:3]  # skip the name part of the match
                 if bus not in ['usb', 'bluetooth']:
                     continue
 

--- a/tools/libwacom-update-db.py
+++ b/tools/libwacom-update-db.py
@@ -130,7 +130,7 @@ class TabletDatabase:
                 # it'll just result in duplicate ID_INPUT_TABLET assignments
                 # for tablets with re-used usbids and that doesn't matter
                 try:
-                    bus, vid, pid, *_ = match.split(":")
+                    bus, vid, pid, *_ = match.split("|")
                 except ValueError as e:
                     print(f"Failed to process match {match} in {file}", file=sys.stderr)
                     raise e

--- a/tools/libwacom-update-db.py
+++ b/tools/libwacom-update-db.py
@@ -132,7 +132,7 @@ class TabletDatabase:
                 try:
                     bus, vid, pid, *_ = match.split(":")
                 except ValueError as e:
-                    print(f"Failed to process match {match}")
+                    print(f"Failed to process match {match} in {file}", file=sys.stderr)
                     raise e
 
                 name = config["Device"]["Name"]


### PR DESCRIPTION
**Completely untested, this is just the first draft**

Add support for specifying a firmware version string in the `DeviceMatch` which is filled in by reading the proposed `fw_name` sysfs attribute.

- `DeviceMatch` now uses `|` as separator, we have a few devices with `:` in the name and it's too painful to handle this otherwise.
- some logic will be needed to do the right thing if we need a fw version but we don't have a fw_name attribute, i.e. running new libwacom on old kernels. Don't know how to handle this yet.

Fixes #610 

cc @JoseExposito