### PR TITLE
Change the generic fallback tablet to be an integrated tablet

### DIFF
--- a/data/generic.tablet
+++ b/data/generic.tablet
@@ -2,9 +2,9 @@
 Name=Generic
 ModelName=generic
 DeviceMatch=generic
+IntegratedIn=Display;System;
 
 [Features]
-Reversible=true
+Reversible=false
 Stylus=true
-Ring=true
-NumStrips=2
+Ring=false


### PR DESCRIPTION
The vast majority of tablets these days are integrated into the respective system without a ring or strips, so let's update our generic tablet to match that.

This way an unknown tablet is more likely to match the tablet the user actually has.