### PR TITLE
Fix the pytest invocation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -285,23 +285,25 @@ if get_option('tests').enabled()
 		message('valgrind not found, disabling valgrind test suite')
 	endif
 
-	env = environment()
-	env.set('MESON_SOURCE_ROOT', meson.current_source_dir())
-	env.set('LIBWACOM_HWDB_FILE', hwdb.full_path())
-	env.set('LD_LIBRARY_PATH', fs.parent(lib_libwacom.full_path()))
-	pymod.find_installation(modules: ['libevdev', 'pyudev', 'pytest'])
-	pytest = find_program('pytest-3', 'pytest')
-	test('pytest',
-	     pytest,
-	     args: ['--verbose',
-		     '-rfES',
-		     '--log-level=DEBUG',
-		     '--log-file', meson.project_build_root() / 'meson-logs' / 'pytest.log',
-		     '--log-file-level=DEBUG',
-		     meson.current_source_dir()
-	     ],
-	     env: env,
-	     suite: ['all'])
+	if get_option('b_sanitize') == 'none'
+		env = environment()
+		env.set('MESON_SOURCE_ROOT', meson.current_source_dir())
+		env.set('LIBWACOM_HWDB_FILE', hwdb.full_path())
+		env.set('LD_LIBRARY_PATH', fs.parent(lib_libwacom.full_path()))
+		pymod.find_installation(modules: ['libevdev', 'pyudev', 'pytest'])
+		pytest = find_program('pytest-3', 'pytest')
+		test('pytest',
+		     pytest,
+		     args: ['--verbose',
+			     '-rfES',
+			     '--log-level=DEBUG',
+			     '--log-file', meson.project_build_root() / 'meson-logs' / 'pytest.log',
+			     '--log-file-level=DEBUG',
+			     meson.current_source_dir()
+		     ],
+		     env: env,
+		     suite: ['all'])
+	endif
 endif
 
 # This is a non-optional test

--- a/meson.build
+++ b/meson.build
@@ -292,17 +292,25 @@ if get_option('tests').enabled()
 		env.set('LD_LIBRARY_PATH', fs.parent(lib_libwacom.full_path()))
 		pymod.find_installation(modules: ['libevdev', 'pyudev', 'pytest'])
 		pytest = find_program('pytest-3', 'pytest')
-		test('pytest',
-		     pytest,
-		     args: ['--verbose',
-			     '-rfES',
-			     '--log-level=DEBUG',
-			     '--log-file', meson.project_build_root() / 'meson-logs' / 'pytest.log',
-			     '--log-file-level=DEBUG',
-			     meson.current_source_dir()
-		     ],
-		     env: env,
-		     suite: ['all'])
+		pytest_files = [
+			'test_data_files.py',
+			'test_libwacom.py',
+			'test_svg.py',
+			'test_udev_rules.py',
+		]
+		foreach f: pytest_files
+			test('pytest @0@'.format(f),
+			     pytest,
+			     args: ['--verbose',
+				     '-rfES',
+				     '--log-level=DEBUG',
+				     '--log-file', meson.project_build_root() / 'meson-logs' / 'pytest.log',
+				     '--log-file-level=DEBUG',
+				     meson.current_source_dir() / 'test' / f,
+			     ],
+			     env: env,
+			     suite: ['all'])
+		endforeach
 	endif
 endif
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,9 +14,6 @@ logger = logging.getLogger(__name__)
 
 
 def load_test_db() -> WacomDatabase:
-    if any(os.environ.get(v) for v in ["ASAN_OPTIONS", "UBSAN_OPTIONS"]):
-        pytest.skip("ASAN/UBSAN not supported in this module")
-
     try:
         dbpath = os.environ.get("MESON_SOURCE_ROOT")
         if dbpath is None and (Path.cwd() / "meson.build").exists():

--- a/test/test_libwacom.py
+++ b/test/test_libwacom.py
@@ -3,15 +3,9 @@
 # This file is formatted with ruff format
 
 import logging
-import os
 import pytest
 
 from . import WacomBuilder, WacomBustype, WacomDatabase, WacomDevice
-
-# If asan/ubsan is set, ctypes.CDLL blows up on us, so skip
-# this module if either is set
-if any(os.environ.get(v) for v in ["ASAN_OPTIONS", "UBSAN_OPTIONS"]):
-    pytest.skip("ASAN/UBSAN not supported in this module", allow_module_level=True)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
meson always sets `ASAN_OPTIONS` so the SVG tests didn't actually run in our CI. oops.

Filing as draft because pretty much all the SVGs added in #659 are missing some bits so they need to get fixed one-by-one.