### PR TITLE
data: XP pen tablets have no Rings

### DIFF
--- a/data/xp-pen-artist13-3-pro.tablet
+++ b/data/xp-pen-artist13-3-pro.tablet
@@ -21,7 +21,7 @@ Stylus=true
 Reversible=false
 Touch=false
 TouchSwitch=false
-Ring=true
+Ring=false
 Ring2=false
 NumStrips=0
 

--- a/data/xp-pen-deco-pro-mw.tablet
+++ b/data/xp-pen-deco-pro-mw.tablet
@@ -33,7 +33,7 @@ Styli=@generic-no-eraser
 Stylus=true
 Reversible=true
 Touch=false
-Ring=true
+Ring=false
 Ring2=false
 NumStrips=0
 

--- a/data/xp-pen-deco-pro-sw.tablet
+++ b/data/xp-pen-deco-pro-sw.tablet
@@ -20,7 +20,7 @@ Styli=@generic-no-eraser
 Stylus=true
 Reversible=true
 Touch=false
-Ring=true
+Ring=false
 Ring2=false
 NumStrips=0
 


### PR DESCRIPTION
They have a physical control that looks like a ring but it's not the Ring as our terminology has it. In the future we may add support for this as "Dial" but for now let's disable it.