### PR TITLE
data: Add GPD WinMax 2 (2023) screen

### DIFF
--- a/data/gpd-winmax-2-2023.tablet
+++ b/data/gpd-winmax-2-2023.tablet
@@ -1,0 +1,14 @@
+# GPD
+# WinMax 2
+
+[Device]
+Name=GPD WinMax 2 2023
+DeviceMatch=i2c:27c6:0113
+Class=ISDV4
+Width=8
+Height=6
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true


### PR DESCRIPTION
I'm not sure if this needs a more specific `DeviceMatch` or should be part of a different tablet specification.
It works with MPP pens I think.