### PR TITLE
data: Intuos Pro 2 is compatible with Intuos 4 styli

### DIFF
--- a/data/intuos-pro-2-l.tablet
+++ b/data/intuos-pro-2-l.tablet
@@ -51,7 +51,7 @@ Width=12
 Height=8
 Layout=intuos-pro-2-l.svg
 IntegratedIn=
-Styli=@intuos5;@mobilestudio;@propengen2;
+Styli=@intuos4;@intuos5;@mobilestudio;@propengen2;
 
 [Features]
 Stylus=true

--- a/data/intuos-pro-2-m.tablet
+++ b/data/intuos-pro-2-m.tablet
@@ -51,7 +51,7 @@ Width=9
 Height=6
 Layout=intuos-pro-2-m.svg
 IntegratedIn=
-Styli=@intuos5;@mobilestudio;@propengen2;
+Styli=@intuos4;@intuos5;@mobilestudio;@propengen2;
 
 [Features]
 Stylus=true

--- a/data/intuos-pro-2-s.tablet
+++ b/data/intuos-pro-2-s.tablet
@@ -38,7 +38,7 @@ Width=6
 Height=4
 Layout=intuos-pro-2-s.svg
 IntegratedIn=
-Styli=@intuos5;@mobilestudio;@propengen2;
+Styli=@intuos4;@intuos5;@mobilestudio;@propengen2;
 
 [Features]
 Stylus=true


### PR DESCRIPTION
The Windows driver at least blocks those but they work just fine. Add them here so we can look them up.


cc @jigpu, @Pinglinux, @Joshua-Dickens 


Note: this is required for [gnome-control-center!2244](https://gitlab.gnome.org/GNOME/gnome-control-center/-/merge_requests/2244) for the tablet to work with the old pens.