### PR TITLE
Update Dell Active Pen

### DIFF
--- a/data/libwacom.stylus
+++ b/data/libwacom.stylus
@@ -159,7 +159,7 @@ Type=Mobile
 # Dell   ; VID_NONE     | 0xf142541e | BAT_SWAP (Dell PN5122W)
 Name=Dell Active Pen
 Group=isdv4-aes
-Buttons=2
+Buttons=1
 EraserType=Button
 Axes=Pressure
 Type=Mobile

--- a/data/libwacom.stylus
+++ b/data/libwacom.stylus
@@ -156,9 +156,10 @@ Type=Mobile
 
 [0x631]
 # Dell   ; VID_NONE     | 0x0000 | BAT_SWAP | LONGPRESS (Dell PN557W)
-Name=AES Pen
+# Dell   ; VID_NONE     | 0xf142541e | BAT_SWAP (Dell PN5122W)
+Name=Dell Active Pen
 Group=isdv4-aes
-Buttons=1
+Buttons=2
 EraserType=Button
 Axes=Pressure
 Type=Mobile


### PR DESCRIPTION
The Dell Active Pen is misconfigured in `libwacom.stylus`.

Firstly, The pen has 2 buttons.

Secondly "AES" pen does not properly illustrate what the pen is to the user.