### PR TITLE
test: remove the requirement for a Layout file

### DIFF
--- a/test/test-tablet-svg-validity.c
+++ b/test/test-tablet-svg-validity.c
@@ -234,19 +234,6 @@ struct fixture {
 };
 
 static void
-test_filename(struct fixture *f, gconstpointer data)
-{
-    const WacomDevice *device = data;
-    const char *filename;
-
-    filename = libwacom_get_layout_filename(device);
-    if (libwacom_get_num_buttons(device) > 0) {
-	    g_assert_nonnull(filename);
-	    g_assert_cmpstr(filename, !=, "");
-    }
-}
-
-static void
 test_svg(struct fixture *f, gconstpointer data)
 {
     g_assert_nonnull(f->doc);
@@ -368,7 +355,6 @@ static void setup_tests(WacomDevice *device)
 	if (g_str_equal(name, "Generic"))
 		return;
 
-	add_test(device, test_filename);
 	if (!libwacom_get_layout_filename(device))
 		return;
 


### PR DESCRIPTION
Previously we required a layout file for any tablet with pad buttons. This somewhat prevents us from adding tablet files for unknown tablets where we can get most of the information from external sources, e.g. see #659. As a result we're missing support for these tablets altogether when we could have at least partial support.

Let's drop this requirement in our tests, users who want their tablet working properly can submit layout files.


cc @JoseExposito 