### PR TITLE
Add libwacom_new_from_builder()

### DIFF
--- a/libwacom/libwacom.sym
+++ b/libwacom/libwacom.sym
@@ -79,4 +79,12 @@ LIBWACOM_2.12 {
     libwacom_get_num_dials;
     libwacom_get_num_rings;
     libwacom_match_get_uniq;
+    libwacom_builder_new;
+    libwacom_builder_destroy;
+    libwacom_builder_set_bustype;
+    libwacom_builder_set_device_name;
+    libwacom_builder_set_match_name;
+    libwacom_builder_set_uniq;
+    libwacom_builder_set_usbid;
+    libwacom_new_from_builder;
 } LIBWACOM_2.9;

--- a/libwacom/libwacomint.h
+++ b/libwacom/libwacomint.h
@@ -48,6 +48,15 @@ enum WacomFeature {
 	FEATURE_TOUCHSWITCH	= (1 << 5)
 };
 
+struct _WacomBuilder {
+	char *device_name;
+	char *match_name;
+	char *uniq;
+	WacomBusType bus;
+	uint32_t vendor_id;
+	uint32_t product_id;
+};
+
 /* WARNING: When adding new members to this struct
  * make sure to update libwacom_copy_match() ! */
 struct _WacomMatch {


### PR DESCRIPTION
This adds a new (and hopefully final) `libwacom_new_from...` call. This one takes a ~~match~~ `WacomBuilder` object which can now be constructed and filled by the user. In the future if we need to add further fields we can extend the `WacomBuilder` with a setter and have this function still work for us.

Notably, see https://github.com/linuxwacom/libwacom/pull/676#issuecomment-2092747045 the builder differentiates between the device name and the match name since those two may not be the same. The behaviour of the builder approach matches the existing approaches we have so the various `libwacom_new_from_` functions can be emulated with the new builder approach.

Prime motivation here is to be able to test better, I don't think any of our callers will switch since they all use `new_from_path`. In particular for the correct loading behaviour in #659.

Closes #670 