### PR TITLE
github: fix the sysinfo check workflow

### DIFF
--- a/.github/workflows/check-for-sysinfo.yml
+++ b/.github/workflows/check-for-sysinfo.yml
@@ -20,6 +20,6 @@ jobs:
         run: |
           for file in ${{ steps.added-files.outputs.added_files }}; do
             if [[ "$file" == *.tablet ]]; then
-                grep -q "sysinfo" $file || (echo "Missing reference to sysinfo.DEADBEEF.gz in $file" && exit 1)
+                grep -q "sysinfo" data/$file || (echo "Missing reference to sysinfo.DEADBEEF.gz in $file" && exit 1)
             fi
           done


### PR DESCRIPTION
The path provided by the tj-actions/changed-files is without the original path, so we need to prefix it with the directory we gave to that action.

Fixes the sysinfo error in #617 