### PR TITLE
Added more device names for kamvas 13 variants

### DIFF
--- a/data/huion-kamvas-13.tablet
+++ b/data/huion-kamvas-13.tablet
@@ -24,7 +24,7 @@
 [Device]
 Name=Huion Kamvas 13
 ModelName=GS1331
-DeviceMatch=usb|256c|006d|HUION Huion Tablet_GS1331 Pad;usb|256c|006d|HUION Huion Tablet_GS1331 Pen
+DeviceMatch=usb:256c:006d:HUION Huion Tablet_GS1331 Pad;usb:256c:006d:HUION Huion Tablet_GS1331 Pen;usb:256c:006d:Tablet Monitor;usb:256c:006d:Tablet Monitor Pad;usb:256c:006d:Tablet Monitor Pen
 Class=Cintiq
 Width=12
 Height=7

--- a/data/huion-kamvas-13.tablet
+++ b/data/huion-kamvas-13.tablet
@@ -24,7 +24,7 @@
 [Device]
 Name=Huion Kamvas 13
 ModelName=GS1331
-DeviceMatch=usb:256c:006d:HUION Huion Tablet_GS1331 Pad;usb:256c:006d:HUION Huion Tablet_GS1331 Pen;usb:256c:006d:Tablet Monitor;usb:256c:006d:Tablet Monitor Pad;usb:256c:006d:Tablet Monitor Pen
+DeviceMatch=usb|256c|006d|HUION Huion Tablet_GS1331 Pad;usb|256c|006d|HUION Huion Tablet_GS1331 Pen;usb|256c|006d|Tablet Monitor;usb|256c|006d|Tablet Monitor Pad;usb|256c|006d|Tablet Monitor Pen
 Class=Cintiq
 Width=12
 Height=7


### PR DESCRIPTION
I am using the Kamvas 13 with the same model number, but it couldn't be detected by libwacom.
After some searching, I found out that the device name used in the descriptor doesn't match the one reported by my tablet.
I suspect there may be a different firmware installed.
Nevertheless, by adding the device names to the descriptor, everything is working.

Is it fine to use colon (:) as serperator?
The Pipe Symbol did not work on my distribution.
If not i can switch it to the other symbol.