### PR TITLE
data: add isdv4-50a0

### DIFF
--- a/data/isdv4-50a0.tablet
+++ b/data/isdv4-50a0.tablet
@@ -1,4 +1,7 @@
 # this is for the Wacom pen + touchscreen as found in some versions of the Lenovo ThinkPad Yoga 370
+#
+# sysinfo.i8xtfznvRF.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/359
 
 [Device]
 Name=Wacom ISDv4 50A0

--- a/data/isdv4-50a0.tablet
+++ b/data/isdv4-50a0.tablet
@@ -1,0 +1,16 @@
+# this is for the Wacom pen + touchscreen as found in some versions of the Lenovo ThinkPad Yoga 370
+
+[Device]
+Name=Wacom ISDv4 50A0
+ModelName=
+DeviceMatch=usb:056a:50a0
+Class=ISDV4
+Width=12
+Height=7
+IntegratedIn=Display;System
+Styli=@isdv4-aes;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
Add tablet of Lenovo Yoga 370

The file isdv4-50a0.tablet is a copy with small modifications of isdv4-509d.tablet that is already in the database.
