### PR TITLE
adding .tablet file for Ingenic touch and pen display.

### DIFF
--- a/data/ingenic-6161.tablet
+++ b/data/ingenic-6161.tablet
@@ -2,7 +2,7 @@
 
 [Device]
 Name=Ingenic Touch/Pen display
-ModelName=Gadget_Serial_and_keyboard
+ModelName=
 Class=Cintiq
 DeviceMatch=usb:17ef:6161
 Width=11
@@ -15,4 +15,3 @@ Stylus=true
 Reversible=false
 Touch=true
 Ring=false
-Buttons=0

--- a/data/ingenic-6161.tablet
+++ b/data/ingenic-6161.tablet
@@ -1,0 +1,18 @@
+# Ingenic Touch/Pen Display
+
+[Device]
+Name=Ingenic Touch/Pen display
+ModelName=Gadget_Serial_and_keyboard
+Class=Cintiq
+DeviceMatch=usb:17ef:6161
+Width=11
+Height=6
+# No pad buttons, so no layout
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Reversible=false
+Touch=true
+Ring=false
+Buttons=0

--- a/data/ingenic-6161.tablet
+++ b/data/ingenic-6161.tablet
@@ -1,4 +1,8 @@
 # Ingenic Touch/Pen Display
+# Integrated into the Lenovo Yoga Book 9i (13IRU8)
+# 
+# sysinfo.zpUboT0IUG.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/346
 
 [Device]
 Name=Ingenic Touch/Pen display

--- a/data/ingenic-6161.tablet
+++ b/data/ingenic-6161.tablet
@@ -7,7 +7,7 @@
 [Device]
 Name=Ingenic Touch/Pen display
 ModelName=
-Class=Cintiq
+Class=PenDisplay
 DeviceMatch=usb:17ef:6161
 Width=11
 Height=6


### PR DESCRIPTION
This is in reference to issue #602 . Adds support for the Ingenic touch/pen screens on the Lenovo Yoga Book 9i.

Edited 2Jan23 to correct laptop model name.