### PR TITLE
Allow for a uniq-only match

### DIFF
--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -158,7 +158,7 @@ make_match_string (const char *name, const char *uniq, WacomBusType bus, int ven
 	return g_strdup_printf("%s|%04x|%04x%s%s%s%s",
 				bus_to_str (bus),
 				vendor_id, product_id,
-				name ? "|" : "",
+				(name || uniq) ? "|" : "",
 				name ? name : "",
 			        uniq ? "|" : "",
 			        uniq ? uniq : "");

--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -752,6 +752,10 @@ libwacom_new_from_builder(const WacomDeviceDatabase *db, const WacomBuilder *bui
 				if (device == NULL) {
 					match_name = NULL;
 					device = libwacom_new (db, match_name, match_uniq, vendor_id, product_id, *bus, error);
+					if (device == NULL) {
+						match_uniq = uniq;
+						device = libwacom_new (db, match_name, match_uniq, vendor_id, product_id, *bus, error);
+					}
 				}
 			}
 			if (device)


### PR DESCRIPTION
First commit extracted from @JoseExposito's patchset in #659 but I think this needs a behaviour change to allow for uniq-only matches to take precedence over name matches, see https://github.com/linuxwacom/libwacom/pull/659#issuecomment-2091928456

Draft because it's untested and to test this we should add #677 and #676 first so we can test this properly.