### PR TITLE
data: Add Gaomon S620 firmware match

### DIFF
--- a/data/gaomon-s620.tablet
+++ b/data/gaomon-s620.tablet
@@ -11,7 +11,7 @@
 [Device]
 Name=GAOMON S620
 ModelName=
-DeviceMatch=usb|256c|006d|GAOMON Gaomon Tablet Pen;usb|256c|006d|GAOMON Gaomon Tablet Pad;
+DeviceMatch=usb|256c|006d|GAOMON Gaomon Tablet Pen;usb|256c|006d|GAOMON Gaomon Tablet Pad;usb|256c|006d|GAOMON Gaomon Tablet Pen|OEM02_T18e;usb|256c|006d|GAOMON Gaomon Tablet Pad|OEM02_T18e;
 Class=Bamboo
 Width=6
 Height=4


### PR DESCRIPTION
This tablet has the same name as Gaomon M106K [1], making it impossible to differentiate between them without matching by their firmware name.

Add an extra match including the firmware to facilitate matching the Gaomon M106K.

[1] https://github.com/linuxwacom/libwacom/issues/609