### PR TITLE
data: add Wacom HID 49A0 (Dell latitude 5320 2-in-1)

### DIFF
--- a/data/wacom-hid-49a0-pen.tablet
+++ b/data/wacom-hid-49a0-pen.tablet
@@ -2,6 +2,9 @@
 # Wacom HID 5362
 #
 # AES Sensor used by the Dell Latitude 5320 2-in-1
+#
+# sysinfo.h5MttpxmAu.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/378
 
 [Device]
 Name=Wacom HID 49A0 Pen

--- a/data/wacom-hid-49a0-pen.tablet
+++ b/data/wacom-hid-49a0-pen.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=Wacom HID 49A0 Pen
 ModelName=
-DeviceMatch=i2c:056a:49a0
+DeviceMatch=i2c|056a|49a0
 Class=ISDV4
 Width=11
 Height=6

--- a/data/wacom-hid-49a0-pen.tablet
+++ b/data/wacom-hid-49a0-pen.tablet
@@ -1,0 +1,18 @@
+# Wacom
+# Wacom HID 5362
+#
+# AES Sensor used by the Dell Latitude 5320 2-in-1
+
+[Device]
+Name=Wacom HID 49A0 Pen
+ModelName=
+DeviceMatch=i2c:056a:49a0
+Class=ISDV4
+Width=11
+Height=6
+IntegratedIn=Display;System
+Styli=@isdv4-aes;
+
+[Features]
+Stylus=true
+Touch=true


### PR DESCRIPTION
Tested and working on my machine, a Dell latitude 5320 2-in-1, but I assume any device with a Wacom HID 49a0 would also work the same.

Sysinfo relating to this can be found here: https://github.com/linuxwacom/wacom-hid-descriptors/issues/378

I did make the file manually, so let me know if I missed something.