### PR TITLE
Use NumRings instead of separate Ring/Ring2

### DIFF
--- a/data/bamboo-0fg-m-p-alt.tablet
+++ b/data/bamboo-0fg-m-p-alt.tablet
@@ -52,7 +52,7 @@ Layout=bamboo-0fg-s-p-alt.svg
 Stylus=true
 Reversible=false
 Touch=false
-Ring=true
+NumRings=1
 
 [Buttons]
 Top=A;B;C;D

--- a/data/bamboo-0fg-s-p-alt.tablet
+++ b/data/bamboo-0fg-s-p-alt.tablet
@@ -53,7 +53,7 @@ Layout=bamboo-0fg-s-p-alt.svg
 Stylus=true
 Reversible=false
 Touch=false
-Ring=true
+NumRings=1
 
 [Buttons]
 Top=A;B;C;D

--- a/data/bamboo-0fg-s-p.tablet
+++ b/data/bamboo-0fg-s-p.tablet
@@ -53,7 +53,7 @@ Layout=bamboo-0fg-s-p.svg
 Stylus=true
 Reversible=false
 Touch=false
-Ring=true
+NumRings=1
 
 [Buttons]
 Top=A;B;C;D

--- a/data/bamboo-one.tablet
+++ b/data/bamboo-one.tablet
@@ -15,5 +15,5 @@ IntegratedIn=
 Reversible=true
 Stylus=true
 Touch=false
-Ring=false
+NumRings=0
 NumStrips=0

--- a/data/cintiq-13hd.tablet
+++ b/data/cintiq-13hd.tablet
@@ -36,7 +36,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
+NumRings=0
 
 [Buttons]
 Left=B;C;G;H;A;F;I;D;E

--- a/data/cintiq-13hdt.tablet
+++ b/data/cintiq-13hdt.tablet
@@ -38,7 +38,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0
 
 [Buttons]
 Left=B;C;G;H;A;F;I;D;E

--- a/data/cintiq-16-2.tablet
+++ b/data/cintiq-16-2.tablet
@@ -17,4 +17,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
+NumRings=0

--- a/data/cintiq-16.tablet
+++ b/data/cintiq-16.tablet
@@ -17,4 +17,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
+NumRings=0

--- a/data/cintiq-21ux2.tablet
+++ b/data/cintiq-21ux2.tablet
@@ -55,7 +55,7 @@ IntegratedIn=Display
 
 [Features]
 Stylus=true
-Ring=false
+NumRings=0
 NumStrips=2
 StatusLEDs=Touchstrip2;Touchstrip
 

--- a/data/cintiq-22.tablet
+++ b/data/cintiq-22.tablet
@@ -17,4 +17,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
+NumRings=0

--- a/data/cintiq-22hd.tablet
+++ b/data/cintiq-22hd.tablet
@@ -45,7 +45,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
+NumRings=0
 NumStrips=2
 
 [Buttons]

--- a/data/cintiq-22hdt.tablet
+++ b/data/cintiq-22hdt.tablet
@@ -47,7 +47,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0
 NumStrips=2
 
 [Buttons]

--- a/data/cintiq-24hd-touch.tablet
+++ b/data/cintiq-24hd-touch.tablet
@@ -55,8 +55,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=true
-Ring2=true
+NumRings=2
 StatusLEDs=Ring2;Ring
 
 [Buttons]

--- a/data/cintiq-24hd.tablet
+++ b/data/cintiq-24hd.tablet
@@ -53,8 +53,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=true
-Ring2=true
+NumRings=2
 StatusLEDs=Ring2;Ring
 
 [Buttons]

--- a/data/cintiq-27hd.tablet
+++ b/data/cintiq-27hd.tablet
@@ -17,5 +17,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
-Ring2=false
+NumRings=0

--- a/data/cintiq-27hdt.tablet
+++ b/data/cintiq-27hdt.tablet
@@ -19,5 +19,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
-Ring2=false
+NumRings=0

--- a/data/cintiq-companion-2.tablet
+++ b/data/cintiq-companion-2.tablet
@@ -41,7 +41,7 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Ring=false
+NumRings=0
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H;I;J;K

--- a/data/cintiq-companion-hybrid.tablet
+++ b/data/cintiq-companion-hybrid.tablet
@@ -40,7 +40,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0
 
 [Buttons]
 Left=B;C;G;H;A;F;I;D;E

--- a/data/cintiq-companion.tablet
+++ b/data/cintiq-companion.tablet
@@ -39,7 +39,7 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Ring=false
+NumRings=0
 
 [Buttons]
 Left=B;C;G;H;A;F;I;D;E

--- a/data/cintiq-pro-13.tablet
+++ b/data/cintiq-pro-13.tablet
@@ -42,7 +42,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0
 
 [Keys]
 # first key is in-kernel display toggle

--- a/data/cintiq-pro-16-2.tablet
+++ b/data/cintiq-pro-16-2.tablet
@@ -39,7 +39,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0
 
 [Buttons]
 Left=A;B;C;D

--- a/data/cintiq-pro-16.tablet
+++ b/data/cintiq-pro-16.tablet
@@ -42,4 +42,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0

--- a/data/cintiq-pro-17.tablet
+++ b/data/cintiq-pro-17.tablet
@@ -40,7 +40,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0
 
 [Buttons]
 Left=A;B;C;D

--- a/data/cintiq-pro-22.tablet
+++ b/data/cintiq-pro-22.tablet
@@ -40,7 +40,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0
 
 [Buttons]
 Left=A;B;C;D

--- a/data/cintiq-pro-24-p.tablet
+++ b/data/cintiq-pro-24-p.tablet
@@ -41,4 +41,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
+NumRings=0

--- a/data/cintiq-pro-24-pt.tablet
+++ b/data/cintiq-pro-24-pt.tablet
@@ -42,4 +42,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0

--- a/data/cintiq-pro-27.tablet
+++ b/data/cintiq-pro-27.tablet
@@ -40,7 +40,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0
 
 [Buttons]
 Left=A;B;C;D

--- a/data/cintiq-pro-32.tablet
+++ b/data/cintiq-pro-32.tablet
@@ -42,4 +42,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0

--- a/data/dell-canvas-27.tablet
+++ b/data/dell-canvas-27.tablet
@@ -34,4 +34,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0

--- a/data/dtc-121.tablet
+++ b/data/dtc-121.tablet
@@ -19,4 +19,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
+NumRings=0

--- a/data/dth-1152.tablet
+++ b/data/dth-1152.tablet
@@ -18,6 +18,5 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0

--- a/data/dth-134.tablet
+++ b/data/dth-134.tablet
@@ -19,4 +19,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0

--- a/data/dth-2242.tablet
+++ b/data/dth-2242.tablet
@@ -31,8 +31,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0
 # Actually 7 buttons but one is reserved for onscreen menus
 

--- a/data/dth-2452.tablet
+++ b/data/dth-2452.tablet
@@ -28,8 +28,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0
 # Actually 5 buttons but one is reserved for onscreen menus
 

--- a/data/dti-520.tablet
+++ b/data/dti-520.tablet
@@ -31,8 +31,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0
 # Actually 11 buttons but the two Ctrl ones send the same scancode
 

--- a/data/dtk-1651.tablet
+++ b/data/dtk-1651.tablet
@@ -26,8 +26,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0
 
 [Buttons]

--- a/data/dtk-1660e-2.tablet
+++ b/data/dtk-1660e-2.tablet
@@ -16,4 +16,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
+NumRings=0

--- a/data/dtk-1660e.tablet
+++ b/data/dtk-1660e.tablet
@@ -16,4 +16,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
+NumRings=0

--- a/data/dtk-2241.tablet
+++ b/data/dtk-2241.tablet
@@ -29,8 +29,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0
 # Actually 7 buttons but one is reserved for onscreen menus
 

--- a/data/dtk-2451.tablet
+++ b/data/dtk-2451.tablet
@@ -27,8 +27,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0
 # Actually 5 buttons but one is reserved for onscreen menus
 

--- a/data/dtu-1031.tablet
+++ b/data/dtu-1031.tablet
@@ -29,8 +29,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0
 
 [Buttons]

--- a/data/dtu-1031x.tablet
+++ b/data/dtu-1031x.tablet
@@ -17,6 +17,5 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0

--- a/data/dtu-1141.tablet
+++ b/data/dtu-1141.tablet
@@ -29,8 +29,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0
 
 [Buttons]

--- a/data/dtu-1141b.tablet
+++ b/data/dtu-1141b.tablet
@@ -27,8 +27,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0
 
 [Buttons]

--- a/data/ek-remote.tablet
+++ b/data/ek-remote.tablet
@@ -20,7 +20,7 @@ Class=Remote
 
 [Features]
 Stylus=false
-Ring=true
+NumRings=1
 NumStrips=0
 StatusLEDs=Ring
 

--- a/data/elan-22e2.tablet
+++ b/data/elan-22e2.tablet
@@ -13,6 +13,5 @@ Stylus=true
 Reversible=false
 Touch=false
 TouchSwitch=false
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0

--- a/data/elan-24d8.tablet
+++ b/data/elan-24d8.tablet
@@ -13,8 +13,7 @@ Styli=@generic-with-eraser;
 [Features]
 Reversible=false
 Stylus=true
-Ring=false
-Ring2=false
+NumRings=0
 Touch=true
 TouchSwitch=false
 # StatusLEDs=

--- a/data/generic.tablet
+++ b/data/generic.tablet
@@ -7,4 +7,4 @@ IntegratedIn=Display;System;
 [Features]
 Reversible=false
 Stylus=true
-Ring=false
+NumRings=0

--- a/data/graphire-wireless-8x6.tablet
+++ b/data/graphire-wireless-8x6.tablet
@@ -27,7 +27,7 @@ IntegratedIn=
 [Features]
 Reversible=false
 Stylus=true
-Ring=false
+NumRings=0
 
 [Buttons]
 Top=A;B

--- a/data/huion-kamvas-13.tablet
+++ b/data/huion-kamvas-13.tablet
@@ -37,7 +37,7 @@ Stylus=true
 Reversible=false
 Touch=false
 TouchSwitch=false
-Ring=false
+NumRings=0
 NumStrips=0
 
 [Buttons]

--- a/data/huion-kamvas-pro-24.tablet
+++ b/data/huion-kamvas-pro-24.tablet
@@ -47,7 +47,7 @@ IntegratedIn=Display
 [Features]
 NumStrips=1
 Reversible=false
-Ring=false
+NumRings=0
 Stylus=true
 Touch=false
 TouchSwitch=false

--- a/data/ingenic-6161.tablet
+++ b/data/ingenic-6161.tablet
@@ -18,4 +18,4 @@ IntegratedIn=Display;System
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0

--- a/data/intuos-pro-2-l.tablet
+++ b/data/intuos-pro-2-l.tablet
@@ -57,7 +57,7 @@ Styli=@intuos4;@intuos5;@mobilestudio;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Ring=true
+NumRings=1
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos-pro-2-m.tablet
+++ b/data/intuos-pro-2-m.tablet
@@ -57,7 +57,7 @@ Styli=@intuos4;@intuos5;@mobilestudio;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Ring=true
+NumRings=1
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos-pro-2-s.tablet
+++ b/data/intuos-pro-2-s.tablet
@@ -44,7 +44,7 @@ Styli=@intuos4;@intuos5;@mobilestudio;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Ring=true
+NumRings=1
 
 [Buttons]
 Left=A;B;C;D;E;F;G

--- a/data/intuos-pro-l.tablet
+++ b/data/intuos-pro-l.tablet
@@ -57,7 +57,7 @@ Styli=@intuos4-lens;@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Ring=true
+NumRings=1
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos-pro-m.tablet
+++ b/data/intuos-pro-m.tablet
@@ -57,7 +57,7 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Ring=true
+NumRings=1
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos-pro-s.tablet
+++ b/data/intuos-pro-s.tablet
@@ -55,7 +55,7 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Ring=true
+NumRings=1
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos4-12x19.tablet
+++ b/data/intuos4-12x19.tablet
@@ -46,7 +46,7 @@ Styli=@intuos4-lens;@intuos4-puck;@intuos5;@intuos4;@propengen2;
 [Features]
 Reversible=true
 Stylus=true
-Ring=true
+NumRings=1
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos4-4x6.tablet
+++ b/data/intuos4-4x6.tablet
@@ -47,7 +47,7 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 [Features]
 Reversible=true
 Stylus=true
-Ring=true
+NumRings=1
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos4-6x9-wl.tablet
+++ b/data/intuos4-6x9-wl.tablet
@@ -46,7 +46,7 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 [Features]
 Reversible=true
 Stylus=true
-Ring=true
+NumRings=1
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos4-6x9.tablet
+++ b/data/intuos4-6x9.tablet
@@ -46,7 +46,7 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 [Features]
 Reversible=true
 Stylus=true
-Ring=true
+NumRings=1
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos4-8x13.tablet
+++ b/data/intuos4-8x13.tablet
@@ -46,7 +46,7 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 [Features]
 Reversible=true
 Stylus=true
-Ring=true
+NumRings=1
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos5-m.tablet
+++ b/data/intuos5-m.tablet
@@ -57,7 +57,7 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Stylus=true
 Reversible=true
 Touch=false
-Ring=true
+NumRings=1
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos5-s.tablet
+++ b/data/intuos5-s.tablet
@@ -55,7 +55,7 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Stylus=true
 Reversible=true
 Touch=false
-Ring=true
+NumRings=1
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos5-touch-l.tablet
+++ b/data/intuos5-touch-l.tablet
@@ -57,7 +57,7 @@ Styli=@intuos4-lens;@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Ring=true
+NumRings=1
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos5-touch-m.tablet
+++ b/data/intuos5-touch-m.tablet
@@ -57,7 +57,7 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Ring=true
+NumRings=1
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/intuos5-touch-s.tablet
+++ b/data/intuos5-touch-s.tablet
@@ -55,7 +55,7 @@ Styli=@intuos4-puck;@intuos5;@intuos4;@propengen2;
 Stylus=true
 Reversible=true
 Touch=true
-Ring=true
+NumRings=1
 StatusLEDs=Ring
 
 [Buttons]

--- a/data/isdv4-52d5.tablet
+++ b/data/isdv4-52d5.tablet
@@ -16,5 +16,5 @@ Height=7
 Reversible=false
 Stylus=true
 Touch=true
-Ring=false
+NumRings=0
 BuiltIn=true

--- a/data/kamvas-pro-13.tablet
+++ b/data/kamvas-pro-13.tablet
@@ -49,7 +49,7 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
+NumRings=0
 
 [Buttons]
 Left=A;B;C;D;E

--- a/data/mobilestudio-pro-13-2.tablet
+++ b/data/mobilestudio-pro-13-2.tablet
@@ -48,7 +48,7 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Ring=true
+NumRings=1
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H;I;J;K

--- a/data/mobilestudio-pro-13.tablet
+++ b/data/mobilestudio-pro-13.tablet
@@ -48,7 +48,7 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Ring=true
+NumRings=1
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H;I;J;K

--- a/data/mobilestudio-pro-16-2.tablet
+++ b/data/mobilestudio-pro-16-2.tablet
@@ -50,7 +50,7 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Ring=true
+NumRings=1
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H;I;J;K;L;M

--- a/data/mobilestudio-pro-16-3.tablet
+++ b/data/mobilestudio-pro-16-3.tablet
@@ -50,7 +50,7 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Ring=true
+NumRings=1
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H;I;J;K;L;M

--- a/data/mobilestudio-pro-16.tablet
+++ b/data/mobilestudio-pro-16.tablet
@@ -50,7 +50,7 @@ IntegratedIn=Display;System
 [Features]
 Stylus=true
 Touch=true
-Ring=true
+NumRings=1
 
 [Buttons]
 Left=A;B;C;D;E;F;G;H;I;J;K;L;M

--- a/data/serial-wacf004.tablet
+++ b/data/serial-wacf004.tablet
@@ -7,4 +7,4 @@ IntegratedIn=Display;System
 
 [Features]
 Stylus=true
-Ring=false
+NumRings=0

--- a/data/wacom-hid-52EB-pen.tablet
+++ b/data/wacom-hid-52EB-pen.tablet
@@ -19,4 +19,4 @@ IntegratedIn=Display;System
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0

--- a/data/wacom-hid-52fa-pen.tablet
+++ b/data/wacom-hid-52fa-pen.tablet
@@ -19,4 +19,4 @@ IntegratedIn=Display;System
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0

--- a/data/wacom-one-12.tablet
+++ b/data/wacom-one-12.tablet
@@ -19,4 +19,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
+NumRings=0

--- a/data/wacom-one-13.tablet
+++ b/data/wacom-one-13.tablet
@@ -19,4 +19,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=true
-Ring=false
+NumRings=0

--- a/data/wacom-one.tablet
+++ b/data/wacom-one.tablet
@@ -16,4 +16,4 @@ IntegratedIn=Display
 Stylus=true
 Reversible=false
 Touch=false
-Ring=false
+NumRings=0

--- a/data/wacom.example
+++ b/data/wacom.example
@@ -165,13 +165,11 @@ Touch=false
 # This tablet provides a hardware touch switch.
 TouchSwitch=false
 
-# This tablet has a touch ring (Intuos4 and Cintiq 24HD)
+# This tablet has one or more touch rings (Intuos4 and Cintiq 24HD)
 # A touch ring is a circular button that responds to touch
 # (rather than clicks):
 # http://intuos.wacom.com/americas/touch-ring.php
-Ring=true
-# This tablet has a second touch ring (Cintiq 24HD)
-Ring2=false
+NumRings=1
 
 # This tablet's number of touch strips (e.g. Cintiq 22HD), default is zero
 NumStrips=1

--- a/data/xp-pen-artist10s.tablet
+++ b/data/xp-pen-artist10s.tablet
@@ -21,8 +21,7 @@ Stylus=true
 Reversible=true
 Touch=false
 TouchSwitch=false
-Ring=false
-Ring2=false
+NumRings=0
 
 [Buttons]
 Left=A;B;C;D;E;F

--- a/data/xp-pen-artist12.tablet
+++ b/data/xp-pen-artist12.tablet
@@ -21,8 +21,7 @@ Stylus=true
 Reversible=true
 Touch=false
 TouchSwitch=false
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=1
 
 [Buttons]

--- a/data/xp-pen-artist13-3-pro.tablet
+++ b/data/xp-pen-artist13-3-pro.tablet
@@ -21,8 +21,7 @@ Stylus=true
 Reversible=false
 Touch=false
 TouchSwitch=false
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0
 
 [Buttons]

--- a/data/xp-pen-deco-l.tablet
+++ b/data/xp-pen-deco-l.tablet
@@ -21,8 +21,7 @@ Stylus=true
 Reversible=true
 Touch=false
 TouchSwitch=false
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0
 
 [Buttons]

--- a/data/xp-pen-deco-mw.tablet
+++ b/data/xp-pen-deco-mw.tablet
@@ -19,8 +19,7 @@ Stylus=true
 Reversible=true
 Touch=false
 TouchSwitch=false
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0
 
 [Buttons]

--- a/data/xp-pen-deco-pro-mw.tablet
+++ b/data/xp-pen-deco-pro-mw.tablet
@@ -33,8 +33,7 @@ Styli=@generic-no-eraser
 Stylus=true
 Reversible=true
 Touch=false
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0
 
 [Buttons]

--- a/data/xp-pen-deco-pro-sw.tablet
+++ b/data/xp-pen-deco-pro-sw.tablet
@@ -20,8 +20,7 @@ Styli=@generic-no-eraser
 Stylus=true
 Reversible=true
 Touch=false
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0
 
 [Buttons]

--- a/data/xp-pen-deco01-v2.tablet
+++ b/data/xp-pen-deco01-v2.tablet
@@ -21,8 +21,7 @@ Stylus=true
 Reversible=true
 Touch=false
 TouchSwitch=false
-Ring=false
-Ring2=false
+NumRings=0
 NumStrips=0
 
 [Buttons]

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -754,12 +754,6 @@ libwacom_parse_features(WacomDevice *device, GKeyFile *keyfile)
 	if (g_key_file_get_boolean(keyfile, FEATURES_GROUP, "Touch", NULL))
 		device->features |= FEATURE_TOUCH;
 
-	if (g_key_file_get_boolean(keyfile, FEATURES_GROUP, "Ring", NULL))
-		device->features |= FEATURE_RING;
-
-	if (g_key_file_get_boolean(keyfile, FEATURES_GROUP, "Ring2", NULL))
-		device->features |= FEATURE_RING2;
-
 	if (g_key_file_get_boolean(keyfile, FEATURES_GROUP, "Reversible", NULL))
 		device->features |= FEATURE_REVERSIBLE;
 
@@ -771,14 +765,11 @@ libwacom_parse_features(WacomDevice *device, GKeyFile *keyfile)
 	    device->features & FEATURE_REVERSIBLE)
 		g_warning ("Tablet '%s' is both reversible and integrated in screen. This is impossible", libwacom_get_match(device));
 
-	if (!(device->features & FEATURE_RING) &&
-	    (device->features & FEATURE_RING2))
-		g_warning ("Tablet '%s' has Ring2 but no Ring. This is impossible", libwacom_get_match(device));
-
 	if (!(device->features & FEATURE_TOUCH) &&
 	    (device->features & FEATURE_TOUCHSWITCH))
 		g_warning ("Tablet '%s' has touch switch but no touch tool. This is impossible", libwacom_get_match(device));
 
+	device->num_rings = g_key_file_get_integer(keyfile, FEATURES_GROUP, "NumRings", NULL);
 	device->num_strips = g_key_file_get_integer(keyfile, FEATURES_GROUP, "NumStrips", NULL);
 
 	string_list = g_key_file_get_string_list(keyfile, FEATURES_GROUP, "StatusLEDs", NULL, NULL);

--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -403,6 +403,7 @@ libwacom_copy(const WacomDevice *device)
 		d->paired = libwacom_match_ref(device->paired);
 	d->cls = device->cls;
 	d->num_strips = device->num_strips;
+	d->num_rings = device->num_rings;
 	d->features = device->features;
 	d->strips_num_modes = device->strips_num_modes;
 	d->ring_num_modes = device->ring_num_modes;
@@ -944,8 +945,7 @@ libwacom_print_device_description(int fd, const WacomDevice *device)
 	dprintf(fd, "[Features]\n");
 	dprintf(fd, "Reversible=%s\n", libwacom_is_reversible(device)	? "true" : "false");
 	dprintf(fd, "Stylus=%s\n",	 libwacom_has_stylus(device)	? "true" : "false");
-	dprintf(fd, "Ring=%s\n",	 libwacom_has_ring(device)	? "true" : "false");
-	dprintf(fd, "Ring2=%s\n",	 libwacom_has_ring2(device)	? "true" : "false");
+	dprintf(fd, "NumRings=%s\n",	 libwacom_get_num_rings(device)	? "true" : "false");
 	dprintf(fd, "Touch=%s\n",	 libwacom_has_touch(device)	? "true" : "false");
 	dprintf(fd, "TouchSwitch=%s\n",	libwacom_has_touchswitch(device)? "true" : "false");
 	print_supported_leds(fd, device);
@@ -1205,13 +1205,19 @@ libwacom_get_supported_styli(const WacomDevice *device, int *num_styli)
 LIBWACOM_EXPORT int
 libwacom_has_ring(const WacomDevice *device)
 {
-	return !!(device->features & FEATURE_RING);
+	return device->num_rings >= 1;
 }
 
 LIBWACOM_EXPORT int
 libwacom_has_ring2(const WacomDevice *device)
 {
-	return !!(device->features & FEATURE_RING2);
+	return device->num_rings >= 2;
+}
+
+LIBWACOM_EXPORT int
+libwacom_get_num_rings(const WacomDevice *device)
+{
+	return device->num_rings;
 }
 
 LIBWACOM_EXPORT int

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -617,17 +617,29 @@ const int *libwacom_get_supported_styli(const WacomDevice *device, int *num_styl
  * @param device The tablet to query
  * @return non-zero if the device has a touch ring or zero otherwise
  *
+ * @deprecated 2.12 Use libwacom_get_num_rings() instead.
  * @ingroup devices
  */
-int libwacom_has_ring(const WacomDevice *device);
+int libwacom_has_ring(const WacomDevice *device) LIBWACOM_DEPRECATED;
 
 /**
  * @param device The tablet to query
  * @return non-zero if the device has a second touch ring or zero otherwise
  *
+ * @deprecated 2.12 Use libwacom_get_num_rings() instead.
  * @ingroup devices
  */
-int libwacom_has_ring2(const WacomDevice *device);
+int libwacom_has_ring2(const WacomDevice *device) LIBWACOM_DEPRECATED;
+
+/**
+ * @param device The tablet to query
+ * @return the number of touch rings on the tablet
+ * otherwise
+ *
+ * @since 2.12
+ * @ingroup devices
+ */
+int libwacom_get_num_rings(const WacomDevice *device);
 
 /**
  * @param device The tablet to query

--- a/libwacom/libwacom.sym
+++ b/libwacom/libwacom.sym
@@ -75,4 +75,5 @@ LIBWACOM_2.9 {
 
 LIBWACOM_2.12 {
     libwacom_match_get_uniq;
+    libwacom_get_num_rings;
 } LIBWACOM_2.9;

--- a/libwacom/libwacomint.h
+++ b/libwacom/libwacomint.h
@@ -44,8 +44,6 @@
 enum WacomFeature {
 	FEATURE_STYLUS		= (1 << 0),
 	FEATURE_TOUCH		= (1 << 1),
-	FEATURE_RING		= (1 << 2),
-	FEATURE_RING2		= (1 << 3),
 	FEATURE_REVERSIBLE	= (1 << 4),
 	FEATURE_TOUCHSWITCH	= (1 << 5)
 };
@@ -89,6 +87,7 @@ struct _WacomDevice {
 
 	WacomClass cls;
 	int num_strips;
+	int num_rings;
 	uint32_t features;
 	uint32_t integration_flags;
 

--- a/test/test-load.c
+++ b/test/test-load.c
@@ -118,8 +118,12 @@ test_intuos4(struct fixture *f, gconstpointer user_data)
 	g_assert_true(libwacom_has_stylus(device));
 	g_assert_true(libwacom_is_reversible(device));
 	g_assert_false(libwacom_has_touch(device));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	g_assert_true(libwacom_has_ring(device));
 	g_assert_false(libwacom_has_ring2(device));
+#pragma GCC diagnostic pop
+	g_assert_cmpint(libwacom_get_num_rings(device), ==, 1);
 	g_assert_false(libwacom_has_touchswitch(device));
 	g_assert_cmpint(libwacom_get_num_strips(device), ==, 0);
 	g_assert_cmpint(libwacom_get_integration_flags (device), ==, WACOM_DEVICE_INTEGRATED_NONE);

--- a/test/test-tablet-svg-validity.c
+++ b/test/test-tablet-svg-validity.c
@@ -262,9 +262,9 @@ test_rings(struct fixture *f, gconstpointer data)
 {
 	const WacomDevice *device = data;
 
-	if (libwacom_has_ring(device))
+	if (libwacom_get_num_rings(device) >= 1)
 		check_touchring(f->root, "Ring");
-	if (libwacom_has_ring2(device))
+	if (libwacom_get_num_rings(device) >= 2)
 		check_touchring(f->root, "Ring2");
 }
 
@@ -362,7 +362,7 @@ static void setup_tests(WacomDevice *device)
 	add_test(device, test_dimensions);
 	if (libwacom_get_num_buttons(device) > 0)
 		add_test(device, test_buttons);
-	if (libwacom_has_ring(device) || libwacom_has_ring2(device))
+	if (libwacom_get_num_rings(device) > 0)
 		add_test(device, test_rings);
 	if (libwacom_get_num_strips(device) > 0)
 		add_test(device, test_strips);

--- a/test/test-tablet-validity.c
+++ b/test/test-tablet-validity.c
@@ -271,11 +271,11 @@ test_rings(gconstpointer data)
 	g_assert_cmpint(libwacom_get_ring_num_modes(device), >=, 0);
 	g_assert_cmpint(libwacom_get_ring2_num_modes(device), >=, 0);
 
-	if (libwacom_has_ring(device))
+	if (libwacom_get_num_rings(device) >= 1)
 		g_assert_true(match_mode_switch(device,
 						libwacom_get_ring_num_modes,
 						WACOM_BUTTON_RING_MODESWITCH));
-	if (libwacom_has_ring2(device))
+	if (libwacom_get_num_rings(device) >= 2)
 		g_assert_true(match_mode_switch(device,
 						libwacom_get_ring2_num_modes,
 						WACOM_BUTTON_RING2_MODESWITCH));

--- a/tools/debug-device.c
+++ b/tools/debug-device.c
@@ -152,8 +152,11 @@ handle_device(WacomDeviceDatabase *db, const char *path)
 	intfunc(libwacom_has_touch, device);
 	intfunc(libwacom_get_num_buttons, device);
 	intfunc(libwacom_get_num_keys, device);
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 	intfunc(libwacom_has_ring, device);
 	intfunc(libwacom_has_ring2, device);
+	#pragma GCC diagnostic pop
 	intfunc(libwacom_has_touchswitch, device);
 	intfunc(libwacom_get_ring_num_modes, device);
 	intfunc(libwacom_get_ring2_num_modes, device);


### PR DESCRIPTION
This deprecates libwacom_has_ring() and libwacom_has_ring2() for the new libwacom_get_num_rings(). In our tablet files we also remove Ring=true/Ring2=true and replace that with NumRings=.

This makes the support line up better with strip support and removes some of the confusion in the tablet file where we have two independent Ring and Ring2 entries with different meanings.


Closes #668 #667 