### PR TITLE
ci: update to actions/checkout@v4

### DIFF
--- a/.github/workflows/check-for-sysinfo.yml
+++ b/.github/workflows/check-for-sysinfo.yml
@@ -9,7 +9,7 @@ jobs:
   checksysinfo:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: tj-actions/changed-files@v41

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -13,7 +13,7 @@ jobs:
   freebsd:
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: meson test
       uses: vmactions/freebsd-vm@v0
       with:

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -15,6 +15,6 @@ jobs:
   comment:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Label Commenter
         uses: peaceiris/actions-label-commenter@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
           # https://github.com/mesonbuild/meson/issues/764
           - '-Db_sanitize=address,undefined -Db_lundef=false'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # install python so we get pip for meson
       - uses: actions/setup-python@v4
         with:
@@ -68,7 +68,7 @@ jobs:
   valgrind:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # install python so we get pip for meson
       - uses: actions/setup-python@v4
         with:
@@ -111,7 +111,7 @@ jobs:
           - sudo csplit data/libwacom.stylus '/^\[0x822\]/' && sudo mv xx00 /etc/libwacom/first.stylus && sudo mv xx01 /usr/share/libwacom/libwacom.stylus
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # install python so we get pip for meson
       - uses: actions/setup-python@v4
         with:
@@ -145,7 +145,7 @@ jobs:
     needs: build-and-dist
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # install python so we get pip for meson
       - uses: actions/setup-python@v4
         with:
@@ -196,7 +196,7 @@ jobs:
       TARBALLDIR: '_tarball_dir'
       INSTALLDIR: '/tmp/libwacom/_inst'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/pkginstall
         with:
           apt: $UBUNTU_PACKAGES


### PR DESCRIPTION
From the current runs:
  Node.js 16 actions are deprecated. Please update the following actions
  to use Node.js 20: actions/checkout@v3, actions/setup-python@v4,
  actions/upload-artifact@v3. For more information see:
  https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.