### PR TITLE
data: add ELAN 9008 and 9009 (zenbook duo UX8406MA)

### DIFF
--- a/data/elan-425a.tablet
+++ b/data/elan-425a.tablet
@@ -1,0 +1,20 @@
+# ELAN touchscreen/pen sensor present in the ASUS ZenBook Duo UX8406MA
+# this is the secondary / bottom touchscreen
+# 298mm x 184mm
+# 11.75in x 7.25in
+#
+# sysinfo.fwYSGljtom.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/363
+
+[Device]
+Name=ELAN9009:00
+ModelName=
+DeviceMatch=i2c:04f3:425a
+Class=ISDV4
+Width=14
+Height=4
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true

--- a/data/elan-425b.tablet
+++ b/data/elan-425b.tablet
@@ -1,0 +1,21 @@
+# ELAN touchscreen/pen sensor present in the ASUS ZenBook Duo UX8406MA
+# this is the main / top touchscreen
+# 298mm x 184mm
+# 11.75in x 7.25in
+#
+# sysinfo.fwYSGljtom.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/363
+
+
+[Device]
+Name=ELAN9008:00
+ModelName=
+DeviceMatch=i2c:04f3:425b
+Class=ISDV4
+Width=14
+Height=4
+IntegratedIn=Display;System
+
+[Features]
+Stylus=true
+Touch=true


### PR DESCRIPTION
Adding both touch panels for the new dualscreen Asus Zenbook Duo