### PR TITLE
Add lenovo IdeaPad Duet 3 10IGL5 (elan-2bd6)

### DIFF
--- a/data/elan-2bd6.tablet
+++ b/data/elan-2bd6.tablet
@@ -1,0 +1,16 @@
+# ELAN touchscreen/pen sensor present in the IdeaPad Duet 3 10IGL5
+#
+# sysinfo.Al8cFbaepN
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/212
+
+[Device]
+Name=Elan 2BD6
+ModelName=
+DeviceMatch=i2c:04f3:2bd6
+Class=ISDV4
+IntegratedIn=Display;System
+Styli=@generic-with-eraser
+
+[Features]
+Stylus=true
+Touch=true


### PR DESCRIPTION
The tablet works, but not sure about the stylus.

`tools/show-stylus.py` says it's only capable of generic stylus.

In Gnome settings I can see the stylus, but changing the button mappings doesn't do anything.

`libinput record` shows some event when pressing stylus buttons, but look random to me. When pressing buttons, sometimes I get a regular key press, sometimes nothing and sometimes eraser/rubber.  Also when using the stylus buttons, they every time produce different event.

Is there anything I can do about this?