### PR TITLE
add support for xp-pen artist 10s table

### DIFF
--- a/data/layouts/xp-pen-artist10s.svg
+++ b/data/layouts/xp-pen-artist10s.svg
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="xp-pen-artist12"
+   width="650.0"
+   height="400.0"
+   style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
+   version="1.1"
+   sodipodi:docname="xp-pen-artist10s.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs7" />
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="4.9907692"
+     inkscape:cx="100.38533"
+     inkscape:cy="200.26973"
+     inkscape:window-width="2880"
+     inkscape:window-height="1692"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="xp-pen-artist12" />
+  <g
+     id="g1">
+    <rect
+       id="ButtonA"
+       class="A Button"
+       x="24.0"
+       y="139.0"
+       width="20.0"
+       height="12.0"
+       rx="0.5"
+       ry="0.5" />
+    <path
+       id="LeaderA"
+       class="A Leader"
+       d="m 46.0 145.0 h 5.0 V 96.0 h 20.0" />
+    <text
+       id="LabelA"
+       class="A Label"
+       x="73.0"
+       y="96.0"
+       style="text-anchor:start;">A</text>
+  </g>
+  <g
+     id="g2">
+    <rect
+       id="ButtonB"
+       class="B Button"
+       x="24.0"
+       y="152.0"
+       width="20.0"
+       height="12.0"
+       rx="0.5"
+       ry="0.5" />
+    <path
+       id="LeaderB"
+       class="B Leader"
+       d="M 46.0 158.0 H 56.0 V 122.0 H 71.0" />
+    <text
+       id="LabelB"
+       class="B Label"
+       x="73.0"
+       y="122.0"
+       style="text-anchor:start;">B</text>
+  </g>
+  <g
+     id="g3">
+    <rect
+       id="ButtonC"
+       class="C Button"
+       x="24.0"
+       y="165.0"
+       width="20.0"
+       height="12.0"
+       rx="0.5"
+       ry="0.5" />
+    <path
+       id="LeaderC"
+       class="C Leader"
+       d="M 46.0 171.0 l 15.0 0.0 l 0.0 -23.0 l 10.0 0.0" />
+    <text
+       id="LabelC"
+       class="C Label"
+       x="73.0"
+       y="148.0"
+       style="text-anchor:start;">C</text>
+  </g>
+  <g
+     id="g4">
+    <rect
+       id="ButtonD"
+       class="D Button"
+       x="24.0"
+       y="223.0"
+       width="20.0"
+       height="12.0"
+       rx="0.5"
+       ry="0.5" />
+    <path
+       id="LeaderD"
+       class="D Leader"
+       d="M 46.0 230.0 l 15.0 0.0 l 0.0 23.0 l 10.0 0.0" />
+    <text
+       id="LabelD"
+       class="D Label"
+       x="73.0"
+       y="252.0"
+       style="text-anchor:start;">D</text>
+  </g>
+  <g
+     id="g5">
+    <rect
+       id="ButtonE"
+       class="E Button"
+       x="24.0"
+       y="236.0"
+       width="20.0"
+       height="12.0"
+       rx="0.5"
+       ry="0.5" />
+    <path
+       id="LeaderE"
+       class="E Leader"
+       d="m 46.0 242.0 h 10.0 v 36.0 h 15.0" />
+    <text
+       id="LabelE"
+       class="E Label"
+       x="73.0"
+       y="278.0"
+       style="text-anchor:start;">E</text>
+  </g>
+  <g
+     id="g6">
+    <rect
+       id="ButtonF"
+       class="F Button"
+       x="24.0"
+       y="249.0"
+       width="20.0"
+       height="12.0"
+       rx="0.5"
+       ry="0.5" />
+    <path
+       id="LeaderF"
+       class="F Leader"
+       d="m 46.0 255.0 h 5.0 v 49.0 h 20.0" />
+    <text
+       id="LabelF"
+       class="F Label"
+       x="73.0"
+       y="304.0"
+       style="text-anchor:start;">F</text>
+  </g>
+</svg>

--- a/data/xp-pen-artist10s.tablet
+++ b/data/xp-pen-artist10s.tablet
@@ -4,12 +4,12 @@
 
 [Device]
 Name=UGEE 10.1 Tablet Monitor
-ModelName=XP-Pen Artist 10S (1st gen)
+ModelName=
 DeviceMatch=usb:5543:004a:UGEE 10.1 Tablet Monitor;usb:5543:004a:UGEE 10.1 Tablet Monitor Pad;usb:5543:004a:UGEE 10.1 Tablet Monitor Mouse
 PairedIDs=
 Class=Bamboo
-Width=8.5
-Height=5.3
+Width=9
+Height=5
 IntegratedIn=
 Layout=xp-pen-artist10s.svg
 Styli=@generic-no-eraser;

--- a/data/xp-pen-artist10s.tablet
+++ b/data/xp-pen-artist10s.tablet
@@ -1,6 +1,8 @@
 # XP-Pen
 # Artist 10S (1st generation)
 #
+# sysinfo.2kd91mftwQ
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/354
 
 [Device]
 Name=UGEE 10.1 Tablet Monitor

--- a/data/xp-pen-artist10s.tablet
+++ b/data/xp-pen-artist10s.tablet
@@ -23,7 +23,6 @@ Touch=false
 TouchSwitch=false
 Ring=false
 Ring2=false
-NumStrips=1
 
 [Buttons]
 Left=A;B;C;D;E;F

--- a/data/xp-pen-artist10s.tablet
+++ b/data/xp-pen-artist10s.tablet
@@ -1,0 +1,28 @@
+# XP-Pen
+# Artist 10S (1st generation)
+#
+
+[Device]
+Name=UGEE 10.1 Tablet Monitor
+ModelName=XP-Pen Artist 10S (1st gen)
+DeviceMatch=usb:5543:004a:UGEE 10.1 Tablet Monitor;usb:5543:004a:UGEE 10.1 Tablet Monitor Pad;usb:5543:004a:UGEE 10.1 Tablet Monitor Mouse
+PairedIDs=
+Class=Bamboo
+Width=8.5
+Height=5.3
+IntegratedIn=
+Layout=xp-pen-artist10s.svg
+Styli=@generic-no-eraser;
+
+[Features]
+Stylus=true
+Reversible=true
+Touch=false
+TouchSwitch=false
+Ring=false
+Ring2=false
+NumStrips=1
+
+[Buttons]
+Left=A;B;C;D;E;F
+EvdevCodes=BTN_0;BTN_1;BTN_2;BTN_3;BTN_4;BTN_5


### PR DESCRIPTION
I have som trouble with this descriptor, please help me with it.

- I had to use the string that is returned by `libinput list-devices` for kwin to recognize the descriptor. However, this is quite weird as the tablet is an XP-Pen Artist 10s, and it is not obvious what an UGEE device is. That would be nice to overwrite, yet the ModelName key has made no difference. Am I doing something wrong, or it is a problem with kwin/ksystem settings?
- In the example table file there is something about a system identifier generated by wacom-hid-descriptor. Howevert, that project seems to be about devices that are drawing computers, while this device is an external, usb connected drawing tablet. Is it alright that I omitted these comment lines or should I extend the .table file somehow?