### PR TITLE
test: add ids to the parametrized tablet file tests

### DIFF
--- a/test/test_data_files.py
+++ b/test/test_data_files.py
@@ -25,7 +25,8 @@ def pytest_generate_tests(metafunc):
     # for any function that takes a "tabletfile" argument return the path to
     # a tablet file
     if "tabletfile" in metafunc.fixturenames:
-        metafunc.parametrize("tabletfile", [f for f in datadir().glob("*.tablet")])
+        files = [f for f in datadir().glob("*.tablet")]
+        metafunc.parametrize("tabletfile", files, ids=[f.name for f in files])
 
 
 def test_device_match(tabletfile):


### PR DESCRIPTION
This now useds the tablet file name as part of the test name as opposed to the less-useful "tabletfile123":
```
    test/test_data_files.py::test_svg_exists[dtk-1651.tablet] PASSED                                                                                                                                                                                                                                                                                      [ 48%]```