### PR TITLE
meson.build: increase timeout of pytest test

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -294,7 +294,8 @@ if get_option('tests').enabled()
 	     pytest,
 	     args: ['--verbose', '--log-level=DEBUG', meson.current_source_dir()],
 	     env: env,
-	     suite: ['all'])
+	     suite: ['all'],
+	     timeout: 300)
 endif
 
 # This is a non-optional test


### PR DESCRIPTION
Running pytest can take a while, especially if the system is already under load (for example, if it's building other packages at the same time as libwacom).  Recently, I saw it take 82 seconds.