### PR TITLE
layouts: Fix buttons for Huion and Gaomon tablets

### DIFF
--- a/data/layouts/gaomon-1060pro.svg
+++ b/data/layouts/gaomon-1060pro.svg
@@ -1,168 +1,66 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-1060pro"
-        width="750"
-        height="499">
-    <title id="title">1060PRO</title>
-    <rect x="149" y="80" width="533" height="341" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="29"
-                      y="89"
-                      width="36"
-                      height="27" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="45"
-                      y="104.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="69"
-                      y="88"
-                      width="36"
-                      height="27" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="85"
-                      y="103.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="29"
-                      y="139"
-                      width="36"
-                      height="27" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="45"
-                      y="154.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="69"
-                      y="139"
-                      width="36"
-                      height="27" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="85"
-                      y="154.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="29"
-                      y="189"
-                      width="36"
-                      height="27" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="45"
-                      y="204.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="69"
-                      y="189"
-                      width="36"
-                      height="27" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="85"
-                      y="204.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="29"
-                      y="287"
-                      width="36"
-                      height="27" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="45"
-                      y="302.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="68"
-                      y="287"
-                      width="36"
-                      height="27" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="84"
-                      y="302.5"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="29"
-                      y="337"
-                      width="36"
-                      height="27" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="45"
-                      y="352.5"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="68"
-                      y="337"
-                      width="36"
-                      height="27" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="84"
-                      y="352.5"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="29"
-                      y="388"
-                      width="36"
-                      height="27" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="45"
-                      y="403.5"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="68"
-                      y="388"
-                      width="36"
-                      height="27" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="84"
-                      y="403.5"
-                      style="text-anchor:start;">L</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-1060pro" width="750" height="499">
+  <title id="title">1060PRO</title>
+  <rect x="149" y="80" width="533" height="341"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="29" y="89" width="36" height="27"/>
+    <text id="LabelA" class="A Label" x="5.0" y="104.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 23.0,102.5 H 15.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="69" y="88" width="36" height="27"/>
+    <text id="LabelB" class="B Label" x="125.0" y="103.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 110.0,101.5 H 117.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="29" y="139" width="36" height="27"/>
+    <text id="LabelC" class="C Label" x="5.0" y="154.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 23.0,152.5 H 15.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="69" y="139" width="36" height="27"/>
+    <text id="LabelD" class="D Label" x="125.0" y="154.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 110.0,152.5 H 117.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="29" y="189" width="36" height="27"/>
+    <text id="LabelE" class="E Label" x="5.0" y="204.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 23.0,202.5 H 15.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="69" y="189" width="36" height="27"/>
+    <text id="LabelF" class="F Label" x="125.0" y="204.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 110.0,202.5 H 117.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="29" y="287" width="36" height="27"/>
+    <text id="LabelG" class="G Label" x="5.0" y="302.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 23.0,300.5 H 15.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="68" y="287" width="36" height="27"/>
+    <text id="LabelH" class="H Label" x="124.0" y="302.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 109.0,300.5 H 116.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="29" y="337" width="36" height="27"/>
+    <text id="LabelI" class="I Label" x="5.0" y="352.5" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 23.0,350.5 H 15.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="68" y="337" width="36" height="27"/>
+    <text id="LabelJ" class="J Label" x="124.0" y="352.5" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 109.0,350.5 H 116.0" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="29" y="388" width="36" height="27"/>
+    <text id="LabelK" class="K Label" x="5.0" y="403.5" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 23.0,401.5 H 15.0" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="68" y="388" width="36" height="27"/>
+    <text id="LabelL" class="L Label" x="124.0" y="403.5" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 109.0,401.5 H 116.0" id="LeaderL" class="Leader L"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-1061pro.svg
+++ b/data/layouts/gaomon-1061pro.svg
@@ -1,168 +1,66 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-1061pro"
-        width="750"
-        height="480">
-    <title id="title">1061Pro</title>
-    <rect x="132" y="62" width="572" height="358" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="20"
-                      y="80"
-                      width="39"
-                      height="27" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="37.5"
-                      y="95.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="62"
-                      y="80"
-                      width="39"
-                      height="27" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="79.5"
-                      y="95.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="20"
-                      y="130"
-                      width="39"
-                      height="27" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="37.5"
-                      y="145.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="62"
-                      y="130"
-                      width="39"
-                      height="27" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="79.5"
-                      y="145.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="20"
-                      y="180"
-                      width="39"
-                      height="27" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="37.5"
-                      y="195.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="62"
-                      y="180"
-                      width="39"
-                      height="27" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="79.5"
-                      y="195.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="20"
-                      y="272"
-                      width="39"
-                      height="27" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="37.5"
-                      y="287.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="62"
-                      y="272"
-                      width="39"
-                      height="27" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="79.5"
-                      y="287.5"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="20"
-                      y="321"
-                      width="39"
-                      height="27" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="37.5"
-                      y="336.5"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="62"
-                      y="321"
-                      width="39"
-                      height="27" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="79.5"
-                      y="336.5"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="20"
-                      y="371"
-                      width="39"
-                      height="27" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="37.5"
-                      y="386.5"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="62"
-                      y="371"
-                      width="39"
-                      height="27" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="79.5"
-                      y="386.5"
-                      style="text-anchor:start;">L</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-1061pro" width="750" height="480">
+  <title id="title">1061Pro</title>
+  <rect x="132" y="62" width="572" height="358"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="20" y="80" width="39" height="27"/>
+    <text id="LabelA" class="A Label" x="-2.5" y="95.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 15.5,93.5 H 7.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="62" y="80" width="39" height="27"/>
+    <text id="LabelB" class="B Label" x="119.5" y="95.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 104.5,93.5 H 111.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="20" y="130" width="39" height="27"/>
+    <text id="LabelC" class="C Label" x="-2.5" y="145.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 15.5,143.5 H 7.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="62" y="130" width="39" height="27"/>
+    <text id="LabelD" class="D Label" x="119.5" y="145.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 104.5,143.5 H 111.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="20" y="180" width="39" height="27"/>
+    <text id="LabelE" class="E Label" x="-2.5" y="195.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 15.5,193.5 H 7.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="62" y="180" width="39" height="27"/>
+    <text id="LabelF" class="F Label" x="119.5" y="195.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 104.5,193.5 H 111.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="20" y="272" width="39" height="27"/>
+    <text id="LabelG" class="G Label" x="-2.5" y="287.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 15.5,285.5 H 7.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="62" y="272" width="39" height="27"/>
+    <text id="LabelH" class="H Label" x="119.5" y="287.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 104.5,285.5 H 111.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="20" y="321" width="39" height="27"/>
+    <text id="LabelI" class="I Label" x="-2.5" y="336.5" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 15.5,334.5 H 7.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="62" y="321" width="39" height="27"/>
+    <text id="LabelJ" class="J Label" x="119.5" y="336.5" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 104.5,334.5 H 111.5" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="20" y="371" width="39" height="27"/>
+    <text id="LabelK" class="K Label" x="-2.5" y="386.5" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 15.5,384.5 H 7.5" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="62" y="371" width="39" height="27"/>
+    <text id="LabelL" class="L Label" x="119.5" y="386.5" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 104.5,384.5 H 111.5" id="LeaderL" class="Leader L"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-a1201.svg
+++ b/data/layouts/gaomon-a1201.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-a1201"
-        width="750"
-        height="447">
-    <title id="title">A1201</title>
-    <rect x="153" y="31" width="557" height="371" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="18"
-                      y="85"
-                      width="40"
-                      height="30" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="36"
-                      y="102"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="19"
-                      y="119"
-                      width="40"
-                      height="30" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="37"
-                      y="136"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="20"
-                      y="152"
-                      width="40"
-                      height="30" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="38"
-                      y="169"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="21"
-                      y="185"
-                      width="40"
-                      height="30" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="39"
-                      y="202"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="21"
-                      y="231"
-                      width="40"
-                      height="30" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="39"
-                      y="248"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="20"
-                      y="265"
-                      width="40"
-                      height="30" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="38"
-                      y="282"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="19"
-                      y="298"
-                      width="40"
-                      height="30" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="37"
-                      y="315"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="18"
-                      y="331"
-                      width="40"
-                      height="30" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="36"
-                      y="348"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-a1201" width="750" height="447">
+  <title id="title">A1201</title>
+  <rect x="153" y="31" width="557" height="371"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="18" y="85" width="40" height="30"/>
+    <text id="LabelA" class="A Label" x="86.0" y="102" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 71.0,100.0 H 78.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="19" y="119" width="40" height="30"/>
+    <text id="LabelB" class="B Label" x="87.0" y="136" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 72.0,134.0 H 79.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="20" y="152" width="40" height="30"/>
+    <text id="LabelC" class="C Label" x="88.0" y="169" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 73.0,167.0 H 80.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="21" y="185" width="40" height="30"/>
+    <text id="LabelD" class="D Label" x="89.0" y="202" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 74.0,200.0 H 81.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="21" y="231" width="40" height="30"/>
+    <text id="LabelE" class="E Label" x="89.0" y="248" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 74.0,246.0 H 81.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="20" y="265" width="40" height="30"/>
+    <text id="LabelF" class="F Label" x="88.0" y="282" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 73.0,280.0 H 80.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="19" y="298" width="40" height="30"/>
+    <text id="LabelG" class="G Label" x="87.0" y="315" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 72.0,313.0 H 79.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="18" y="331" width="40" height="30"/>
+    <text id="LabelH" class="H Label" x="86.0" y="348" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 71.0,346.0 H 78.0" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-a5h.svg
+++ b/data/layouts/gaomon-a5h.svg
@@ -1,181 +1,71 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-a5h"
-        width="750"
-        height="478">
-    <title id="title">A5H</title>
-    <rect x="138" y="37" width="576" height="405" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="37"
-                      y="234"
-                      width="24"
-                      height="24" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="47"
-                      y="248"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="66"
-                      y="234"
-                      width="24"
-                      height="24" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="76"
-                      y="248"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="37"
-                      y="200"
-                      width="24"
-                      height="24" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="47"
-                      y="214"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="66"
-                      y="200"
-                      width="24"
-                      height="24" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="76"
-                      y="214"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="37"
-                      y="165"
-                      width="24"
-                      height="24" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="47"
-                      y="179"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="66"
-                      y="165"
-                      width="24"
-                      height="24" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="76"
-                      y="179"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="37"
-                      y="131"
-                      width="24"
-                      height="24" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="47"
-                      y="145"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="66"
-                      y="131"
-                      width="24"
-                      height="24" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="76"
-                      y="145"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="37"
-                      y="97"
-                      width="24"
-                      height="24" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="47"
-                      y="111"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="66"
-                      y="97"
-                      width="24"
-                      height="24" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="76"
-                      y="111"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="37"
-                      y="62"
-                      width="24"
-                      height="24" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="47"
-                      y="76"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="66"
-                      y="62"
-                      width="24"
-                      height="24" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="76"
-                      y="76"
-                      style="text-anchor:start;">L</text>
-            </g>
-            <g>
-                <rect id="ButtonM"
-                      class="M Button"
-                      x="44"
-                      y="274"
-                      width="40"
-                      height="40" />
-                <text id="LabelM"
-                      class="M Label"
-                      x="62"
-                      y="296"
-                      style="text-anchor:start;">M</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-a5h" width="750" height="478">
+  <title id="title">A5H</title>
+  <rect x="138" y="37" width="576" height="405"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="37" y="234" width="24" height="24"/>
+    <text id="LabelA" class="A Label" x="7.0" y="248" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 25.0,246.0 H 17.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="66" y="234" width="24" height="24"/>
+    <text id="LabelB" class="B Label" x="116.0" y="248" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 101.0,246.0 H 108.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="37" y="200" width="24" height="24"/>
+    <text id="LabelC" class="C Label" x="7.0" y="214" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 25.0,212.0 H 17.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="66" y="200" width="24" height="24"/>
+    <text id="LabelD" class="D Label" x="116.0" y="214" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 101.0,212.0 H 108.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="37" y="165" width="24" height="24"/>
+    <text id="LabelE" class="E Label" x="7.0" y="179" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 25.0,177.0 H 17.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="66" y="165" width="24" height="24"/>
+    <text id="LabelF" class="F Label" x="116.0" y="179" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 101.0,177.0 H 108.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="37" y="131" width="24" height="24"/>
+    <text id="LabelG" class="G Label" x="7.0" y="145" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 25.0,143.0 H 17.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="66" y="131" width="24" height="24"/>
+    <text id="LabelH" class="H Label" x="116.0" y="145" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 101.0,143.0 H 108.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="37" y="97" width="24" height="24"/>
+    <text id="LabelI" class="I Label" x="7.0" y="111" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 25.0,109.0 H 17.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="66" y="97" width="24" height="24"/>
+    <text id="LabelJ" class="J Label" x="116.0" y="111" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 101.0,109.0 H 108.0" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="37" y="62" width="24" height="24"/>
+    <text id="LabelK" class="K Label" x="7.0" y="76" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 25.0,74.0 H 17.0" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="66" y="62" width="24" height="24"/>
+    <text id="LabelL" class="L Label" x="116.0" y="76" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 101.0,74.0 H 108.0" id="LeaderL" class="Leader L"/>
+  </g>
+  <g>
+    <rect id="ButtonM" class="M Button" x="44" y="274" width="40" height="40"/>
+    <text id="LabelM" class="M Label" x="102.0" y="296" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 87.0,294.0 H 94.0" id="LeaderM" class="Leader M"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-a5h_mt.svg
+++ b/data/layouts/gaomon-a5h_mt.svg
@@ -1,181 +1,71 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-a5h_mt"
-        width="750"
-        height="477">
-    <title id="title">A5H_MT</title>
-    <rect x="139" y="36" width="575" height="407" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="34"
-                      y="246"
-                      width="20"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="42"
-                      y="258"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="75"
-                      y="245"
-                      width="20"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="83"
-                      y="257"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="34"
-                      y="221"
-                      width="20"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="42"
-                      y="233"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="75"
-                      y="220"
-                      width="20"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="83"
-                      y="232"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="34"
-                      y="196"
-                      width="20"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="42"
-                      y="208"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="75"
-                      y="196"
-                      width="20"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="83"
-                      y="208"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="34"
-                      y="172"
-                      width="20"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="42"
-                      y="184"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="75"
-                      y="172"
-                      width="20"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="83"
-                      y="184"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="37"
-                      y="96"
-                      width="24"
-                      height="27" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="47"
-                      y="111.5"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="66"
-                      y="96"
-                      width="24"
-                      height="27" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="76"
-                      y="111.5"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="34"
-                      y="147"
-                      width="20"
-                      height="20" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="42"
-                      y="159"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="75"
-                      y="147"
-                      width="20"
-                      height="20" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="83"
-                      y="159"
-                      style="text-anchor:start;">L</text>
-            </g>
-            <g>
-                <rect id="ButtonM"
-                      class="M Button"
-                      x="43"
-                      y="274"
-                      width="42"
-                      height="41" />
-                <text id="LabelM"
-                      class="M Label"
-                      x="62"
-                      y="296.5"
-                      style="text-anchor:start;">M</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-a5h_mt" width="750" height="477">
+  <title id="title">A5H_MT</title>
+  <rect x="139" y="36" width="575" height="407"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="34" y="246" width="20" height="20"/>
+    <text id="LabelA" class="A Label" x="12.0" y="258" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 30.0,256.0 H 22.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="75" y="245" width="20" height="20"/>
+    <text id="LabelB" class="B Label" x="113.0" y="257" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 98.0,255.0 H 105.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="34" y="221" width="20" height="20"/>
+    <text id="LabelC" class="C Label" x="12.0" y="233" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 30.0,231.0 H 22.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="75" y="220" width="20" height="20"/>
+    <text id="LabelD" class="D Label" x="113.0" y="232" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 98.0,230.0 H 105.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="34" y="196" width="20" height="20"/>
+    <text id="LabelE" class="E Label" x="12.0" y="208" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 30.0,206.0 H 22.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="75" y="196" width="20" height="20"/>
+    <text id="LabelF" class="F Label" x="113.0" y="208" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 98.0,206.0 H 105.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="34" y="172" width="20" height="20"/>
+    <text id="LabelG" class="G Label" x="12.0" y="184" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 30.0,182.0 H 22.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="75" y="172" width="20" height="20"/>
+    <text id="LabelH" class="H Label" x="113.0" y="184" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 98.0,182.0 H 105.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="37" y="96" width="24" height="27"/>
+    <text id="LabelI" class="I Label" x="17.0" y="111.5" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 35.0,109.5 H 27.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="66" y="96" width="24" height="27"/>
+    <text id="LabelJ" class="J Label" x="106.0" y="111.5" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 91.0,109.5 H 98.0" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="34" y="147" width="20" height="20"/>
+    <text id="LabelK" class="K Label" x="12.0" y="159" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 30.0,157.0 H 22.0" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="75" y="147" width="20" height="20"/>
+    <text id="LabelL" class="L Label" x="113.0" y="159" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 98.0,157.0 H 105.0" id="LeaderL" class="Leader L"/>
+  </g>
+  <g>
+    <rect id="ButtonM" class="M Button" x="43" y="274" width="42" height="41"/>
+    <text id="LabelM" class="M Label" x="92.0" y="296.5" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 77.0,294.5 H 84.0" id="LeaderM" class="Leader M"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-a601.svg
+++ b/data/layouts/gaomon-a601.svg
@@ -1,64 +1,26 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-a601"
-        width="587"
-        height="500">
-    <title id="title">A601</title>
-    <rect x="80" y="181" width="425" height="265" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="32"
-                      y="20"
-                      width="52"
-                      height="36" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="56"
-                      y="40"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="94"
-                      y="16"
-                      width="65"
-                      height="37" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="124.5"
-                      y="36.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="429"
-                      y="16"
-                      width="65"
-                      height="37" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="459.5"
-                      y="36.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="502"
-                      y="20"
-                      width="52"
-                      height="36" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="526"
-                      y="40"
-                      style="text-anchor:start;">D</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-a601" width="587" height="500">
+  <title id="title">A601</title>
+  <rect x="80" y="181" width="425" height="265"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="32" y="20" width="52" height="36"/>
+    <text id="LabelA" class="A Label" x="56" y="90.0" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 58.0,75.0 V 82.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="94" y="16" width="65" height="37"/>
+    <text id="LabelB" class="B Label" x="124.5" y="86.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 126.5,71.5 V 78.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="429" y="16" width="65" height="37"/>
+    <text id="LabelC" class="C Label" x="459.5" y="86.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 461.5,71.5 V 78.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="502" y="20" width="52" height="36"/>
+    <text id="LabelD" class="D Label" x="526" y="90.0" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 528.0,75.0 V 82.0" id="LeaderD" class="Leader D"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-a801.svg
+++ b/data/layouts/gaomon-a801.svg
@@ -1,64 +1,26 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-a801"
-        width="568"
-        height="500">
-    <title id="title">A801</title>
-    <rect x="60" y="162" width="447" height="279" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="39"
-                      y="21"
-                      width="46"
-                      height="30" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="60"
-                      y="38"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="85"
-                      y="18"
-                      width="65"
-                      height="30" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="115.5"
-                      y="35"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="418"
-                      y="18"
-                      width="65"
-                      height="30" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="448.5"
-                      y="35"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="482"
-                      y="22"
-                      width="46"
-                      height="30" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="503"
-                      y="39"
-                      style="text-anchor:start;">D</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-a801" width="568" height="500">
+  <title id="title">A801</title>
+  <rect x="60" y="162" width="447" height="279"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="39" y="21" width="46" height="30"/>
+    <text id="LabelA" class="A Label" x="60" y="88.0" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 62.0,73.0 V 80.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="85" y="18" width="65" height="30"/>
+    <text id="LabelB" class="B Label" x="115.5" y="85.0" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 117.5,70.0 V 77.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="418" y="18" width="65" height="30"/>
+    <text id="LabelC" class="C Label" x="448.5" y="85.0" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 450.5,70.0 V 77.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="482" y="22" width="46" height="30"/>
+    <text id="LabelD" class="D Label" x="503" y="89.0" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 505.0,74.0 V 81.0" id="LeaderD" class="Leader D"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-d16-pro.svg
+++ b/data/layouts/gaomon-d16-pro.svg
@@ -1,129 +1,51 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-d16-pro"
-        width="750"
-        height="463">
-    <title id="title">D16 PRO</title>
-    <rect x="105" y="66" width="585" height="327" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="29"
-                      y="79"
-                      width="25"
-                      height="30" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="39.5"
-                      y="96"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="29"
-                      y="116"
-                      width="25"
-                      height="24" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="39.5"
-                      y="130"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="29"
-                      y="148"
-                      width="25"
-                      height="25" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="39.5"
-                      y="162.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="29"
-                      y="184"
-                      width="25"
-                      height="24" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="39.5"
-                      y="198"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="29"
-                      y="256"
-                      width="25"
-                      height="24" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="39.5"
-                      y="270"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="29"
-                      y="292"
-                      width="25"
-                      height="24" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="39.5"
-                      y="306"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="29"
-                      y="325"
-                      width="25"
-                      height="24" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="39.5"
-                      y="339"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="29"
-                      y="355"
-                      width="25"
-                      height="30" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="39.5"
-                      y="372"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="31"
-                      y="223"
-                      width="18"
-                      height="18" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="38"
-                      y="234"
-                      style="text-anchor:start;">I</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-d16-pro" width="750" height="463">
+  <title id="title">D16 PRO</title>
+  <rect x="105" y="66" width="585" height="327"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="29" y="79" width="25" height="30"/>
+    <text id="LabelA" class="A Label" x="89.5" y="96" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 74.5,94.0 H 81.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="29" y="116" width="25" height="24"/>
+    <text id="LabelB" class="B Label" x="89.5" y="130" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 74.5,128.0 H 81.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="29" y="148" width="25" height="25"/>
+    <text id="LabelC" class="C Label" x="89.5" y="162.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 74.5,160.5 H 81.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="29" y="184" width="25" height="24"/>
+    <text id="LabelD" class="D Label" x="89.5" y="198" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 74.5,196.0 H 81.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="29" y="256" width="25" height="24"/>
+    <text id="LabelE" class="E Label" x="89.5" y="270" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 74.5,268.0 H 81.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="29" y="292" width="25" height="24"/>
+    <text id="LabelF" class="F Label" x="89.5" y="306" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 74.5,304.0 H 81.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="29" y="325" width="25" height="24"/>
+    <text id="LabelG" class="G Label" x="89.5" y="339" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 74.5,337.0 H 81.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="29" y="355" width="25" height="30"/>
+    <text id="LabelH" class="H Label" x="89.5" y="372" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 74.5,370.0 H 81.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="31" y="223" width="18" height="18"/>
+    <text id="LabelI" class="I Label" x="88.0" y="234" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 73.0,232.0 H 80.0" id="LeaderI" class="Leader I"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-g12.svg
+++ b/data/layouts/gaomon-g12.svg
@@ -1,129 +1,51 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-g12"
-        width="750"
-        height="429">
-    <title id="title">G12</title>
-    <rect x="134" y="56" width="557" height="314" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="36"
-                      y="58"
-                      width="35"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="51.5"
-                      y="70"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="36"
-                      y="90"
-                      width="35"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="51.5"
-                      y="102"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="36"
-                      y="122"
-                      width="35"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="51.5"
-                      y="134"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="36"
-                      y="154"
-                      width="35"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="51.5"
-                      y="166"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="36"
-                      y="253"
-                      width="35"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="51.5"
-                      y="265"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="36"
-                      y="285"
-                      width="35"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="51.5"
-                      y="297"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="36"
-                      y="318"
-                      width="35"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="51.5"
-                      y="330"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="36"
-                      y="350"
-                      width="35"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="51.5"
-                      y="362"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="37"
-                      y="198"
-                      width="30"
-                      height="30" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="50"
-                      y="215"
-                      style="text-anchor:start;">I</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-g12" width="750" height="429">
+  <title id="title">G12</title>
+  <rect x="134" y="56" width="557" height="314"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="36" y="58" width="35" height="20"/>
+    <text id="LabelA" class="A Label" x="101.5" y="70" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 86.5,68.0 H 93.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="36" y="90" width="35" height="20"/>
+    <text id="LabelB" class="B Label" x="101.5" y="102" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 86.5,100.0 H 93.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="36" y="122" width="35" height="20"/>
+    <text id="LabelC" class="C Label" x="101.5" y="134" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 86.5,132.0 H 93.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="36" y="154" width="35" height="20"/>
+    <text id="LabelD" class="D Label" x="101.5" y="166" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 86.5,164.0 H 93.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="36" y="253" width="35" height="20"/>
+    <text id="LabelE" class="E Label" x="101.5" y="265" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 86.5,263.0 H 93.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="36" y="285" width="35" height="20"/>
+    <text id="LabelF" class="F Label" x="101.5" y="297" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 86.5,295.0 H 93.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="36" y="318" width="35" height="20"/>
+    <text id="LabelG" class="G Label" x="101.5" y="330" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 86.5,328.0 H 93.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="36" y="350" width="35" height="20"/>
+    <text id="LabelH" class="H Label" x="101.5" y="362" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 86.5,360.0 H 93.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="37" y="198" width="30" height="30"/>
+    <text id="LabelI" class="I Label" x="100.0" y="215" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 85.0,213.0 H 92.0" id="LeaderI" class="Leader I"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-g12gd.svg
+++ b/data/layouts/gaomon-g12gd.svg
@@ -1,129 +1,51 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-g12gd"
-        width="750"
-        height="429">
-    <title id="title">G12(GD)</title>
-    <rect x="135" y="56" width="554" height="315" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="36"
-                      y="58"
-                      width="35"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="51.5"
-                      y="70"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="36"
-                      y="90"
-                      width="35"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="51.5"
-                      y="102"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="36"
-                      y="123"
-                      width="35"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="51.5"
-                      y="135"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="36"
-                      y="155"
-                      width="35"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="51.5"
-                      y="167"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="36"
-                      y="255"
-                      width="35"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="51.5"
-                      y="267"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="36"
-                      y="286"
-                      width="35"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="51.5"
-                      y="298"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="36"
-                      y="319"
-                      width="35"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="51.5"
-                      y="331"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="36"
-                      y="351"
-                      width="35"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="51.5"
-                      y="363"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="41"
-                      y="201"
-                      width="25"
-                      height="25" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="51.5"
-                      y="215.5"
-                      style="text-anchor:start;">I</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-g12gd" width="750" height="429">
+  <title id="title">G12(GD)</title>
+  <rect x="135" y="56" width="554" height="315"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="36" y="58" width="35" height="20"/>
+    <text id="LabelA" class="A Label" x="101.5" y="70" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 86.5,68.0 H 93.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="36" y="90" width="35" height="20"/>
+    <text id="LabelB" class="B Label" x="101.5" y="102" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 86.5,100.0 H 93.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="36" y="123" width="35" height="20"/>
+    <text id="LabelC" class="C Label" x="101.5" y="135" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 86.5,133.0 H 93.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="36" y="155" width="35" height="20"/>
+    <text id="LabelD" class="D Label" x="101.5" y="167" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 86.5,165.0 H 93.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="36" y="255" width="35" height="20"/>
+    <text id="LabelE" class="E Label" x="101.5" y="267" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 86.5,265.0 H 93.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="36" y="286" width="35" height="20"/>
+    <text id="LabelF" class="F Label" x="101.5" y="298" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 86.5,296.0 H 93.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="36" y="319" width="35" height="20"/>
+    <text id="LabelG" class="G Label" x="101.5" y="331" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 86.5,329.0 H 93.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="36" y="351" width="35" height="20"/>
+    <text id="LabelH" class="H Label" x="101.5" y="363" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 86.5,361.0 H 93.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="41" y="201" width="25" height="25"/>
+    <text id="LabelI" class="I Label" x="101.5" y="215.5" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 86.5,213.5 H 93.5" id="LeaderI" class="Leader I"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-g13.svg
+++ b/data/layouts/gaomon-g13.svg
@@ -1,155 +1,61 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-g13"
-        width="750"
-        height="434">
-    <title id="title">G13</title>
-    <rect x="129" y="58" width="572" height="320" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="37"
-                      y="53"
-                      width="35"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="52.5"
-                      y="65"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="37"
-                      y="81"
-                      width="35"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="52.5"
-                      y="93"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="37"
-                      y="108"
-                      width="35"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="52.5"
-                      y="120"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="37"
-                      y="135"
-                      width="35"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="52.5"
-                      y="147"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="37"
-                      y="162"
-                      width="35"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="52.5"
-                      y="174"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="37"
-                      y="252"
-                      width="35"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="52.5"
-                      y="264"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="37"
-                      y="279"
-                      width="35"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="52.5"
-                      y="291"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="37"
-                      y="307"
-                      width="35"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="52.5"
-                      y="319"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="37"
-                      y="334"
-                      width="35"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="52.5"
-                      y="346"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="37"
-                      y="362"
-                      width="35"
-                      height="20" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="52.5"
-                      y="374"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="40"
-                      y="204"
-                      width="25"
-                      height="25" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="50.5"
-                      y="218.5"
-                      style="text-anchor:start;">K</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-g13" width="750" height="434">
+  <title id="title">G13</title>
+  <rect x="129" y="58" width="572" height="320"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="37" y="53" width="35" height="20"/>
+    <text id="LabelA" class="A Label" x="102.5" y="65" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 87.5,63.0 H 94.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="37" y="81" width="35" height="20"/>
+    <text id="LabelB" class="B Label" x="102.5" y="93" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 87.5,91.0 H 94.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="37" y="108" width="35" height="20"/>
+    <text id="LabelC" class="C Label" x="102.5" y="120" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 87.5,118.0 H 94.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="37" y="135" width="35" height="20"/>
+    <text id="LabelD" class="D Label" x="102.5" y="147" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 87.5,145.0 H 94.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="37" y="162" width="35" height="20"/>
+    <text id="LabelE" class="E Label" x="102.5" y="174" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 87.5,172.0 H 94.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="37" y="252" width="35" height="20"/>
+    <text id="LabelF" class="F Label" x="102.5" y="264" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 87.5,262.0 H 94.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="37" y="279" width="35" height="20"/>
+    <text id="LabelG" class="G Label" x="102.5" y="291" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 87.5,289.0 H 94.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="37" y="307" width="35" height="20"/>
+    <text id="LabelH" class="H Label" x="102.5" y="319" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 87.5,317.0 H 94.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="37" y="334" width="35" height="20"/>
+    <text id="LabelI" class="I Label" x="102.5" y="346" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 87.5,344.0 H 94.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="37" y="362" width="35" height="20"/>
+    <text id="LabelJ" class="J Label" x="102.5" y="374" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 87.5,372.0 H 94.5" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="40" y="204" width="25" height="25"/>
+    <text id="LabelK" class="K Label" x="100.5" y="218.5" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 85.5,216.5 H 92.5" id="LeaderK" class="Leader K"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-g13gd.svg
+++ b/data/layouts/gaomon-g13gd.svg
@@ -1,155 +1,61 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-g13gd"
-        width="750"
-        height="434">
-    <title id="title">G13(GD)</title>
-    <rect x="126" y="54" width="576" height="324" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="37"
-                      y="53"
-                      width="35"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="52.5"
-                      y="65"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="37"
-                      y="81"
-                      width="35"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="52.5"
-                      y="93"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="37"
-                      y="108"
-                      width="35"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="52.5"
-                      y="120"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="37"
-                      y="135"
-                      width="35"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="52.5"
-                      y="147"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="38"
-                      y="164"
-                      width="35"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="53.5"
-                      y="176"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="37"
-                      y="251"
-                      width="35"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="52.5"
-                      y="263"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="37"
-                      y="279"
-                      width="35"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="52.5"
-                      y="291"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="37"
-                      y="307"
-                      width="35"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="52.5"
-                      y="319"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="37"
-                      y="334"
-                      width="35"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="52.5"
-                      y="346"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="37"
-                      y="361"
-                      width="35"
-                      height="20" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="52.5"
-                      y="373"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="41"
-                      y="204"
-                      width="25"
-                      height="25" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="51.5"
-                      y="218.5"
-                      style="text-anchor:start;">K</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-g13gd" width="750" height="434">
+  <title id="title">G13(GD)</title>
+  <rect x="126" y="54" width="576" height="324"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="37" y="53" width="35" height="20"/>
+    <text id="LabelA" class="A Label" x="102.5" y="65" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 87.5,63.0 H 94.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="37" y="81" width="35" height="20"/>
+    <text id="LabelB" class="B Label" x="102.5" y="93" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 87.5,91.0 H 94.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="37" y="108" width="35" height="20"/>
+    <text id="LabelC" class="C Label" x="102.5" y="120" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 87.5,118.0 H 94.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="37" y="135" width="35" height="20"/>
+    <text id="LabelD" class="D Label" x="102.5" y="147" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 87.5,145.0 H 94.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="38" y="164" width="35" height="20"/>
+    <text id="LabelE" class="E Label" x="103.5" y="176" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 88.5,174.0 H 95.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="37" y="251" width="35" height="20"/>
+    <text id="LabelF" class="F Label" x="102.5" y="263" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 87.5,261.0 H 94.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="37" y="279" width="35" height="20"/>
+    <text id="LabelG" class="G Label" x="102.5" y="291" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 87.5,289.0 H 94.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="37" y="307" width="35" height="20"/>
+    <text id="LabelH" class="H Label" x="102.5" y="319" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 87.5,317.0 H 94.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="37" y="334" width="35" height="20"/>
+    <text id="LabelI" class="I Label" x="102.5" y="346" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 87.5,344.0 H 94.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="37" y="361" width="35" height="20"/>
+    <text id="LabelJ" class="J Label" x="102.5" y="373" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 87.5,371.0 H 94.5" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="41" y="204" width="25" height="25"/>
+    <text id="LabelK" class="K Label" x="101.5" y="218.5" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 86.5,216.5 H 93.5" id="LeaderK" class="Leader K"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-g16.svg
+++ b/data/layouts/gaomon-g16.svg
@@ -1,155 +1,61 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-g16"
-        width="750"
-        height="464">
-    <title id="title">G16</title>
-    <rect x="103" y="63" width="587" height="333" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="23"
-                      y="98"
-                      width="30"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="36"
-                      y="110"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="23"
-                      y="120"
-                      width="30"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="36"
-                      y="132"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="23"
-                      y="142"
-                      width="30"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="36"
-                      y="154"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="23"
-                      y="164"
-                      width="30"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="36"
-                      y="176"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="23"
-                      y="186"
-                      width="30"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="36"
-                      y="198"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="23"
-                      y="254"
-                      width="30"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="36"
-                      y="266"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="23"
-                      y="276"
-                      width="30"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="36"
-                      y="288"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="23"
-                      y="298"
-                      width="30"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="36"
-                      y="310"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="23"
-                      y="320"
-                      width="30"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="36"
-                      y="332"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="23"
-                      y="343"
-                      width="30"
-                      height="20" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="36"
-                      y="355"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="28"
-                      y="220"
-                      width="20"
-                      height="20" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="36"
-                      y="232"
-                      style="text-anchor:start;">K</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-g16" width="750" height="464">
+  <title id="title">G16</title>
+  <rect x="103" y="63" width="587" height="333"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="23" y="98" width="30" height="20"/>
+    <text id="LabelA" class="A Label" x="86.0" y="110" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 71.0,108.0 H 78.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="23" y="120" width="30" height="20"/>
+    <text id="LabelB" class="B Label" x="86.0" y="132" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 71.0,130.0 H 78.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="23" y="142" width="30" height="20"/>
+    <text id="LabelC" class="C Label" x="86.0" y="154" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 71.0,152.0 H 78.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="23" y="164" width="30" height="20"/>
+    <text id="LabelD" class="D Label" x="86.0" y="176" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 71.0,174.0 H 78.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="23" y="186" width="30" height="20"/>
+    <text id="LabelE" class="E Label" x="86.0" y="198" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 71.0,196.0 H 78.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="23" y="254" width="30" height="20"/>
+    <text id="LabelF" class="F Label" x="86.0" y="266" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 71.0,264.0 H 78.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="23" y="276" width="30" height="20"/>
+    <text id="LabelG" class="G Label" x="86.0" y="288" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 71.0,286.0 H 78.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="23" y="298" width="30" height="20"/>
+    <text id="LabelH" class="H Label" x="86.0" y="310" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 71.0,308.0 H 78.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="23" y="320" width="30" height="20"/>
+    <text id="LabelI" class="I Label" x="86.0" y="332" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 71.0,330.0 H 78.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="23" y="343" width="30" height="20"/>
+    <text id="LabelJ" class="J Label" x="86.0" y="355" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 71.0,353.0 H 78.0" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="28" y="220" width="20" height="20"/>
+    <text id="LabelK" class="K Label" x="86.0" y="232" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 71.0,230.0 H 78.0" id="LeaderK" class="Leader K"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-g16gd.svg
+++ b/data/layouts/gaomon-g16gd.svg
@@ -1,155 +1,61 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-g16gd"
-        width="750"
-        height="464">
-    <title id="title">G16(GD)</title>
-    <rect x="103" y="66" width="584" height="332" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="23"
-                      y="98"
-                      width="30"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="36"
-                      y="110"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="23"
-                      y="120"
-                      width="30"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="36"
-                      y="132"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="23"
-                      y="142"
-                      width="30"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="36"
-                      y="154"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="23"
-                      y="165"
-                      width="30"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="36"
-                      y="177"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="23"
-                      y="186"
-                      width="30"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="36"
-                      y="198"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="23"
-                      y="254"
-                      width="30"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="36"
-                      y="266"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="23"
-                      y="276"
-                      width="30"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="36"
-                      y="288"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="23"
-                      y="298"
-                      width="30"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="36"
-                      y="310"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="23"
-                      y="321"
-                      width="30"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="36"
-                      y="333"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="23"
-                      y="344"
-                      width="30"
-                      height="20" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="36"
-                      y="356"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="28"
-                      y="220"
-                      width="20"
-                      height="20" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="36"
-                      y="232"
-                      style="text-anchor:start;">K</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-g16gd" width="750" height="464">
+  <title id="title">G16(GD)</title>
+  <rect x="103" y="66" width="584" height="332"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="23" y="98" width="30" height="20"/>
+    <text id="LabelA" class="A Label" x="86.0" y="110" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 71.0,108.0 H 78.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="23" y="120" width="30" height="20"/>
+    <text id="LabelB" class="B Label" x="86.0" y="132" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 71.0,130.0 H 78.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="23" y="142" width="30" height="20"/>
+    <text id="LabelC" class="C Label" x="86.0" y="154" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 71.0,152.0 H 78.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="23" y="165" width="30" height="20"/>
+    <text id="LabelD" class="D Label" x="86.0" y="177" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 71.0,175.0 H 78.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="23" y="186" width="30" height="20"/>
+    <text id="LabelE" class="E Label" x="86.0" y="198" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 71.0,196.0 H 78.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="23" y="254" width="30" height="20"/>
+    <text id="LabelF" class="F Label" x="86.0" y="266" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 71.0,264.0 H 78.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="23" y="276" width="30" height="20"/>
+    <text id="LabelG" class="G Label" x="86.0" y="288" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 71.0,286.0 H 78.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="23" y="298" width="30" height="20"/>
+    <text id="LabelH" class="H Label" x="86.0" y="310" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 71.0,308.0 H 78.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="23" y="321" width="30" height="20"/>
+    <text id="LabelI" class="I Label" x="86.0" y="333" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 71.0,331.0 H 78.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="23" y="344" width="30" height="20"/>
+    <text id="LabelJ" class="J Label" x="86.0" y="356" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 71.0,354.0 H 78.0" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="28" y="220" width="20" height="20"/>
+    <text id="LabelK" class="K Label" x="86.0" y="232" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 71.0,230.0 H 78.0" id="LeaderK" class="Leader K"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-g22.svg
+++ b/data/layouts/gaomon-g22.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-g22"
-        width="750"
-        height="470">
-    <title id="title">G22</title>
-    <rect x="32" y="31" width="684" height="386" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="7"
-                      y="29"
-                      width="15"
-                      height="15" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="12.5"
-                      y="38.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="7"
-                      y="51"
-                      width="15"
-                      height="15" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="12.5"
-                      y="60.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="7"
-                      y="72"
-                      width="15"
-                      height="15" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="12.5"
-                      y="81.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="7"
-                      y="93"
-                      width="15"
-                      height="15" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="12.5"
-                      y="102.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="7"
-                      y="115"
-                      width="15"
-                      height="15" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="12.5"
-                      y="124.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="7"
-                      y="136"
-                      width="15"
-                      height="15" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="12.5"
-                      y="145.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="7"
-                      y="159"
-                      width="15"
-                      height="15" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="12.5"
-                      y="168.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="7"
-                      y="180"
-                      width="15"
-                      height="15" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="12.5"
-                      y="189.5"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-g22" width="750" height="470">
+  <title id="title">G22</title>
+  <rect x="32" y="31" width="684" height="386"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="7" y="29" width="15" height="15"/>
+    <text id="LabelA" class="A Label" x="62.5" y="38.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 47.5,36.5 H 54.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="7" y="51" width="15" height="15"/>
+    <text id="LabelB" class="B Label" x="62.5" y="60.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 47.5,58.5 H 54.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="7" y="72" width="15" height="15"/>
+    <text id="LabelC" class="C Label" x="62.5" y="81.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 47.5,79.5 H 54.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="7" y="93" width="15" height="15"/>
+    <text id="LabelD" class="D Label" x="62.5" y="102.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 47.5,100.5 H 54.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="7" y="115" width="15" height="15"/>
+    <text id="LabelE" class="E Label" x="62.5" y="124.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 47.5,122.5 H 54.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="7" y="136" width="15" height="15"/>
+    <text id="LabelF" class="F Label" x="62.5" y="145.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 47.5,143.5 H 54.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="7" y="159" width="15" height="15"/>
+    <text id="LabelG" class="G Label" x="62.5" y="168.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 47.5,166.5 H 54.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="7" y="180" width="15" height="15"/>
+    <text id="LabelH" class="H Label" x="62.5" y="189.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 47.5,187.5 H 54.5" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-gm116hd.svg
+++ b/data/layouts/gaomon-gm116hd.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-gm116hd"
-        width="750"
-        height="414">
-    <title id="title">GM116HD</title>
-    <rect x="158" y="57" width="533" height="302" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="34"
-                      y="62"
-                      width="55"
-                      height="25" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="59.5"
-                      y="76.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="34"
-                      y="94"
-                      width="55"
-                      height="25" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="59.5"
-                      y="108.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="34"
-                      y="126"
-                      width="55"
-                      height="25" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="59.5"
-                      y="140.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="34"
-                      y="159"
-                      width="55"
-                      height="25" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="59.5"
-                      y="173.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="33"
-                      y="233"
-                      width="55"
-                      height="25" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="58.5"
-                      y="247.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="33"
-                      y="265"
-                      width="55"
-                      height="25" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="58.5"
-                      y="279.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="33"
-                      y="298"
-                      width="55"
-                      height="25" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="58.5"
-                      y="312.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="33"
-                      y="331"
-                      width="55"
-                      height="25" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="58.5"
-                      y="345.5"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-gm116hd" width="750" height="414">
+  <title id="title">GM116HD</title>
+  <rect x="158" y="57" width="533" height="302"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="34" y="62" width="55" height="25"/>
+    <text id="LabelA" class="A Label" x="109.5" y="76.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 94.5,74.5 H 101.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="34" y="94" width="55" height="25"/>
+    <text id="LabelB" class="B Label" x="109.5" y="108.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 94.5,106.5 H 101.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="34" y="126" width="55" height="25"/>
+    <text id="LabelC" class="C Label" x="109.5" y="140.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 94.5,138.5 H 101.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="34" y="159" width="55" height="25"/>
+    <text id="LabelD" class="D Label" x="109.5" y="173.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 94.5,171.5 H 101.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="33" y="233" width="55" height="25"/>
+    <text id="LabelE" class="E Label" x="108.5" y="247.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 93.5,245.5 H 100.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="33" y="265" width="55" height="25"/>
+    <text id="LabelF" class="F Label" x="108.5" y="279.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 93.5,277.5 H 100.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="33" y="298" width="55" height="25"/>
+    <text id="LabelG" class="G Label" x="108.5" y="312.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 93.5,310.5 H 100.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="33" y="331" width="55" height="25"/>
+    <text id="LabelH" class="H Label" x="108.5" y="345.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 93.5,343.5 H 100.5" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-gm116hdtp.svg
+++ b/data/layouts/gaomon-gm116hdtp.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-gm116hdtp"
-        width="750"
-        height="414">
-    <title id="title">GM116HD(TP)</title>
-    <rect x="160" y="56" width="531" height="304" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="36"
-                      y="58"
-                      width="50"
-                      height="25" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="59"
-                      y="72.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="36"
-                      y="92"
-                      width="50"
-                      height="25" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="59"
-                      y="106.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="36"
-                      y="125"
-                      width="50"
-                      height="25" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="59"
-                      y="139.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="36"
-                      y="158"
-                      width="50"
-                      height="25" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="59"
-                      y="172.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="36"
-                      y="230"
-                      width="50"
-                      height="25" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="59"
-                      y="244.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="36"
-                      y="264"
-                      width="50"
-                      height="25" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="59"
-                      y="278.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="36"
-                      y="297"
-                      width="50"
-                      height="25" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="59"
-                      y="311.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="36"
-                      y="330"
-                      width="50"
-                      height="25" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="59"
-                      y="344.5"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-gm116hdtp" width="750" height="414">
+  <title id="title">GM116HD(TP)</title>
+  <rect x="160" y="56" width="531" height="304"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="36" y="58" width="50" height="25"/>
+    <text id="LabelA" class="A Label" x="109.0" y="72.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 94.0,70.5 H 101.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="36" y="92" width="50" height="25"/>
+    <text id="LabelB" class="B Label" x="109.0" y="106.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 94.0,104.5 H 101.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="36" y="125" width="50" height="25"/>
+    <text id="LabelC" class="C Label" x="109.0" y="139.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 94.0,137.5 H 101.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="36" y="158" width="50" height="25"/>
+    <text id="LabelD" class="D Label" x="109.0" y="172.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 94.0,170.5 H 101.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="36" y="230" width="50" height="25"/>
+    <text id="LabelE" class="E Label" x="109.0" y="244.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 94.0,242.5 H 101.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="36" y="264" width="50" height="25"/>
+    <text id="LabelF" class="F Label" x="109.0" y="278.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 94.0,276.5 H 101.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="36" y="297" width="50" height="25"/>
+    <text id="LabelG" class="G Label" x="109.0" y="311.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 94.0,309.5 H 101.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="36" y="330" width="50" height="25"/>
+    <text id="LabelH" class="H Label" x="109.0" y="344.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 94.0,342.5 H 101.0" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-gm156hd.svg
+++ b/data/layouts/gaomon-gm156hd.svg
@@ -1,142 +1,56 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-gm156hd"
-        width="750"
-        height="415">
-    <title id="title">GM156HD</title>
-    <rect x="128" y="45" width="575" height="324" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="29"
-                      y="74"
-                      width="40"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="47"
-                      y="86"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="29"
-                      y="101"
-                      width="40"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="47"
-                      y="113"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="29"
-                      y="127"
-                      width="40"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="47"
-                      y="139"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="29"
-                      y="153"
-                      width="40"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="47"
-                      y="165"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="35"
-                      y="188"
-                      width="30"
-                      height="15" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="48"
-                      y="197.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="35"
-                      y="212"
-                      width="30"
-                      height="15" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="48"
-                      y="221.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="29"
-                      y="241"
-                      width="40"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="47"
-                      y="253"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="29"
-                      y="267"
-                      width="40"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="47"
-                      y="279"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="29"
-                      y="294"
-                      width="40"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="47"
-                      y="306"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="29"
-                      y="320"
-                      width="40"
-                      height="20" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="47"
-                      y="332"
-                      style="text-anchor:start;">J</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-gm156hd" width="750" height="415">
+  <title id="title">GM156HD</title>
+  <rect x="128" y="45" width="575" height="324"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="29" y="74" width="40" height="20"/>
+    <text id="LabelA" class="A Label" x="97.0" y="86" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 82.0,84.0 H 89.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="29" y="101" width="40" height="20"/>
+    <text id="LabelB" class="B Label" x="97.0" y="113" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 82.0,111.0 H 89.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="29" y="127" width="40" height="20"/>
+    <text id="LabelC" class="C Label" x="97.0" y="139" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 82.0,137.0 H 89.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="29" y="153" width="40" height="20"/>
+    <text id="LabelD" class="D Label" x="97.0" y="165" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 82.0,163.0 H 89.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="35" y="188" width="30" height="15"/>
+    <text id="LabelE" class="E Label" x="98.0" y="197.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 83.0,195.5 H 90.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="35" y="212" width="30" height="15"/>
+    <text id="LabelF" class="F Label" x="98.0" y="221.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 83.0,219.5 H 90.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="29" y="241" width="40" height="20"/>
+    <text id="LabelG" class="G Label" x="97.0" y="253" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 82.0,251.0 H 89.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="29" y="267" width="40" height="20"/>
+    <text id="LabelH" class="H Label" x="97.0" y="279" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 82.0,277.0 H 89.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="29" y="294" width="40" height="20"/>
+    <text id="LabelI" class="I Label" x="97.0" y="306" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 82.0,304.0 H 89.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="29" y="320" width="40" height="20"/>
+    <text id="LabelJ" class="J Label" x="97.0" y="332" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 82.0,330.0 H 89.0" id="LeaderJ" class="Leader J"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-gm156hdtp.svg
+++ b/data/layouts/gaomon-gm156hdtp.svg
@@ -1,142 +1,56 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-gm156hdtp"
-        width="750"
-        height="415">
-    <title id="title">GM156HD(TP)</title>
-    <rect x="129" y="44" width="571" height="326" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="30"
-                      y="72"
-                      width="40"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="48"
-                      y="84"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="30"
-                      y="99"
-                      width="40"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="48"
-                      y="111"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="29"
-                      y="126"
-                      width="40"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="47"
-                      y="138"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="29"
-                      y="153"
-                      width="40"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="47"
-                      y="165"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="34"
-                      y="184"
-                      width="30"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="47"
-                      y="196"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="34"
-                      y="209"
-                      width="30"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="47"
-                      y="221"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="29"
-                      y="240"
-                      width="40"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="47"
-                      y="252"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="29"
-                      y="267"
-                      width="40"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="47"
-                      y="279"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="29"
-                      y="293"
-                      width="40"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="47"
-                      y="305"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="29"
-                      y="319"
-                      width="40"
-                      height="20" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="47"
-                      y="331"
-                      style="text-anchor:start;">J</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-gm156hdtp" width="750" height="415">
+  <title id="title">GM156HD(TP)</title>
+  <rect x="129" y="44" width="571" height="326"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="30" y="72" width="40" height="20"/>
+    <text id="LabelA" class="A Label" x="98.0" y="84" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 83.0,82.0 H 90.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="30" y="99" width="40" height="20"/>
+    <text id="LabelB" class="B Label" x="98.0" y="111" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 83.0,109.0 H 90.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="29" y="126" width="40" height="20"/>
+    <text id="LabelC" class="C Label" x="97.0" y="138" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 82.0,136.0 H 89.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="29" y="153" width="40" height="20"/>
+    <text id="LabelD" class="D Label" x="97.0" y="165" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 82.0,163.0 H 89.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="34" y="184" width="30" height="20"/>
+    <text id="LabelE" class="E Label" x="97.0" y="196" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 82.0,194.0 H 89.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="34" y="209" width="30" height="20"/>
+    <text id="LabelF" class="F Label" x="97.0" y="221" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 82.0,219.0 H 89.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="29" y="240" width="40" height="20"/>
+    <text id="LabelG" class="G Label" x="97.0" y="252" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 82.0,250.0 H 89.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="29" y="267" width="40" height="20"/>
+    <text id="LabelH" class="H Label" x="97.0" y="279" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 82.0,277.0 H 89.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="29" y="293" width="40" height="20"/>
+    <text id="LabelI" class="I Label" x="97.0" y="305" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 82.0,303.0 H 89.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="29" y="319" width="40" height="20"/>
+    <text id="LabelJ" class="J Label" x="97.0" y="331" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 82.0,329.0 H 89.0" id="LeaderJ" class="Leader J"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-gt-1106.svg
+++ b/data/layouts/gaomon-gt-1106.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-gt-1106"
-        width="750"
-        height="414">
-    <title id="title">GT-1106</title>
-    <rect x="158" y="58" width="533" height="301" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="34"
-                      y="60"
-                      width="55"
-                      height="25" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="59.5"
-                      y="74.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="34"
-                      y="93"
-                      width="55"
-                      height="25" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="59.5"
-                      y="107.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="34"
-                      y="126"
-                      width="55"
-                      height="25" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="59.5"
-                      y="140.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="34"
-                      y="160"
-                      width="55"
-                      height="25" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="59.5"
-                      y="174.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="34"
-                      y="231"
-                      width="55"
-                      height="25" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="59.5"
-                      y="245.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="34"
-                      y="265"
-                      width="55"
-                      height="25" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="59.5"
-                      y="279.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="34"
-                      y="298"
-                      width="55"
-                      height="25" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="59.5"
-                      y="312.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="34"
-                      y="331"
-                      width="55"
-                      height="25" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="59.5"
-                      y="345.5"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-gt-1106" width="750" height="414">
+  <title id="title">GT-1106</title>
+  <rect x="158" y="58" width="533" height="301"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="34" y="60" width="55" height="25"/>
+    <text id="LabelA" class="A Label" x="109.5" y="74.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 94.5,72.5 H 101.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="34" y="93" width="55" height="25"/>
+    <text id="LabelB" class="B Label" x="109.5" y="107.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 94.5,105.5 H 101.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="34" y="126" width="55" height="25"/>
+    <text id="LabelC" class="C Label" x="109.5" y="140.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 94.5,138.5 H 101.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="34" y="160" width="55" height="25"/>
+    <text id="LabelD" class="D Label" x="109.5" y="174.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 94.5,172.5 H 101.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="34" y="231" width="55" height="25"/>
+    <text id="LabelE" class="E Label" x="109.5" y="245.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 94.5,243.5 H 101.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="34" y="265" width="55" height="25"/>
+    <text id="LabelF" class="F Label" x="109.5" y="279.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 94.5,277.5 H 101.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="34" y="298" width="55" height="25"/>
+    <text id="LabelG" class="G Label" x="109.5" y="312.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 94.5,310.5 H 101.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="34" y="331" width="55" height="25"/>
+    <text id="LabelH" class="H Label" x="109.5" y="345.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 94.5,343.5 H 101.5" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-gt116h.svg
+++ b/data/layouts/gaomon-gt116h.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-gt116h"
-        width="750"
-        height="414">
-    <title id="title">GT116H</title>
-    <rect x="157" y="57" width="536" height="301" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="33"
-                      y="60"
-                      width="55"
-                      height="25" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="58.5"
-                      y="74.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="33"
-                      y="94"
-                      width="55"
-                      height="25" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="58.5"
-                      y="108.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="33"
-                      y="126"
-                      width="55"
-                      height="25" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="58.5"
-                      y="140.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="33"
-                      y="160"
-                      width="55"
-                      height="25" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="58.5"
-                      y="174.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="34"
-                      y="232"
-                      width="55"
-                      height="25" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="59.5"
-                      y="246.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="34"
-                      y="266"
-                      width="55"
-                      height="25" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="59.5"
-                      y="280.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="34"
-                      y="299"
-                      width="55"
-                      height="25" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="59.5"
-                      y="313.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="34"
-                      y="332"
-                      width="55"
-                      height="25" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="59.5"
-                      y="346.5"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-gt116h" width="750" height="414">
+  <title id="title">GT116H</title>
+  <rect x="157" y="57" width="536" height="301"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="33" y="60" width="55" height="25"/>
+    <text id="LabelA" class="A Label" x="108.5" y="74.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 93.5,72.5 H 100.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="33" y="94" width="55" height="25"/>
+    <text id="LabelB" class="B Label" x="108.5" y="108.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 93.5,106.5 H 100.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="33" y="126" width="55" height="25"/>
+    <text id="LabelC" class="C Label" x="108.5" y="140.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 93.5,138.5 H 100.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="33" y="160" width="55" height="25"/>
+    <text id="LabelD" class="D Label" x="108.5" y="174.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 93.5,172.5 H 100.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="34" y="232" width="55" height="25"/>
+    <text id="LabelE" class="E Label" x="109.5" y="246.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 94.5,244.5 H 101.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="34" y="266" width="55" height="25"/>
+    <text id="LabelF" class="F Label" x="109.5" y="280.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 94.5,278.5 H 101.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="34" y="299" width="55" height="25"/>
+    <text id="LabelG" class="G Label" x="109.5" y="313.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 94.5,311.5 H 101.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="34" y="332" width="55" height="25"/>
+    <text id="LabelH" class="H Label" x="109.5" y="346.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 94.5,344.5 H 101.5" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-m0610-pro.svg
+++ b/data/layouts/gaomon-m0610-pro.svg
@@ -1,129 +1,51 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-m0610-pro"
-        width="750"
-        height="442">
-    <title id="title">M0610 PRO</title>
-    <rect x="134" y="49" width="554" height="343" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="42"
-                      y="55"
-                      width="32"
-                      height="32" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="56"
-                      y="73"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="42"
-                      y="94"
-                      width="32"
-                      height="26" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="56"
-                      y="109"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="42"
-                      y="129"
-                      width="32"
-                      height="26" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="56"
-                      y="144"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="42"
-                      y="167"
-                      width="32"
-                      height="26" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="56"
-                      y="182"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="42"
-                      y="250"
-                      width="32"
-                      height="26" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="56"
-                      y="265"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="42"
-                      y="288"
-                      width="32"
-                      height="26" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="56"
-                      y="303"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="42"
-                      y="322"
-                      width="32"
-                      height="26" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="56"
-                      y="337"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="42"
-                      y="355"
-                      width="32"
-                      height="32" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="56"
-                      y="373"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="46"
-                      y="210"
-                      width="22"
-                      height="22" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="55"
-                      y="223"
-                      style="text-anchor:start;">I</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-m0610-pro" width="750" height="442">
+  <title id="title">M0610 PRO</title>
+  <rect x="134" y="49" width="554" height="343"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="42" y="55" width="32" height="32"/>
+    <text id="LabelA" class="A Label" x="106" y="73" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 91,71 H 98" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="42" y="94" width="32" height="26"/>
+    <text id="LabelB" class="B Label" x="106" y="109" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 91,107 H 98" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="42" y="129" width="32" height="26"/>
+    <text id="LabelC" class="C Label" x="106" y="144" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 91,142 H 98" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="42" y="167" width="32" height="26"/>
+    <text id="LabelD" class="D Label" x="106" y="182" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 91,180 H 98" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="42" y="250" width="32" height="26"/>
+    <text id="LabelE" class="E Label" x="106" y="265" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 91,263 H 98" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="42" y="288" width="32" height="26"/>
+    <text id="LabelF" class="F Label" x="106" y="303" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 91,301 H 98" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="42" y="322" width="32" height="26"/>
+    <text id="LabelG" class="G Label" x="106" y="337" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 91,335 H 98" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="42" y="355" width="32" height="32"/>
+    <text id="LabelH" class="H Label" x="106" y="373" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 91,371 H 98" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="46" y="210" width="22" height="22"/>
+    <text id="LabelI" class="I Label" x="105" y="223" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 90,221 H 97" id="LeaderI" class="Leader I"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-m10.svg
+++ b/data/layouts/gaomon-m10.svg
@@ -1,168 +1,66 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-m10"
-        width="750"
-        height="394">
-    <title id="title">M10</title>
-    <rect x="188" y="39" width="522" height="316" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="73"
-                      y="48"
-                      width="28"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="85"
-                      y="60"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="45"
-                      y="63"
-                      width="20"
-                      height="30" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="53"
-                      y="80"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="73"
-                      y="89"
-                      width="28"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="85"
-                      y="101"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="74"
-                      y="166"
-                      width="28"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="86"
-                      y="178"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="43"
-                      y="180"
-                      width="20"
-                      height="30" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="51"
-                      y="197"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="74"
-                      y="207"
-                      width="28"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="86"
-                      y="219"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="73"
-                      y="283"
-                      width="28"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="85"
-                      y="295"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="44"
-                      y="299"
-                      width="20"
-                      height="30" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="52"
-                      y="316"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="73"
-                      y="325"
-                      width="28"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="85"
-                      y="337"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="70"
-                      y="71"
-                      width="15"
-                      height="15" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="75.5"
-                      y="80.5"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="70"
-                      y="190"
-                      width="15"
-                      height="15" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="75.5"
-                      y="199.5"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="69"
-                      y="307"
-                      width="16"
-                      height="15" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="75"
-                      y="316.5"
-                      style="text-anchor:start;">L</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-m10" width="750" height="394">
+  <title id="title">M10</title>
+  <rect x="188" y="39" width="522" height="316"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="73" y="48" width="28" height="20"/>
+    <text id="LabelA" class="A Label" x="125.0" y="60" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 110.0,58.0 H 117.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="45" y="63" width="20" height="30"/>
+    <text id="LabelB" class="B Label" x="23.0" y="80" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 41.0,78.0 H 33.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="73" y="89" width="28" height="20"/>
+    <text id="LabelC" class="C Label" x="125.0" y="101" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 110.0,99.0 H 117.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="74" y="166" width="28" height="20"/>
+    <text id="LabelD" class="D Label" x="126.0" y="178" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 111.0,176.0 H 118.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="43" y="180" width="20" height="30"/>
+    <text id="LabelE" class="E Label" x="21.0" y="197" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 39.0,195.0 H 31.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="74" y="207" width="28" height="20"/>
+    <text id="LabelF" class="F Label" x="126.0" y="219" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 111.0,217.0 H 118.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="73" y="283" width="28" height="20"/>
+    <text id="LabelG" class="G Label" x="125.0" y="295" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 110.0,293.0 H 117.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="44" y="299" width="20" height="30"/>
+    <text id="LabelH" class="H Label" x="22.0" y="316" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 40.0,314.0 H 32.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="73" y="325" width="28" height="20"/>
+    <text id="LabelI" class="I Label" x="125.0" y="337" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 110.0,335.0 H 117.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="70" y="71" width="15" height="15"/>
+    <text id="LabelJ" class="J Label" x="115.5" y="80.5" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 100.5,78.5 H 107.5" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="70" y="190" width="15" height="15"/>
+    <text id="LabelK" class="K Label" x="115.5" y="199.5" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 100.5,197.5 H 107.5" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="69" y="307" width="16" height="15"/>
+    <text id="LabelL" class="L Label" x="115.0" y="316.5" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 100.0,314.5 H 107.0" id="LeaderL" class="Leader L"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-m106k-pro.svg
+++ b/data/layouts/gaomon-m106k-pro.svg
@@ -1,168 +1,66 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-m106k-pro"
-        width="750"
-        height="479">
-    <title id="title">M106K PRO</title>
-    <rect x="146" y="74" width="511" height="326" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="21"
-                      y="78"
-                      width="35"
-                      height="35" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="36.5"
-                      y="97.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="74"
-                      y="78"
-                      width="35"
-                      height="35" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="89.5"
-                      y="97.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="21"
-                      y="126"
-                      width="35"
-                      height="35" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="36.5"
-                      y="145.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="74"
-                      y="126"
-                      width="35"
-                      height="35" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="89.5"
-                      y="145.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="21"
-                      y="175"
-                      width="35"
-                      height="35" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="36.5"
-                      y="194.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="74"
-                      y="175"
-                      width="35"
-                      height="35" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="89.5"
-                      y="194.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="21"
-                      y="269"
-                      width="35"
-                      height="35" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="36.5"
-                      y="288.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="74"
-                      y="269"
-                      width="35"
-                      height="35" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="89.5"
-                      y="288.5"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="21"
-                      y="318"
-                      width="35"
-                      height="35" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="36.5"
-                      y="337.5"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="74"
-                      y="318"
-                      width="35"
-                      height="35" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="89.5"
-                      y="337.5"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="21"
-                      y="366"
-                      width="35"
-                      height="35" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="36.5"
-                      y="385.5"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="74"
-                      y="366"
-                      width="35"
-                      height="35" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="89.5"
-                      y="385.5"
-                      style="text-anchor:start;">L</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-m106k-pro" width="750" height="479">
+  <title id="title">M106K PRO</title>
+  <rect x="146" y="74" width="511" height="326"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="21" y="78" width="35" height="35"/>
+    <text id="LabelA" class="A Label" x="6.5" y="97.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 24.5,95.5 H 16.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="74" y="78" width="35" height="35"/>
+    <text id="LabelB" class="B Label" x="119.5" y="97.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 104.5,95.5 H 111.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="21" y="126" width="35" height="35"/>
+    <text id="LabelC" class="C Label" x="6.5" y="145.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 24.5,143.5 H 16.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="74" y="126" width="35" height="35"/>
+    <text id="LabelD" class="D Label" x="119.5" y="145.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 104.5,143.5 H 111.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="21" y="175" width="35" height="35"/>
+    <text id="LabelE" class="E Label" x="6.5" y="194.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 24.5,192.5 H 16.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="74" y="175" width="35" height="35"/>
+    <text id="LabelF" class="F Label" x="119.5" y="194.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 104.5,192.5 H 111.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="21" y="269" width="35" height="35"/>
+    <text id="LabelG" class="G Label" x="6.5" y="288.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 24.5,286.5 H 16.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="74" y="269" width="35" height="35"/>
+    <text id="LabelH" class="H Label" x="119.5" y="288.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 104.5,286.5 H 111.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="21" y="318" width="35" height="35"/>
+    <text id="LabelI" class="I Label" x="6.5" y="337.5" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 24.5,335.5 H 16.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="74" y="318" width="35" height="35"/>
+    <text id="LabelJ" class="J Label" x="119.5" y="337.5" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 104.5,335.5 H 111.5" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="21" y="366" width="35" height="35"/>
+    <text id="LabelK" class="K Label" x="6.5" y="385.5" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 24.5,383.5 H 16.5" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="74" y="366" width="35" height="35"/>
+    <text id="LabelL" class="L Label" x="119.5" y="385.5" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 104.5,383.5 H 111.5" id="LeaderL" class="Leader L"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-m106k.svg
+++ b/data/layouts/gaomon-m106k.svg
@@ -1,168 +1,66 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-m106k"
-        width="750"
-        height="498">
-    <title id="title">M106K</title>
-    <rect x="145" y="80" width="533" height="334" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="23"
-                      y="86"
-                      width="39"
-                      height="26" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="40.5"
-                      y="101"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="69"
-                      y="86"
-                      width="39"
-                      height="26" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="86.5"
-                      y="101"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="23"
-                      y="136"
-                      width="39"
-                      height="26" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="40.5"
-                      y="151"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="69"
-                      y="136"
-                      width="39"
-                      height="26" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="86.5"
-                      y="151"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="23"
-                      y="189"
-                      width="39"
-                      height="26" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="40.5"
-                      y="204"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="69"
-                      y="189"
-                      width="39"
-                      height="26" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="86.5"
-                      y="204"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="23"
-                      y="286"
-                      width="39"
-                      height="26" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="40.5"
-                      y="301"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="69"
-                      y="286"
-                      width="39"
-                      height="26" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="86.5"
-                      y="301"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="23"
-                      y="337"
-                      width="39"
-                      height="26" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="40.5"
-                      y="352"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="69"
-                      y="337"
-                      width="39"
-                      height="26" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="86.5"
-                      y="352"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="23"
-                      y="386"
-                      width="39"
-                      height="26" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="40.5"
-                      y="401"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="69"
-                      y="386"
-                      width="39"
-                      height="26" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="86.5"
-                      y="401"
-                      style="text-anchor:start;">L</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-m106k" width="750" height="498">
+  <title id="title">M106K</title>
+  <rect x="145" y="80" width="533" height="334"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="23" y="86" width="39" height="26"/>
+    <text id="LabelA" class="A Label" x="10.5" y="101" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 28.5,99.0 H 20.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="69" y="86" width="39" height="26"/>
+    <text id="LabelB" class="B Label" x="116.5" y="101" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 101.5,99.0 H 108.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="23" y="136" width="39" height="26"/>
+    <text id="LabelC" class="C Label" x="10.5" y="151" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 28.5,149.0 H 20.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="69" y="136" width="39" height="26"/>
+    <text id="LabelD" class="D Label" x="116.5" y="151" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 101.5,149.0 H 108.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="23" y="189" width="39" height="26"/>
+    <text id="LabelE" class="E Label" x="10.5" y="204" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 28.5,202.0 H 20.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="69" y="189" width="39" height="26"/>
+    <text id="LabelF" class="F Label" x="116.5" y="204" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 101.5,202.0 H 108.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="23" y="286" width="39" height="26"/>
+    <text id="LabelG" class="G Label" x="10.5" y="301" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 28.5,299.0 H 20.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="69" y="286" width="39" height="26"/>
+    <text id="LabelH" class="H Label" x="116.5" y="301" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 101.5,299.0 H 108.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="23" y="337" width="39" height="26"/>
+    <text id="LabelI" class="I Label" x="10.5" y="352" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 28.5,350.0 H 20.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="69" y="337" width="39" height="26"/>
+    <text id="LabelJ" class="J Label" x="116.5" y="352" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 101.5,350.0 H 108.5" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="23" y="386" width="39" height="26"/>
+    <text id="LabelK" class="K Label" x="10.5" y="401" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 28.5,399.0 H 20.5" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="69" y="386" width="39" height="26"/>
+    <text id="LabelL" class="L Label" x="116.5" y="401" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 101.5,399.0 H 108.5" id="LeaderL" class="Leader L"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-m10k-2018.svg
+++ b/data/layouts/gaomon-m10k-2018.svg
@@ -1,155 +1,61 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-m10k-2018"
-        width="750"
-        height="478">
-    <title id="title">M10K 2018</title>
-    <rect x="142" y="77" width="512" height="322" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="39"
-                      y="59"
-                      width="50"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="62"
-                      y="71"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="39"
-                      y="85"
-                      width="50"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="62"
-                      y="97"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="39"
-                      y="110"
-                      width="50"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="62"
-                      y="122"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="39"
-                      y="135"
-                      width="50"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="62"
-                      y="147"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="39"
-                      y="161"
-                      width="50"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="62"
-                      y="173"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="47"
-                      y="221"
-                      width="35"
-                      height="35" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="62.5"
-                      y="240.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="38"
-                      y="295"
-                      width="50"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="61"
-                      y="307"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="39"
-                      y="322"
-                      width="50"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="62"
-                      y="334"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="39"
-                      y="348"
-                      width="50"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="62"
-                      y="360"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="39"
-                      y="372"
-                      width="50"
-                      height="20" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="62"
-                      y="384"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="39"
-                      y="397"
-                      width="50"
-                      height="20" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="62"
-                      y="409"
-                      style="text-anchor:start;">K</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-m10k-2018" width="750" height="478">
+  <title id="title">M10K 2018</title>
+  <rect x="142" y="77" width="512" height="322"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="39" y="59" width="50" height="20"/>
+    <text id="LabelA" class="A Label" x="112.0" y="71" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 97.0,69.0 H 104.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="39" y="85" width="50" height="20"/>
+    <text id="LabelB" class="B Label" x="112.0" y="97" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 97.0,95.0 H 104.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="39" y="110" width="50" height="20"/>
+    <text id="LabelC" class="C Label" x="112.0" y="122" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 97.0,120.0 H 104.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="39" y="135" width="50" height="20"/>
+    <text id="LabelD" class="D Label" x="112.0" y="147" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 97.0,145.0 H 104.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="39" y="161" width="50" height="20"/>
+    <text id="LabelE" class="E Label" x="112.0" y="173" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 97.0,171.0 H 104.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="47" y="221" width="35" height="35"/>
+    <text id="LabelF" class="F Label" x="112.5" y="240.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 97.5,238.5 H 104.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="38" y="295" width="50" height="20"/>
+    <text id="LabelG" class="G Label" x="111.0" y="307" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 96.0,305.0 H 103.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="39" y="322" width="50" height="20"/>
+    <text id="LabelH" class="H Label" x="112.0" y="334" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 97.0,332.0 H 104.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="39" y="348" width="50" height="20"/>
+    <text id="LabelI" class="I Label" x="112.0" y="360" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 97.0,358.0 H 104.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="39" y="372" width="50" height="20"/>
+    <text id="LabelJ" class="J Label" x="112.0" y="384" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 97.0,382.0 H 104.0" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="39" y="397" width="50" height="20"/>
+    <text id="LabelK" class="K Label" x="112.0" y="409" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 97.0,407.0 H 104.0" id="LeaderK" class="Leader K"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-m10k-pro.svg
+++ b/data/layouts/gaomon-m10k-pro.svg
@@ -1,155 +1,61 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-m10k-pro"
-        width="750"
-        height="478">
-    <title id="title">M10K PRO</title>
-    <rect x="143" y="78" width="512" height="322" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="39"
-                      y="59"
-                      width="50"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="62"
-                      y="71"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="39"
-                      y="87"
-                      width="50"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="62"
-                      y="99"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="39"
-                      y="112"
-                      width="50"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="62"
-                      y="124"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="39"
-                      y="136"
-                      width="50"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="62"
-                      y="148"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="39"
-                      y="161"
-                      width="50"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="62"
-                      y="173"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="39"
-                      y="295"
-                      width="50"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="62"
-                      y="307"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="39"
-                      y="322"
-                      width="50"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="62"
-                      y="334"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="39"
-                      y="347"
-                      width="50"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="62"
-                      y="359"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="39"
-                      y="372"
-                      width="50"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="62"
-                      y="384"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="39"
-                      y="397"
-                      width="50"
-                      height="20" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="62"
-                      y="409"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="47"
-                      y="221"
-                      width="35"
-                      height="35" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="62.5"
-                      y="240.5"
-                      style="text-anchor:start;">K</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-m10k-pro" width="750" height="478">
+  <title id="title">M10K PRO</title>
+  <rect x="143" y="78" width="512" height="322"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="39" y="59" width="50" height="20"/>
+    <text id="LabelA" class="A Label" x="112.0" y="71" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 97.0,69.0 H 104.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="39" y="87" width="50" height="20"/>
+    <text id="LabelB" class="B Label" x="112.0" y="99" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 97.0,97.0 H 104.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="39" y="112" width="50" height="20"/>
+    <text id="LabelC" class="C Label" x="112.0" y="124" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 97.0,122.0 H 104.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="39" y="136" width="50" height="20"/>
+    <text id="LabelD" class="D Label" x="112.0" y="148" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 97.0,146.0 H 104.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="39" y="161" width="50" height="20"/>
+    <text id="LabelE" class="E Label" x="112.0" y="173" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 97.0,171.0 H 104.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="39" y="295" width="50" height="20"/>
+    <text id="LabelF" class="F Label" x="112.0" y="307" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 97.0,305.0 H 104.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="39" y="322" width="50" height="20"/>
+    <text id="LabelG" class="G Label" x="112.0" y="334" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 97.0,332.0 H 104.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="39" y="347" width="50" height="20"/>
+    <text id="LabelH" class="H Label" x="112.0" y="359" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 97.0,357.0 H 104.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="39" y="372" width="50" height="20"/>
+    <text id="LabelI" class="I Label" x="112.0" y="384" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 97.0,382.0 H 104.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="39" y="397" width="50" height="20"/>
+    <text id="LabelJ" class="J Label" x="112.0" y="409" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 97.0,407.0 H 104.0" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="47" y="221" width="35" height="35"/>
+    <text id="LabelK" class="K Label" x="112.5" y="240.5" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 97.5,238.5 H 104.5" id="LeaderK" class="Leader K"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-m1220.svg
+++ b/data/layouts/gaomon-m1220.svg
@@ -1,129 +1,51 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-m1220"
-        width="750"
-        height="469">
-    <title id="title">M1220</title>
-    <rect x="135" y="66" width="569" height="359" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="48"
-                      y="64"
-                      width="48"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="70"
-                      y="76"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="48"
-                      y="98"
-                      width="48"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="70"
-                      y="110"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="48"
-                      y="131"
-                      width="48"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="70"
-                      y="143"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="48"
-                      y="164"
-                      width="48"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="70"
-                      y="176"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="49"
-                      y="310"
-                      width="48"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="71"
-                      y="322"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="49"
-                      y="343"
-                      width="48"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="71"
-                      y="355"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="49"
-                      y="376"
-                      width="48"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="71"
-                      y="388"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="49"
-                      y="409"
-                      width="48"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="71"
-                      y="421"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="56"
-                      y="229"
-                      width="34"
-                      height="34" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="71"
-                      y="248"
-                      style="text-anchor:start;">I</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-m1220" width="750" height="469">
+  <title id="title">M1220</title>
+  <rect x="135" y="66" width="569" height="359"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="48" y="64" width="48" height="20"/>
+    <text id="LabelA" class="A Label" x="120" y="76" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 105,74 H 112" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="48" y="98" width="48" height="20"/>
+    <text id="LabelB" class="B Label" x="120" y="110" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 105,108 H 112" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="48" y="131" width="48" height="20"/>
+    <text id="LabelC" class="C Label" x="120" y="143" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 105,141 H 112" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="48" y="164" width="48" height="20"/>
+    <text id="LabelD" class="D Label" x="120" y="176" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 105,174 H 112" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="49" y="310" width="48" height="20"/>
+    <text id="LabelE" class="E Label" x="121" y="322" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 106,320 H 113" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="49" y="343" width="48" height="20"/>
+    <text id="LabelF" class="F Label" x="121" y="355" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 106,353 H 113" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="49" y="376" width="48" height="20"/>
+    <text id="LabelG" class="G Label" x="121" y="388" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 106,386 H 113" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="49" y="409" width="48" height="20"/>
+    <text id="LabelH" class="H Label" x="121" y="421" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 106,419 H 113" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="56" y="229" width="34" height="34"/>
+    <text id="LabelI" class="I Label" x="121" y="248" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 106,246 H 113" id="LeaderI" class="Leader I"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-m1230.svg
+++ b/data/layouts/gaomon-m1230.svg
@@ -1,181 +1,71 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-m1230"
-        width="750"
-        height="437">
-    <title id="title">M1230</title>
-    <rect x="118" y="30" width="547" height="369" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="45"
-                      y="48"
-                      width="35"
-                      height="27" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="60.5"
-                      y="63.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="45"
-                      y="77"
-                      width="35"
-                      height="27" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="60.5"
-                      y="92.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="45"
-                      y="106"
-                      width="35"
-                      height="27" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="60.5"
-                      y="121.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="45"
-                      y="136"
-                      width="35"
-                      height="27" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="60.5"
-                      y="151.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="45"
-                      y="180"
-                      width="35"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="60.5"
-                      y="192"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="22"
-                      y="203"
-                      width="20"
-                      height="35" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="30"
-                      y="222.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="47"
-                      y="205"
-                      width="30"
-                      height="30" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="60"
-                      y="222"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="83"
-                      y="203"
-                      width="20"
-                      height="35" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="91"
-                      y="222.5"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="45"
-                      y="240"
-                      width="35"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="60.5"
-                      y="252"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="45"
-                      y="280"
-                      width="35"
-                      height="27" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="60.5"
-                      y="295.5"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="45"
-                      y="308"
-                      width="35"
-                      height="27" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="60.5"
-                      y="323.5"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="45"
-                      y="338"
-                      width="35"
-                      height="27" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="60.5"
-                      y="353.5"
-                      style="text-anchor:start;">L</text>
-            </g>
-            <g>
-                <rect id="ButtonM"
-                      class="M Button"
-                      x="45"
-                      y="367"
-                      width="35"
-                      height="27" />
-                <text id="LabelM"
-                      class="M Label"
-                      x="60.5"
-                      y="382.5"
-                      style="text-anchor:start;">M</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-m1230" width="750" height="437">
+  <title id="title">M1230</title>
+  <rect x="118" y="30" width="547" height="369"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="45" y="48" width="35" height="27"/>
+    <text id="LabelA" class="A Label" x="100.5" y="63.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 85.5,61.5 H 92.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="45" y="77" width="35" height="27"/>
+    <text id="LabelB" class="B Label" x="100.5" y="92.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 85.5,90.5 H 92.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="45" y="106" width="35" height="27"/>
+    <text id="LabelC" class="C Label" x="100.5" y="121.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 85.5,119.5 H 92.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="45" y="136" width="35" height="27"/>
+    <text id="LabelD" class="D Label" x="100.5" y="151.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 85.5,149.5 H 92.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="45" y="180" width="35" height="20"/>
+    <text id="LabelE" class="E Label" x="100.5" y="192" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 85.5,190.0 H 92.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="22" y="203" width="20" height="35"/>
+    <text id="LabelF" class="F Label" x="30" y="262.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 32.0,247.5 V 254.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="47" y="205" width="30" height="30"/>
+    <text id="LabelG" class="G Label" x="100.0" y="222" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 85.0,220.0 H 92.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="83" y="203" width="20" height="35"/>
+    <text id="LabelH" class="H Label" x="131.0" y="222.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 116.0,220.5 H 123.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="45" y="240" width="35" height="20"/>
+    <text id="LabelI" class="I Label" x="100.5" y="252" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 85.5,250.0 H 92.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="45" y="280" width="35" height="27"/>
+    <text id="LabelJ" class="J Label" x="100.5" y="295.5" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 85.5,293.5 H 92.5" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="45" y="308" width="35" height="27"/>
+    <text id="LabelK" class="K Label" x="100.5" y="323.5" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 85.5,321.5 H 92.5" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="45" y="338" width="35" height="27"/>
+    <text id="LabelL" class="L Label" x="100.5" y="353.5" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 85.5,351.5 H 92.5" id="LeaderL" class="Leader L"/>
+  </g>
+  <g>
+    <rect id="ButtonM" class="M Button" x="45" y="367" width="35" height="27"/>
+    <text id="LabelM" class="M Label" x="100.5" y="382.5" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 85.5,380.5 H 92.5" id="LeaderM" class="Leader M"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-m6.svg
+++ b/data/layouts/gaomon-m6.svg
@@ -1,181 +1,71 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-m6"
-        width="750"
-        height="440">
-    <title id="title">M6</title>
-    <rect x="156" y="43" width="552" height="349" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="49"
-                      y="77"
-                      width="26"
-                      height="27" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="60"
-                      y="92.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="26"
-                      y="149"
-                      width="35"
-                      height="22" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="41.5"
-                      y="162"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="64"
-                      y="149"
-                      width="35"
-                      height="22" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="79.5"
-                      y="162"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="26"
-                      y="174"
-                      width="35"
-                      height="22" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="41.5"
-                      y="187"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="64"
-                      y="174"
-                      width="35"
-                      height="22" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="79.5"
-                      y="187"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="26"
-                      y="200"
-                      width="35"
-                      height="22" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="41.5"
-                      y="213"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="64"
-                      y="200"
-                      width="35"
-                      height="22" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="79.5"
-                      y="213"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="26"
-                      y="225"
-                      width="35"
-                      height="22" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="41.5"
-                      y="238"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="64"
-                      y="225"
-                      width="35"
-                      height="22" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="79.5"
-                      y="238"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="26"
-                      y="250"
-                      width="35"
-                      height="22" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="41.5"
-                      y="263"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="64"
-                      y="250"
-                      width="35"
-                      height="22" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="79.5"
-                      y="263"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="26"
-                      y="274"
-                      width="35"
-                      height="22" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="41.5"
-                      y="287"
-                      style="text-anchor:start;">L</text>
-            </g>
-            <g>
-                <rect id="ButtonM"
-                      class="M Button"
-                      x="64"
-                      y="274"
-                      width="35"
-                      height="22" />
-                <text id="LabelM"
-                      class="M Label"
-                      x="79.5"
-                      y="287"
-                      style="text-anchor:start;">M</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-m6" width="750" height="440">
+  <title id="title">M6</title>
+  <rect x="156" y="43" width="552" height="349"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="49" y="77" width="26" height="27"/>
+    <text id="LabelA" class="A Label" x="100.0" y="92.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 85.0,90.5 H 92.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="26" y="149" width="35" height="22"/>
+    <text id="LabelB" class="B Label" x="1.5" y="162" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 19.5,160.0 H 11.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="64" y="149" width="35" height="22"/>
+    <text id="LabelC" class="C Label" x="119.5" y="162" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 104.5,160.0 H 111.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="26" y="174" width="35" height="22"/>
+    <text id="LabelD" class="D Label" x="1.5" y="187" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 19.5,185.0 H 11.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="64" y="174" width="35" height="22"/>
+    <text id="LabelE" class="E Label" x="119.5" y="187" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 104.5,185.0 H 111.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="26" y="200" width="35" height="22"/>
+    <text id="LabelF" class="F Label" x="1.5" y="213" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 19.5,211.0 H 11.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="64" y="200" width="35" height="22"/>
+    <text id="LabelG" class="G Label" x="119.5" y="213" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 104.5,211.0 H 111.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="26" y="225" width="35" height="22"/>
+    <text id="LabelH" class="H Label" x="1.5" y="238" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 19.5,236.0 H 11.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="64" y="225" width="35" height="22"/>
+    <text id="LabelI" class="I Label" x="119.5" y="238" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 104.5,236.0 H 111.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="26" y="250" width="35" height="22"/>
+    <text id="LabelJ" class="J Label" x="1.5" y="263" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 19.5,261.0 H 11.5" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="64" y="250" width="35" height="22"/>
+    <text id="LabelK" class="K Label" x="119.5" y="263" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 104.5,261.0 H 111.5" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="26" y="274" width="35" height="22"/>
+    <text id="LabelL" class="L Label" x="1.5" y="287" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 19.5,285.0 H 11.5" id="LeaderL" class="Leader L"/>
+  </g>
+  <g>
+    <rect id="ButtonM" class="M Button" x="64" y="274" width="35" height="22"/>
+    <text id="LabelM" class="M Label" x="119.5" y="287" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 104.5,285.0 H 111.5" id="LeaderM" class="Leader M"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-m62022.svg
+++ b/data/layouts/gaomon-m62022.svg
@@ -1,181 +1,71 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-m62022"
-        width="750"
-        height="440">
-    <title id="title">M6(2022)</title>
-    <rect x="156" y="39" width="552" height="355" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="50"
-                      y="76"
-                      width="27"
-                      height="27" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="61.5"
-                      y="91.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="28"
-                      y="144"
-                      width="35"
-                      height="22" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="43.5"
-                      y="157"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="65"
-                      y="144"
-                      width="35"
-                      height="22" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="80.5"
-                      y="157"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="28"
-                      y="172"
-                      width="35"
-                      height="22" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="43.5"
-                      y="185"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="65"
-                      y="172"
-                      width="35"
-                      height="22" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="80.5"
-                      y="185"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="28"
-                      y="199"
-                      width="35"
-                      height="22" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="43.5"
-                      y="212"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="65"
-                      y="200"
-                      width="35"
-                      height="22" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="80.5"
-                      y="213"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="28"
-                      y="226"
-                      width="35"
-                      height="22" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="43.5"
-                      y="239"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="65"
-                      y="227"
-                      width="35"
-                      height="22" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="80.5"
-                      y="240"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="28"
-                      y="251"
-                      width="35"
-                      height="22" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="43.5"
-                      y="264"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="65"
-                      y="252"
-                      width="35"
-                      height="22" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="80.5"
-                      y="265"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="28"
-                      y="276"
-                      width="35"
-                      height="22" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="43.5"
-                      y="289"
-                      style="text-anchor:start;">L</text>
-            </g>
-            <g>
-                <rect id="ButtonM"
-                      class="M Button"
-                      x="65"
-                      y="276"
-                      width="35"
-                      height="22" />
-                <text id="LabelM"
-                      class="M Label"
-                      x="80.5"
-                      y="289"
-                      style="text-anchor:start;">M</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-m62022" width="750" height="440">
+  <title id="title">M6(2022)</title>
+  <rect x="156" y="39" width="552" height="355"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="50" y="76" width="27" height="27"/>
+    <text id="LabelA" class="A Label" x="101.5" y="91.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 86.5,89.5 H 93.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="28" y="144" width="35" height="22"/>
+    <text id="LabelB" class="B Label" x="3.5" y="157" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 21.5,155.0 H 13.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="65" y="144" width="35" height="22"/>
+    <text id="LabelC" class="C Label" x="120.5" y="157" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 105.5,155.0 H 112.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="28" y="172" width="35" height="22"/>
+    <text id="LabelD" class="D Label" x="3.5" y="185" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 21.5,183.0 H 13.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="65" y="172" width="35" height="22"/>
+    <text id="LabelE" class="E Label" x="120.5" y="185" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 105.5,183.0 H 112.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="28" y="199" width="35" height="22"/>
+    <text id="LabelF" class="F Label" x="3.5" y="212" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 21.5,210.0 H 13.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="65" y="200" width="35" height="22"/>
+    <text id="LabelG" class="G Label" x="120.5" y="213" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 105.5,211.0 H 112.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="28" y="226" width="35" height="22"/>
+    <text id="LabelH" class="H Label" x="3.5" y="239" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 21.5,237.0 H 13.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="65" y="227" width="35" height="22"/>
+    <text id="LabelI" class="I Label" x="120.5" y="240" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 105.5,238.0 H 112.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="28" y="251" width="35" height="22"/>
+    <text id="LabelJ" class="J Label" x="3.5" y="264" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 21.5,262.0 H 13.5" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="65" y="252" width="35" height="22"/>
+    <text id="LabelK" class="K Label" x="120.5" y="265" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 105.5,263.0 H 112.5" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="28" y="276" width="35" height="22"/>
+    <text id="LabelL" class="L Label" x="3.5" y="289" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 21.5,287.0 H 13.5" id="LeaderL" class="Leader L"/>
+  </g>
+  <g>
+    <rect id="ButtonM" class="M Button" x="65" y="276" width="35" height="22"/>
+    <text id="LabelM" class="M Label" x="120.5" y="289" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 105.5,287.0 H 112.5" id="LeaderM" class="Leader M"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-m7.svg
+++ b/data/layouts/gaomon-m7.svg
@@ -1,181 +1,71 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-m7"
-        width="750"
-        height="437">
-    <title id="title">M7</title>
-    <rect x="118" y="29" width="547" height="371" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="45"
-                      y="49"
-                      width="35"
-                      height="25" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="60.5"
-                      y="63.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="45"
-                      y="78"
-                      width="35"
-                      height="25" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="60.5"
-                      y="92.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="45"
-                      y="108"
-                      width="35"
-                      height="25" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="60.5"
-                      y="122.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="45"
-                      y="136"
-                      width="35"
-                      height="25" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="60.5"
-                      y="150.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="44"
-                      y="179"
-                      width="35"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="59.5"
-                      y="191"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="21"
-                      y="204"
-                      width="20"
-                      height="35" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="29"
-                      y="223.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="47"
-                      y="205"
-                      width="30"
-                      height="30" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="60"
-                      y="222"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="84"
-                      y="204"
-                      width="20"
-                      height="35" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="92"
-                      y="223.5"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="45"
-                      y="241"
-                      width="35"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="60.5"
-                      y="253"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="45"
-                      y="281"
-                      width="35"
-                      height="25" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="60.5"
-                      y="295.5"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="45"
-                      y="310"
-                      width="35"
-                      height="25" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="60.5"
-                      y="324.5"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="45"
-                      y="339"
-                      width="35"
-                      height="25" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="60.5"
-                      y="353.5"
-                      style="text-anchor:start;">L</text>
-            </g>
-            <g>
-                <rect id="ButtonM"
-                      class="M Button"
-                      x="45"
-                      y="368"
-                      width="35"
-                      height="25" />
-                <text id="LabelM"
-                      class="M Label"
-                      x="60.5"
-                      y="382.5"
-                      style="text-anchor:start;">M</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-m7" width="750" height="437">
+  <title id="title">M7</title>
+  <rect x="118" y="29" width="547" height="371"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="45" y="49" width="35" height="25"/>
+    <text id="LabelA" class="A Label" x="100.5" y="63.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 85.5,61.5 H 92.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="45" y="78" width="35" height="25"/>
+    <text id="LabelB" class="B Label" x="100.5" y="92.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 85.5,90.5 H 92.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="45" y="108" width="35" height="25"/>
+    <text id="LabelC" class="C Label" x="100.5" y="122.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 85.5,120.5 H 92.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="45" y="136" width="35" height="25"/>
+    <text id="LabelD" class="D Label" x="100.5" y="150.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 85.5,148.5 H 92.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="44" y="179" width="35" height="20"/>
+    <text id="LabelE" class="E Label" x="99.5" y="191" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 84.5,189.0 H 91.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="21" y="204" width="20" height="35"/>
+    <text id="LabelF" class="F Label" x="29" y="263.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 31.0,248.5 V 255.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="47" y="205" width="30" height="30"/>
+    <text id="LabelG" class="G Label" x="80.0" y="222" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 65.0,220.0 H 72.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="84" y="204" width="20" height="35"/>
+    <text id="LabelH" class="H Label" x="132.0" y="223.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 117.0,221.5 H 124.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="45" y="241" width="35" height="20"/>
+    <text id="LabelI" class="I Label" x="100.5" y="253" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 85.5,251.0 H 92.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="45" y="281" width="35" height="25"/>
+    <text id="LabelJ" class="J Label" x="100.5" y="295.5" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 85.5,293.5 H 92.5" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="45" y="310" width="35" height="25"/>
+    <text id="LabelK" class="K Label" x="100.5" y="324.5" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 85.5,322.5 H 92.5" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="45" y="339" width="35" height="25"/>
+    <text id="LabelL" class="L Label" x="100.5" y="353.5" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 85.5,351.5 H 92.5" id="LeaderL" class="Leader L"/>
+  </g>
+  <g>
+    <rect id="ButtonM" class="M Button" x="45" y="368" width="35" height="25"/>
+    <text id="LabelM" class="M Label" x="100.5" y="382.5" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 85.5,380.5 H 92.5" id="LeaderM" class="Leader M"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-m8.svg
+++ b/data/layouts/gaomon-m8.svg
@@ -1,129 +1,51 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-m8"
-        width="750"
-        height="469">
-    <title id="title">M8</title>
-    <rect x="135" y="66" width="569" height="360" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="50"
-                      y="65"
-                      width="45"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="70.5"
-                      y="77"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="50"
-                      y="98"
-                      width="45"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="70.5"
-                      y="110"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="50"
-                      y="131"
-                      width="45"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="70.5"
-                      y="143"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="50"
-                      y="164"
-                      width="45"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="70.5"
-                      y="176"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="51"
-                      y="310"
-                      width="45"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="71.5"
-                      y="322"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="51"
-                      y="343"
-                      width="45"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="71.5"
-                      y="355"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="51"
-                      y="376"
-                      width="45"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="71.5"
-                      y="388"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="51"
-                      y="409"
-                      width="45"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="71.5"
-                      y="421"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="58"
-                      y="232"
-                      width="30"
-                      height="30" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="71"
-                      y="249"
-                      style="text-anchor:start;">I</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-m8" width="750" height="469">
+  <title id="title">M8</title>
+  <rect x="135" y="66" width="569" height="360"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="50" y="65" width="45" height="20"/>
+    <text id="LabelA" class="A Label" x="120.5" y="77" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 105.5,75.0 H 112.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="50" y="98" width="45" height="20"/>
+    <text id="LabelB" class="B Label" x="120.5" y="110" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 105.5,108.0 H 112.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="50" y="131" width="45" height="20"/>
+    <text id="LabelC" class="C Label" x="120.5" y="143" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 105.5,141.0 H 112.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="50" y="164" width="45" height="20"/>
+    <text id="LabelD" class="D Label" x="120.5" y="176" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 105.5,174.0 H 112.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="51" y="310" width="45" height="20"/>
+    <text id="LabelE" class="E Label" x="121.5" y="322" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 106.5,320.0 H 113.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="51" y="343" width="45" height="20"/>
+    <text id="LabelF" class="F Label" x="121.5" y="355" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 106.5,353.0 H 113.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="51" y="376" width="45" height="20"/>
+    <text id="LabelG" class="G Label" x="121.5" y="388" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 106.5,386.0 H 113.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="51" y="409" width="45" height="20"/>
+    <text id="LabelH" class="H Label" x="121.5" y="421" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 106.5,419.0 H 113.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="58" y="232" width="30" height="30"/>
+    <text id="LabelI" class="I Label" x="121.0" y="249" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 106.0,247.0 H 113.0" id="LeaderI" class="Leader I"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-pd1161.svg
+++ b/data/layouts/gaomon-pd1161.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-pd1161"
-        width="750"
-        height="414">
-    <title id="title">PD1161</title>
-    <rect x="157" y="58" width="535" height="303" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="34"
-                      y="61"
-                      width="52"
-                      height="25" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="58"
-                      y="75.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="34"
-                      y="94"
-                      width="52"
-                      height="25" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="58"
-                      y="108.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="34"
-                      y="127"
-                      width="52"
-                      height="25" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="58"
-                      y="141.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="34"
-                      y="160"
-                      width="52"
-                      height="25" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="58"
-                      y="174.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="34"
-                      y="232"
-                      width="52"
-                      height="25" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="58"
-                      y="246.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="34"
-                      y="265"
-                      width="52"
-                      height="25" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="58"
-                      y="279.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="34"
-                      y="298"
-                      width="52"
-                      height="25" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="58"
-                      y="312.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="34"
-                      y="331"
-                      width="52"
-                      height="25" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="58"
-                      y="345.5"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-pd1161" width="750" height="414">
+  <title id="title">PD1161</title>
+  <rect x="157" y="58" width="535" height="303"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="34" y="61" width="52" height="25"/>
+    <text id="LabelA" class="A Label" x="108.0" y="75.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 93.0,73.5 H 100.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="34" y="94" width="52" height="25"/>
+    <text id="LabelB" class="B Label" x="108.0" y="108.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 93.0,106.5 H 100.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="34" y="127" width="52" height="25"/>
+    <text id="LabelC" class="C Label" x="108.0" y="141.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 93.0,139.5 H 100.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="34" y="160" width="52" height="25"/>
+    <text id="LabelD" class="D Label" x="108.0" y="174.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 93.0,172.5 H 100.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="34" y="232" width="52" height="25"/>
+    <text id="LabelE" class="E Label" x="108.0" y="246.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 93.0,244.5 H 100.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="34" y="265" width="52" height="25"/>
+    <text id="LabelF" class="F Label" x="108.0" y="279.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 93.0,277.5 H 100.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="34" y="298" width="52" height="25"/>
+    <text id="LabelG" class="G Label" x="108.0" y="312.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 93.0,310.5 H 100.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="34" y="331" width="52" height="25"/>
+    <text id="LabelH" class="H Label" x="108.0" y="345.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 93.0,343.5 H 100.0" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-pd1161gd.svg
+++ b/data/layouts/gaomon-pd1161gd.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-pd1161gd"
-        width="750"
-        height="414">
-    <title id="title">PD1161(GD)</title>
-    <rect x="159" y="56" width="533" height="303" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="34"
-                      y="60"
-                      width="52"
-                      height="25" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="58"
-                      y="74.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="34"
-                      y="92"
-                      width="52"
-                      height="25" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="58"
-                      y="106.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="34"
-                      y="126"
-                      width="52"
-                      height="25" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="58"
-                      y="140.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="34"
-                      y="159"
-                      width="52"
-                      height="25" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="58"
-                      y="173.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="34"
-                      y="231"
-                      width="52"
-                      height="25" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="58"
-                      y="245.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="34"
-                      y="265"
-                      width="52"
-                      height="25" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="58"
-                      y="279.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="34"
-                      y="298"
-                      width="52"
-                      height="25" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="58"
-                      y="312.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="34"
-                      y="331"
-                      width="52"
-                      height="25" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="58"
-                      y="345.5"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-pd1161gd" width="750" height="414">
+  <title id="title">PD1161(GD)</title>
+  <rect x="159" y="56" width="533" height="303"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="34" y="60" width="52" height="25"/>
+    <text id="LabelA" class="A Label" x="108.0" y="74.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 93.0,72.5 H 100.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="34" y="92" width="52" height="25"/>
+    <text id="LabelB" class="B Label" x="108.0" y="106.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 93.0,104.5 H 100.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="34" y="126" width="52" height="25"/>
+    <text id="LabelC" class="C Label" x="108.0" y="140.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 93.0,138.5 H 100.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="34" y="159" width="52" height="25"/>
+    <text id="LabelD" class="D Label" x="108.0" y="173.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 93.0,171.5 H 100.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="34" y="231" width="52" height="25"/>
+    <text id="LabelE" class="E Label" x="108.0" y="245.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 93.0,243.5 H 100.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="34" y="265" width="52" height="25"/>
+    <text id="LabelF" class="F Label" x="108.0" y="279.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 93.0,277.5 H 100.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="34" y="298" width="52" height="25"/>
+    <text id="LabelG" class="G Label" x="108.0" y="312.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 93.0,310.5 H 100.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="34" y="331" width="52" height="25"/>
+    <text id="LabelH" class="H Label" x="108.0" y="345.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 93.0,343.5 H 100.0" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-pd1560.svg
+++ b/data/layouts/gaomon-pd1560.svg
@@ -1,142 +1,56 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-pd1560"
-        width="750"
-        height="415">
-    <title id="title">PD1560</title>
-    <rect x="128" y="46" width="572" height="321" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="29"
-                      y="75"
-                      width="40"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="47"
-                      y="87"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="29"
-                      y="101"
-                      width="40"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="47"
-                      y="113"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="29"
-                      y="127"
-                      width="40"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="47"
-                      y="139"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="29"
-                      y="154"
-                      width="40"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="47"
-                      y="166"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="32"
-                      y="188"
-                      width="35"
-                      height="15" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="47.5"
-                      y="197.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="32"
-                      y="212"
-                      width="35"
-                      height="15" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="47.5"
-                      y="221.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="29"
-                      y="241"
-                      width="40"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="47"
-                      y="253"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="29"
-                      y="267"
-                      width="40"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="47"
-                      y="279"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="29"
-                      y="294"
-                      width="40"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="47"
-                      y="306"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="29"
-                      y="320"
-                      width="40"
-                      height="20" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="47"
-                      y="332"
-                      style="text-anchor:start;">J</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-pd1560" width="750" height="415">
+  <title id="title">PD1560</title>
+  <rect x="128" y="46" width="572" height="321"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="29" y="75" width="40" height="20"/>
+    <text id="LabelA" class="A Label" x="97.0" y="87" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 82.0,85.0 H 89.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="29" y="101" width="40" height="20"/>
+    <text id="LabelB" class="B Label" x="97.0" y="113" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 82.0,111.0 H 89.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="29" y="127" width="40" height="20"/>
+    <text id="LabelC" class="C Label" x="97.0" y="139" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 82.0,137.0 H 89.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="29" y="154" width="40" height="20"/>
+    <text id="LabelD" class="D Label" x="97.0" y="166" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 82.0,164.0 H 89.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="32" y="188" width="35" height="15"/>
+    <text id="LabelE" class="E Label" x="97.5" y="197.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 82.5,195.5 H 89.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="32" y="212" width="35" height="15"/>
+    <text id="LabelF" class="F Label" x="97.5" y="221.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 82.5,219.5 H 89.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="29" y="241" width="40" height="20"/>
+    <text id="LabelG" class="G Label" x="97.0" y="253" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 82.0,251.0 H 89.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="29" y="267" width="40" height="20"/>
+    <text id="LabelH" class="H Label" x="97.0" y="279" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 82.0,277.0 H 89.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="29" y="294" width="40" height="20"/>
+    <text id="LabelI" class="I Label" x="97.0" y="306" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 82.0,304.0 H 89.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="29" y="320" width="40" height="20"/>
+    <text id="LabelJ" class="J Label" x="97.0" y="332" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 82.0,330.0 H 89.0" id="LeaderJ" class="Leader J"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-pd1561.svg
+++ b/data/layouts/gaomon-pd1561.svg
@@ -1,142 +1,56 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-pd1561"
-        width="750"
-        height="418">
-    <title id="title">PD1561</title>
-    <rect x="130" y="48" width="570" height="321" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="30"
-                      y="77"
-                      width="40"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="48"
-                      y="89"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="30"
-                      y="103"
-                      width="40"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="48"
-                      y="115"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="30"
-                      y="129"
-                      width="40"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="48"
-                      y="141"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="30"
-                      y="156"
-                      width="40"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="48"
-                      y="168"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="33"
-                      y="191"
-                      width="34"
-                      height="14" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="48"
-                      y="200"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="33"
-                      y="215"
-                      width="34"
-                      height="14" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="48"
-                      y="224"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="30"
-                      y="243"
-                      width="40"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="48"
-                      y="255"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="30"
-                      y="270"
-                      width="40"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="48"
-                      y="282"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="30"
-                      y="296"
-                      width="40"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="48"
-                      y="308"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="30"
-                      y="322"
-                      width="40"
-                      height="20" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="48"
-                      y="334"
-                      style="text-anchor:start;">J</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-pd1561" width="750" height="418">
+  <title id="title">PD1561</title>
+  <rect x="130" y="48" width="570" height="321"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="30" y="77" width="40" height="20"/>
+    <text id="LabelA" class="A Label" x="98.0" y="89" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 83.0,87.0 H 90.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="30" y="103" width="40" height="20"/>
+    <text id="LabelB" class="B Label" x="98.0" y="115" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 83.0,113.0 H 90.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="30" y="129" width="40" height="20"/>
+    <text id="LabelC" class="C Label" x="98.0" y="141" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 83.0,139.0 H 90.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="30" y="156" width="40" height="20"/>
+    <text id="LabelD" class="D Label" x="98.0" y="168" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 83.0,166.0 H 90.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="33" y="191" width="34" height="14"/>
+    <text id="LabelE" class="E Label" x="98.0" y="200" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 83.0,198.0 H 90.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="33" y="215" width="34" height="14"/>
+    <text id="LabelF" class="F Label" x="98.0" y="224" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 83.0,222.0 H 90.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="30" y="243" width="40" height="20"/>
+    <text id="LabelG" class="G Label" x="98.0" y="255" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 83.0,253.0 H 90.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="30" y="270" width="40" height="20"/>
+    <text id="LabelH" class="H Label" x="98.0" y="282" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 83.0,280.0 H 90.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="30" y="296" width="40" height="20"/>
+    <text id="LabelI" class="I Label" x="98.0" y="308" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 83.0,306.0 H 90.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="30" y="322" width="40" height="20"/>
+    <text id="LabelJ" class="J Label" x="98.0" y="334" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 83.0,332.0 H 90.0" id="LeaderJ" class="Leader J"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-pd1561gd.svg
+++ b/data/layouts/gaomon-pd1561gd.svg
@@ -1,142 +1,56 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-pd1561gd"
-        width="750"
-        height="418">
-    <title id="title">PD1561(GD)</title>
-    <rect x="129" y="47" width="572" height="324" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="30"
-                      y="77"
-                      width="40"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="48"
-                      y="89"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="30"
-                      y="102"
-                      width="40"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="48"
-                      y="114"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="30"
-                      y="128"
-                      width="40"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="48"
-                      y="140"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="30"
-                      y="155"
-                      width="40"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="48"
-                      y="167"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="33"
-                      y="190"
-                      width="34"
-                      height="14" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="48"
-                      y="199"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="33"
-                      y="213"
-                      width="34"
-                      height="14" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="48"
-                      y="222"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="30"
-                      y="243"
-                      width="40"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="48"
-                      y="255"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="30"
-                      y="270"
-                      width="40"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="48"
-                      y="282"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="30"
-                      y="297"
-                      width="40"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="48"
-                      y="309"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="30"
-                      y="323"
-                      width="40"
-                      height="20" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="48"
-                      y="335"
-                      style="text-anchor:start;">J</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-pd1561gd" width="750" height="418">
+  <title id="title">PD1561(GD)</title>
+  <rect x="129" y="47" width="572" height="324"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="30" y="77" width="40" height="20"/>
+    <text id="LabelA" class="A Label" x="98.0" y="89" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 83.0,87.0 H 90.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="30" y="102" width="40" height="20"/>
+    <text id="LabelB" class="B Label" x="98.0" y="114" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 83.0,112.0 H 90.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="30" y="128" width="40" height="20"/>
+    <text id="LabelC" class="C Label" x="98.0" y="140" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 83.0,138.0 H 90.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="30" y="155" width="40" height="20"/>
+    <text id="LabelD" class="D Label" x="98.0" y="167" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 83.0,165.0 H 90.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="33" y="190" width="34" height="14"/>
+    <text id="LabelE" class="E Label" x="98.0" y="199" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 83.0,197.0 H 90.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="33" y="213" width="34" height="14"/>
+    <text id="LabelF" class="F Label" x="98.0" y="222" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 83.0,220.0 H 90.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="30" y="243" width="40" height="20"/>
+    <text id="LabelG" class="G Label" x="98.0" y="255" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 83.0,253.0 H 90.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="30" y="270" width="40" height="20"/>
+    <text id="LabelH" class="H Label" x="98.0" y="282" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 83.0,280.0 H 90.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="30" y="297" width="40" height="20"/>
+    <text id="LabelI" class="I Label" x="98.0" y="309" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 83.0,307.0 H 90.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="30" y="323" width="40" height="20"/>
+    <text id="LabelJ" class="J Label" x="98.0" y="335" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 83.0,333.0 H 90.0" id="LeaderJ" class="Leader J"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-pd156pro.svg
+++ b/data/layouts/gaomon-pd156pro.svg
@@ -1,155 +1,61 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-pd156pro"
-        width="750"
-        height="464">
-    <title id="title">PD156Pro</title>
-    <rect x="103" y="65" width="588" height="328" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="23"
-                      y="98"
-                      width="30"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="36"
-                      y="110"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="23"
-                      y="120"
-                      width="30"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="36"
-                      y="132"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="23"
-                      y="142"
-                      width="30"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="36"
-                      y="154"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="23"
-                      y="164"
-                      width="30"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="36"
-                      y="176"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="23"
-                      y="187"
-                      width="30"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="36"
-                      y="199"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="23"
-                      y="255"
-                      width="30"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="36"
-                      y="267"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="23"
-                      y="277"
-                      width="30"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="36"
-                      y="289"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="23"
-                      y="299"
-                      width="30"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="36"
-                      y="311"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="23"
-                      y="321"
-                      width="30"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="36"
-                      y="333"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="23"
-                      y="344"
-                      width="30"
-                      height="20" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="36"
-                      y="356"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="28"
-                      y="220"
-                      width="20"
-                      height="20" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="36"
-                      y="232"
-                      style="text-anchor:start;">K</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-pd156pro" width="750" height="464">
+  <title id="title">PD156Pro</title>
+  <rect x="103" y="65" width="588" height="328"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="23" y="98" width="30" height="20"/>
+    <text id="LabelA" class="A Label" x="86" y="110" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 71,108 H 78" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="23" y="120" width="30" height="20"/>
+    <text id="LabelB" class="B Label" x="86" y="132" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 71,130 H 78" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="23" y="142" width="30" height="20"/>
+    <text id="LabelC" class="C Label" x="86" y="154" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 71,152 H 78" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="23" y="164" width="30" height="20"/>
+    <text id="LabelD" class="D Label" x="86" y="176" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 71,174 H 78" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="23" y="187" width="30" height="20"/>
+    <text id="LabelE" class="E Label" x="86" y="199" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 71,197 H 78" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="23" y="255" width="30" height="20"/>
+    <text id="LabelF" class="F Label" x="86" y="267" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 71,265 H 78" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="23" y="277" width="30" height="20"/>
+    <text id="LabelG" class="G Label" x="86" y="289" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 71,287 H 78" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="23" y="299" width="30" height="20"/>
+    <text id="LabelH" class="H Label" x="86" y="311" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 71,309 H 78" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="23" y="321" width="30" height="20"/>
+    <text id="LabelI" class="I Label" x="86" y="333" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 71,331 H 78" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="23" y="344" width="30" height="20"/>
+    <text id="LabelJ" class="J Label" x="86" y="356" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 71,354 H 78" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="28" y="220" width="20" height="20"/>
+    <text id="LabelK" class="K Label" x="86" y="232" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 71,230 H 78" id="LeaderK" class="Leader K"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-pd156progd.svg
+++ b/data/layouts/gaomon-pd156progd.svg
@@ -1,155 +1,61 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-pd156progd"
-        width="750"
-        height="464">
-    <title id="title">PD156Pro(GD)</title>
-    <rect x="103" y="63" width="585" height="332" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="23"
-                      y="98"
-                      width="30"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="36"
-                      y="110"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="23"
-                      y="121"
-                      width="30"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="36"
-                      y="133"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="23"
-                      y="143"
-                      width="30"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="36"
-                      y="155"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="23"
-                      y="165"
-                      width="30"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="36"
-                      y="177"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="23"
-                      y="188"
-                      width="30"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="36"
-                      y="200"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="23"
-                      y="255"
-                      width="30"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="36"
-                      y="267"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="23"
-                      y="277"
-                      width="30"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="36"
-                      y="289"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="23"
-                      y="299"
-                      width="30"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="36"
-                      y="311"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="23"
-                      y="321"
-                      width="30"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="36"
-                      y="333"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="23"
-                      y="343"
-                      width="30"
-                      height="20" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="36"
-                      y="355"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="28"
-                      y="221"
-                      width="20"
-                      height="20" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="36"
-                      y="233"
-                      style="text-anchor:start;">K</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-pd156progd" width="750" height="464">
+  <title id="title">PD156Pro(GD)</title>
+  <rect x="103" y="63" width="585" height="332"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="23" y="98" width="30" height="20"/>
+    <text id="LabelA" class="A Label" x="86" y="110" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 71,108 H 78" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="23" y="121" width="30" height="20"/>
+    <text id="LabelB" class="B Label" x="86" y="133" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 71,131 H 78" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="23" y="143" width="30" height="20"/>
+    <text id="LabelC" class="C Label" x="86" y="155" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 71,153 H 78" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="23" y="165" width="30" height="20"/>
+    <text id="LabelD" class="D Label" x="86" y="177" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 71,175 H 78" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="23" y="188" width="30" height="20"/>
+    <text id="LabelE" class="E Label" x="86" y="200" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 71,198 H 78" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="23" y="255" width="30" height="20"/>
+    <text id="LabelF" class="F Label" x="86" y="267" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 71,265 H 78" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="23" y="277" width="30" height="20"/>
+    <text id="LabelG" class="G Label" x="86" y="289" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 71,287 H 78" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="23" y="299" width="30" height="20"/>
+    <text id="LabelH" class="H Label" x="86" y="311" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 71,309 H 78" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="23" y="321" width="30" height="20"/>
+    <text id="LabelI" class="I Label" x="86" y="333" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 71,331 H 78" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="23" y="343" width="30" height="20"/>
+    <text id="LabelJ" class="J Label" x="86" y="355" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 71,353 H 78" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="28" y="221" width="20" height="20"/>
+    <text id="LabelK" class="K Label" x="86" y="233" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 71,231 H 78" id="LeaderK" class="Leader K"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-pd1610.svg
+++ b/data/layouts/gaomon-pd1610.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-pd1610"
-        width="750"
-        height="471">
-    <title id="title">PD1610</title>
-    <rect x="74" y="46" width="602" height="377" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="21"
-                      y="52"
-                      width="30"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="34"
-                      y="64"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="21"
-                      y="100"
-                      width="30"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="34"
-                      y="112"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="21"
-                      y="149"
-                      width="30"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="34"
-                      y="161"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="21"
-                      y="197"
-                      width="30"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="34"
-                      y="209"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="21"
-                      y="250"
-                      width="30"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="34"
-                      y="262"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="21"
-                      y="299"
-                      width="30"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="34"
-                      y="311"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="21"
-                      y="348"
-                      width="30"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="34"
-                      y="360"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="21"
-                      y="397"
-                      width="30"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="34"
-                      y="409"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-pd1610" width="750" height="471">
+  <title id="title">PD1610</title>
+  <rect x="74" y="46" width="602" height="377"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="21" y="52" width="30" height="20"/>
+    <text id="LabelA" class="A Label" x="84.0" y="64" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 69.0,62.0 H 76.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="21" y="100" width="30" height="20"/>
+    <text id="LabelB" class="B Label" x="84.0" y="112" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 69.0,110.0 H 76.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="21" y="149" width="30" height="20"/>
+    <text id="LabelC" class="C Label" x="84.0" y="161" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 69.0,159.0 H 76.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="21" y="197" width="30" height="20"/>
+    <text id="LabelD" class="D Label" x="84.0" y="209" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 69.0,207.0 H 76.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="21" y="250" width="30" height="20"/>
+    <text id="LabelE" class="E Label" x="84.0" y="262" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 69.0,260.0 H 76.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="21" y="299" width="30" height="20"/>
+    <text id="LabelF" class="F Label" x="84.0" y="311" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 69.0,309.0 H 76.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="21" y="348" width="30" height="20"/>
+    <text id="LabelG" class="G Label" x="84.0" y="360" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 69.0,358.0 H 76.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="21" y="397" width="30" height="20"/>
+    <text id="LabelH" class="H Label" x="84.0" y="409" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 69.0,407.0 H 76.0" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-pd1611.svg
+++ b/data/layouts/gaomon-pd1611.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-pd1611"
-        width="750"
-        height="471">
-    <title id="title">PD1611</title>
-    <rect x="74" y="46" width="601" height="377" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="21"
-                      y="51"
-                      width="30"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="34"
-                      y="63"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="21"
-                      y="99"
-                      width="30"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="34"
-                      y="111"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="21"
-                      y="149"
-                      width="30"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="34"
-                      y="161"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="21"
-                      y="197"
-                      width="30"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="34"
-                      y="209"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="21"
-                      y="250"
-                      width="30"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="34"
-                      y="262"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="21"
-                      y="299"
-                      width="30"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="34"
-                      y="311"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="21"
-                      y="347"
-                      width="30"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="34"
-                      y="359"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="21"
-                      y="396"
-                      width="30"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="34"
-                      y="408"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-pd1611" width="750" height="471">
+  <title id="title">PD1611</title>
+  <rect x="74" y="46" width="601" height="377"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="21" y="51" width="30" height="20"/>
+    <text id="LabelA" class="A Label" x="84.0" y="63" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 69.0,61.0 H 76.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="21" y="99" width="30" height="20"/>
+    <text id="LabelB" class="B Label" x="84.0" y="111" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 69.0,109.0 H 76.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="21" y="149" width="30" height="20"/>
+    <text id="LabelC" class="C Label" x="84.0" y="161" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 69.0,159.0 H 76.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="21" y="197" width="30" height="20"/>
+    <text id="LabelD" class="D Label" x="84.0" y="209" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 69.0,207.0 H 76.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="21" y="250" width="30" height="20"/>
+    <text id="LabelE" class="E Label" x="84.0" y="262" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 69.0,260.0 H 76.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="21" y="299" width="30" height="20"/>
+    <text id="LabelF" class="F Label" x="84.0" y="311" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 69.0,309.0 H 76.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="21" y="347" width="30" height="20"/>
+    <text id="LabelG" class="G Label" x="84.0" y="359" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 69.0,357.0 H 76.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="21" y="396" width="30" height="20"/>
+    <text id="LabelH" class="H Label" x="84.0" y="408" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 69.0,406.0 H 76.0" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-pd2200.svg
+++ b/data/layouts/gaomon-pd2200.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-pd2200"
-        width="750"
-        height="470">
-    <title id="title">PD2200</title>
-    <rect x="32" y="31" width="684" height="385" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="7"
-                      y="29"
-                      width="15"
-                      height="15" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="12.5"
-                      y="38.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="7"
-                      y="51"
-                      width="15"
-                      height="15" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="12.5"
-                      y="60.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="7"
-                      y="72"
-                      width="15"
-                      height="15" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="12.5"
-                      y="81.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="7"
-                      y="94"
-                      width="15"
-                      height="15" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="12.5"
-                      y="103.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="7"
-                      y="115"
-                      width="15"
-                      height="15" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="12.5"
-                      y="124.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="7"
-                      y="137"
-                      width="15"
-                      height="15" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="12.5"
-                      y="146.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="7"
-                      y="158"
-                      width="15"
-                      height="15" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="12.5"
-                      y="167.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="7"
-                      y="180"
-                      width="15"
-                      height="15" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="12.5"
-                      y="189.5"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-pd2200" width="750" height="470">
+  <title id="title">PD2200</title>
+  <rect x="32" y="31" width="684" height="385"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="7" y="29" width="15" height="15"/>
+    <text id="LabelA" class="A Label" x="62.5" y="38.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 47.5,36.5 H 54.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="7" y="51" width="15" height="15"/>
+    <text id="LabelB" class="B Label" x="62.5" y="60.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 47.5,58.5 H 54.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="7" y="72" width="15" height="15"/>
+    <text id="LabelC" class="C Label" x="62.5" y="81.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 47.5,79.5 H 54.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="7" y="94" width="15" height="15"/>
+    <text id="LabelD" class="D Label" x="62.5" y="103.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 47.5,101.5 H 54.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="7" y="115" width="15" height="15"/>
+    <text id="LabelE" class="E Label" x="62.5" y="124.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 47.5,122.5 H 54.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="7" y="137" width="15" height="15"/>
+    <text id="LabelF" class="F Label" x="62.5" y="146.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 47.5,144.5 H 54.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="7" y="158" width="15" height="15"/>
+    <text id="LabelG" class="G Label" x="62.5" y="167.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 47.5,165.5 H 54.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="7" y="180" width="15" height="15"/>
+    <text id="LabelH" class="H Label" x="62.5" y="189.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 47.5,187.5 H 54.5" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-s630.svg
+++ b/data/layouts/gaomon-s630.svg
@@ -1,64 +1,26 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-s630"
-        width="537"
-        height="500">
-    <title id="title">S630</title>
-    <rect x="82" y="140" width="373" height="234" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="37"
-                      y="41"
-                      width="40"
-                      height="40" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="55"
-                      y="63"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="98"
-                      y="39"
-                      width="45"
-                      height="45" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="118.5"
-                      y="63.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="394"
-                      y="39"
-                      width="45"
-                      height="45" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="414.5"
-                      y="63.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="459"
-                      y="40"
-                      width="40"
-                      height="40" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="477"
-                      y="62"
-                      style="text-anchor:start;">D</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-s630" width="537" height="500">
+  <title id="title">S630</title>
+  <rect x="82" y="140" width="373" height="234"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="37" y="41" width="40" height="40"/>
+    <text id="LabelA" class="A Label" x="55" y="113.0" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 57.0,98.0 V 105.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="98" y="39" width="45" height="45"/>
+    <text id="LabelB" class="B Label" x="118.5" y="113.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 120.5,98.5 V 105.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="394" y="39" width="45" height="45"/>
+    <text id="LabelC" class="C Label" x="414.5" y="113.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 416.5,98.5 V 105.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="459" y="40" width="40" height="40"/>
+    <text id="LabelD" class="D Label" x="477" y="112.0" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 479.0,97.0 V 104.0" id="LeaderD" class="Leader D"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-s830.svg
+++ b/data/layouts/gaomon-s830.svg
@@ -1,64 +1,26 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-s830"
-        width="552"
-        height="500">
-    <title id="title">S830</title>
-    <rect x="71" y="128" width="406" height="254" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="42"
-                      y="34"
-                      width="40"
-                      height="40" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="60"
-                      y="56"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="110"
-                      y="32"
-                      width="45"
-                      height="45" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="130.5"
-                      y="56.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="398"
-                      y="32"
-                      width="45"
-                      height="45" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="418.5"
-                      y="56.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="469"
-                      y="34"
-                      width="40"
-                      height="40" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="487"
-                      y="56"
-                      style="text-anchor:start;">D</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-s830" width="552" height="500">
+  <title id="title">S830</title>
+  <rect x="71" y="128" width="406" height="254"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="42" y="34" width="40" height="40"/>
+    <text id="LabelA" class="A Label" x="60" y="106.0" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 62.0,91.0 V 98.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="110" y="32" width="45" height="45"/>
+    <text id="LabelB" class="B Label" x="130.5" y="106.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 132.5,91.5 V 98.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="398" y="32" width="45" height="45"/>
+    <text id="LabelC" class="C Label" x="418.5" y="106.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 420.5,91.5 V 98.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="469" y="34" width="40" height="40"/>
+    <text id="LabelD" class="D Label" x="487" y="106.0" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 489.0,91.0 V 98.0" id="LeaderD" class="Leader D"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-sn540-m5.svg
+++ b/data/layouts/gaomon-sn540-m5.svg
@@ -1,25 +1,11 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-sn540-m5"
-        width="715"
-        height="500">
-    <title id="title">SN540/M5</title>
-    <rect x="73" y="38" width="572" height="380" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="664"
-                      y="50"
-                      width="35"
-                      height="35" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="679.5"
-                      y="69.5"
-                      style="text-anchor:start;">A</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-sn540-m5" width="715" height="500">
+  <title id="title">SN540/M5</title>
+  <rect x="73" y="38" width="572" height="380"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="664" y="50" width="35" height="35"/>
+    <text id="LabelA" class="A Label" x="679.5" y="119.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 681.5,104.5 V 111.5" id="LeaderA" class="Leader A"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-sp1603.svg
+++ b/data/layouts/gaomon-sp1603.svg
@@ -1,207 +1,81 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-sp1603"
-        width="750"
-        height="423">
-    <title id="title">SP1603</title>
-    <rect x="136" y="47" width="573" height="327" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="13"
-                      y="140"
-                      width="17"
-                      height="39" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="19.5"
-                      y="161.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="13"
-                      y="246"
-                      width="17"
-                      height="39" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="19.5"
-                      y="267.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="40"
-                      y="52"
-                      width="16"
-                      height="38" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="46"
-                      y="73"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="60"
-                      y="46"
-                      width="17"
-                      height="41" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="66.5"
-                      y="68.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="37"
-                      y="98"
-                      width="18"
-                      height="52" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="44"
-                      y="126"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="60"
-                      y="94"
-                      width="17"
-                      height="51" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="66.5"
-                      y="121.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="32"
-                      y="160"
-                      width="19"
-                      height="37" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="39.5"
-                      y="180.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="60"
-                      y="147"
-                      width="17"
-                      height="35" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="66.5"
-                      y="166.5"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="31"
-                      y="228"
-                      width="19"
-                      height="36" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="38.5"
-                      y="248"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="60"
-                      y="241"
-                      width="18"
-                      height="41" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="67"
-                      y="263.5"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="37"
-                      y="276"
-                      width="19"
-                      height="48" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="44.5"
-                      y="302"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="61"
-                      y="283"
-                      width="14"
-                      height="47" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="66"
-                      y="308.5"
-                      style="text-anchor:start;">L</text>
-            </g>
-            <g>
-                <rect id="ButtonM"
-                      class="M Button"
-                      x="40"
-                      y="335"
-                      width="17"
-                      height="41" />
-                <text id="LabelM"
-                      class="M Label"
-                      x="46.5"
-                      y="357.5"
-                      style="text-anchor:start;">M</text>
-            </g>
-            <g>
-                <rect id="ButtonN"
-                      class="N Button"
-                      x="60"
-                      y="337"
-                      width="14"
-                      height="44" />
-                <text id="LabelN"
-                      class="N Label"
-                      x="65"
-                      y="361"
-                      style="text-anchor:start;">N</text>
-            </g>
-            <g>
-                <rect id="ButtonO"
-                      class="O Button"
-                      x="53"
-                      y="201"
-                      width="21"
-                      height="21" />
-                <text id="LabelO"
-                      class="O Label"
-                      x="61.5"
-                      y="213.5"
-                      style="text-anchor:start;">O</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-sp1603" width="750" height="423">
+  <title id="title">SP1603</title>
+  <rect x="136" y="47" width="573" height="327"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="13" y="140" width="17" height="39"/>
+    <text id="LabelA" class="A Label" x="19.5" y="201.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 21.5,186.5 V 193.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="13" y="246" width="17" height="39"/>
+    <text id="LabelB" class="B Label" x="19.5" y="227.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 21.5,242.5 V 235.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="40" y="52" width="16" height="38"/>
+    <text id="LabelC" class="C Label" x="16.0" y="73" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 34.0,71.0 H 26.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="60" y="46" width="17" height="41"/>
+    <text id="LabelD" class="D Label" x="96.5" y="68.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 81.5,66.5 H 88.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="37" y="98" width="18" height="52"/>
+    <text id="LabelE" class="E Label" x="14.0" y="126" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 32.0,124.0 H 24.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="60" y="94" width="17" height="51"/>
+    <text id="LabelF" class="F Label" x="96.5" y="121.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 81.5,119.5 H 88.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="32" y="160" width="19" height="37"/>
+    <text id="LabelG" class="G Label" x="39.5" y="180.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 54.5,178.5 H 61.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="60" y="147" width="17" height="35"/>
+    <text id="LabelH" class="H Label" x="96.5" y="166.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 81.5,164.5 H 88.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="31" y="228" width="19" height="36"/>
+    <text id="LabelI" class="I Label" x="8.5" y="248" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 26.5,246.0 H 18.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="60" y="241" width="18" height="41"/>
+    <text id="LabelJ" class="J Label" x="67.0" y="263.5" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 85.0,261.5 H 77.0" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="37" y="276" width="19" height="48"/>
+    <text id="LabelK" class="K Label" x="14.5" y="302" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 32.5,300.0 H 24.5" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="61" y="283" width="14" height="47"/>
+    <text id="LabelL" class="L Label" x="96.0" y="308.5" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 81.0,306.5 H 88.0" id="LeaderL" class="Leader L"/>
+  </g>
+  <g>
+    <rect id="ButtonM" class="M Button" x="40" y="335" width="17" height="41"/>
+    <text id="LabelM" class="M Label" x="16.5" y="357.5" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 34.5,355.5 H 26.5" id="LeaderM" class="Leader M"/>
+  </g>
+  <g>
+    <rect id="ButtonN" class="N Button" x="60" y="337" width="14" height="44"/>
+    <text id="LabelN" class="N Label" x="95.0" y="361" style="text-anchor:start;">N</text>
+    <path style="fill:none" d="M 80.0,359.0 H 87.0" id="LeaderN" class="Leader N"/>
+  </g>
+  <g>
+    <rect id="ButtonO" class="O Button" x="53" y="201" width="21" height="21"/>
+    <text id="LabelO" class="O Label" x="91.5" y="213.5" style="text-anchor:start;">O</text>
+    <path style="fill:none" d="M 76.5,211.5 H 83.5" id="LeaderO" class="Leader O"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-t01.svg
+++ b/data/layouts/gaomon-t01.svg
@@ -1,129 +1,51 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-t01"
-        width="750"
-        height="440">
-    <title id="title">T01</title>
-    <rect x="163" y="53" width="535" height="335" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="22"
-                      y="93"
-                      width="42"
-                      height="33" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="41"
-                      y="111.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="22"
-                      y="134"
-                      width="42"
-                      height="33" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="41"
-                      y="152.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="22"
-                      y="175"
-                      width="42"
-                      height="33" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="41"
-                      y="193.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="22"
-                      y="216"
-                      width="42"
-                      height="33" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="41"
-                      y="234.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="22"
-                      y="257"
-                      width="42"
-                      height="33" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="41"
-                      y="275.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="22"
-                      y="299"
-                      width="42"
-                      height="33" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="41"
-                      y="317.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="22"
-                      y="340"
-                      width="42"
-                      height="33" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="41"
-                      y="358.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="22"
-                      y="382"
-                      width="42"
-                      height="33" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="41"
-                      y="400.5"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="29"
-                      y="29"
-                      width="28"
-                      height="28" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="41"
-                      y="45"
-                      style="text-anchor:start;">I</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-t01" width="750" height="440">
+  <title id="title">T01</title>
+  <rect x="163" y="53" width="535" height="335"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="22" y="93" width="42" height="33"/>
+    <text id="LabelA" class="A Label" x="91.0" y="111.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 76.0,109.5 H 83.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="22" y="134" width="42" height="33"/>
+    <text id="LabelB" class="B Label" x="91.0" y="152.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 76.0,150.5 H 83.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="22" y="175" width="42" height="33"/>
+    <text id="LabelC" class="C Label" x="91.0" y="193.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 76.0,191.5 H 83.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="22" y="216" width="42" height="33"/>
+    <text id="LabelD" class="D Label" x="91.0" y="234.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 76.0,232.5 H 83.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="22" y="257" width="42" height="33"/>
+    <text id="LabelE" class="E Label" x="91.0" y="275.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 76.0,273.5 H 83.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="22" y="299" width="42" height="33"/>
+    <text id="LabelF" class="F Label" x="91.0" y="317.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 76.0,315.5 H 83.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="22" y="340" width="42" height="33"/>
+    <text id="LabelG" class="G Label" x="91.0" y="358.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 76.0,356.5 H 83.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="22" y="382" width="42" height="33"/>
+    <text id="LabelH" class="H Label" x="91.0" y="400.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 76.0,398.5 H 83.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="29" y="29" width="28" height="28"/>
+    <text id="LabelI" class="I Label" x="91.0" y="45" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 76.0,43.0 H 83.0" id="LeaderI" class="Leader I"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-t02.svg
+++ b/data/layouts/gaomon-t02.svg
@@ -1,51 +1,21 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-t02"
-        width="750"
-        height="462">
-    <title id="title">T02</title>
-    <rect x="143" y="58" width="548" height="344" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="20"
-                      y="167"
-                      width="40"
-                      height="40" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="38"
-                      y="189"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="20"
-                      y="210"
-                      width="40"
-                      height="40" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="38"
-                      y="232"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="20"
-                      y="253"
-                      width="40"
-                      height="40" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="38"
-                      y="275"
-                      style="text-anchor:start;">C</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-t02" width="750" height="462">
+  <title id="title">T02</title>
+  <rect x="143" y="58" width="548" height="344"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="20" y="167" width="40" height="40"/>
+    <text id="LabelA" class="A Label" x="88.0" y="189" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 73.0,187.0 H 80.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="20" y="210" width="40" height="40"/>
+    <text id="LabelB" class="B Label" x="88.0" y="232" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 73.0,230.0 H 80.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="20" y="253" width="40" height="40"/>
+    <text id="LabelC" class="C Label" x="88.0" y="275" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 73.0,273.0 H 80.0" id="LeaderC" class="Leader C"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-wh850.svg
+++ b/data/layouts/gaomon-wh850.svg
@@ -1,90 +1,36 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-wh850"
-        width="750"
-        height="496">
-    <title id="title">WH850</title>
-    <rect x="144" y="94" width="485" height="303" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="40"
-                      y="107"
-                      width="50"
-                      height="25" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="63"
-                      y="121.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="40"
-                      y="145"
-                      width="50"
-                      height="25" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="63"
-                      y="159.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="40"
-                      y="182"
-                      width="50"
-                      height="25" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="63"
-                      y="196.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="40"
-                      y="288"
-                      width="50"
-                      height="25" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="63"
-                      y="302.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="40"
-                      y="326"
-                      width="50"
-                      height="25" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="63"
-                      y="340.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="40"
-                      y="364"
-                      width="50"
-                      height="25" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="63"
-                      y="378.5"
-                      style="text-anchor:start;">F</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-wh850" width="750" height="496">
+  <title id="title">WH850</title>
+  <rect x="144" y="94" width="485" height="303"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="40" y="107" width="50" height="25"/>
+    <text id="LabelA" class="A Label" x="113.0" y="121.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 98.0,119.5 H 105.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="40" y="145" width="50" height="25"/>
+    <text id="LabelB" class="B Label" x="113.0" y="159.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 98.0,157.5 H 105.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="40" y="182" width="50" height="25"/>
+    <text id="LabelC" class="C Label" x="113.0" y="196.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 98.0,194.5 H 105.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="40" y="288" width="50" height="25"/>
+    <text id="LabelD" class="D Label" x="113.0" y="302.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 98.0,300.5 H 105.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="40" y="326" width="50" height="25"/>
+    <text id="LabelE" class="E Label" x="113.0" y="340.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 98.0,338.5 H 105.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="40" y="364" width="50" height="25"/>
+    <text id="LabelF" class="F Label" x="113.0" y="378.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 98.0,376.5 H 105.0" id="LeaderF" class="Leader F"/>
+  </g>
 </svg>

--- a/data/layouts/gaomon-wh851.svg
+++ b/data/layouts/gaomon-wh851.svg
@@ -1,129 +1,51 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="gaomon-wh851"
-        width="727"
-        height="430">
-    <title id="title">WH851</title>
-    <rect x="160" y="56" width="511" height="318" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="36"
-                      y="41"
-                      width="43"
-                      height="29" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="55.5"
-                      y="57.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="36"
-                      y="75"
-                      width="43"
-                      height="29" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="55.5"
-                      y="91.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="36"
-                      y="109"
-                      width="43"
-                      height="29" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="55.5"
-                      y="125.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="36"
-                      y="143"
-                      width="43"
-                      height="29" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="55.5"
-                      y="159.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="36"
-                      y="258"
-                      width="43"
-                      height="29" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="55.5"
-                      y="274.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="36"
-                      y="292"
-                      width="43"
-                      height="29" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="55.5"
-                      y="308.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="36"
-                      y="326"
-                      width="43"
-                      height="29" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="55.5"
-                      y="342.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="36"
-                      y="360"
-                      width="43"
-                      height="29" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="55.5"
-                      y="376.5"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="20"
-                      y="178"
-                      width="74"
-                      height="74" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="55"
-                      y="217"
-                      style="text-anchor:start;">I</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="gaomon-wh851" width="727" height="430">
+  <title id="title">WH851</title>
+  <rect x="160" y="56" width="511" height="318"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="36" y="41" width="43" height="29"/>
+    <text id="LabelA" class="A Label" x="105.5" y="57.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 90.5,55.5 H 97.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="36" y="75" width="43" height="29"/>
+    <text id="LabelB" class="B Label" x="105.5" y="91.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 90.5,89.5 H 97.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="36" y="109" width="43" height="29"/>
+    <text id="LabelC" class="C Label" x="105.5" y="125.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 90.5,123.5 H 97.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="36" y="143" width="43" height="29"/>
+    <text id="LabelD" class="D Label" x="105.5" y="159.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 90.5,157.5 H 97.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="36" y="258" width="43" height="29"/>
+    <text id="LabelE" class="E Label" x="105.5" y="274.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 90.5,272.5 H 97.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="36" y="292" width="43" height="29"/>
+    <text id="LabelF" class="F Label" x="105.5" y="308.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 90.5,306.5 H 97.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="36" y="326" width="43" height="29"/>
+    <text id="LabelG" class="G Label" x="105.5" y="342.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 90.5,340.5 H 97.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="36" y="360" width="43" height="29"/>
+    <text id="LabelH" class="H Label" x="105.5" y="376.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 90.5,374.5 H 97.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="20" y="178" width="74" height="74"/>
+    <text id="LabelI" class="I Label" x="105.0" y="217" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 90.0,215.0 H 97.0" id="LeaderI" class="Leader I"/>
+  </g>
 </svg>

--- a/data/layouts/huion-gc610-710.svg
+++ b/data/layouts/huion-gc610-710.svg
@@ -1,90 +1,36 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-gc610-710"
-        width="750"
-        height="355">
-    <title id="title">Huion GC610/710</title>
-    <rect x="217" y="13" width="509" height="322" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="29"
-                      y="96"
-                      width="46"
-                      height="17" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="50"
-                      y="106.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="93"
-                      y="96"
-                      width="30"
-                      height="16" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="106"
-                      y="106"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="141"
-                      y="96"
-                      width="46"
-                      height="17" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="162"
-                      y="106.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="29"
-                      y="242"
-                      width="46"
-                      height="17" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="50"
-                      y="252.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="93"
-                      y="242"
-                      width="30"
-                      height="16" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="106"
-                      y="252"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="141"
-                      y="242"
-                      width="46"
-                      height="17" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="162"
-                      y="252.5"
-                      style="text-anchor:start;">F</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-gc610-710" width="750" height="355">
+  <title id="title">Huion GC610/710</title>
+  <rect x="217" y="13" width="509" height="322"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="29" y="96" width="46" height="17"/>
+    <text id="LabelA" class="A Label" x="50" y="136.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 52.0,121.5 V 128.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="93" y="96" width="30" height="16"/>
+    <text id="LabelB" class="B Label" x="106" y="136.0" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 108.0,121.0 V 128.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="141" y="96" width="46" height="17"/>
+    <text id="LabelC" class="C Label" x="162" y="136.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 164.0,121.5 V 128.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="29" y="242" width="46" height="17"/>
+    <text id="LabelD" class="D Label" x="50" y="282.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 52.0,267.5 V 274.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="93" y="242" width="30" height="16"/>
+    <text id="LabelE" class="E Label" x="106" y="282.0" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 108.0,267.0 V 274.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="141" y="242" width="46" height="17"/>
+    <text id="LabelF" class="F Label" x="162" y="282.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 164.0,267.5 V 274.5" id="LeaderF" class="Leader F"/>
+  </g>
 </svg>

--- a/data/layouts/huion-h950p-igg.svg
+++ b/data/layouts/huion-h950p-igg.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-h950p-igg"
-        width="721"
-        height="427">
-    <title id="title">H950P-IGG</title>
-    <rect x="161" y="59" width="491" height="311" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="45"
-                      y="65"
-                      width="44"
-                      height="26" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="65"
-                      y="80"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="45"
-                      y="102"
-                      width="44"
-                      height="23" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="65"
-                      y="115.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="45"
-                      y="137"
-                      width="45"
-                      height="25" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="65.5"
-                      y="151.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="45"
-                      y="172"
-                      width="44"
-                      height="25" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="65"
-                      y="186.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="45"
-                      y="229"
-                      width="44"
-                      height="26" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="65"
-                      y="244"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="45"
-                      y="265"
-                      width="44"
-                      height="25" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="65"
-                      y="279.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="45"
-                      y="301"
-                      width="44"
-                      height="24" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="65"
-                      y="315"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="45"
-                      y="337"
-                      width="44"
-                      height="24" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="65"
-                      y="351"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-h950p-igg" width="721" height="427">
+  <title id="title">H950P-IGG</title>
+  <rect x="161" y="59" width="491" height="311"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="45" y="65" width="44" height="26"/>
+    <text id="LabelA" class="A Label" x="115.0" y="80" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 100.0,78.0 H 107.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="45" y="102" width="44" height="23"/>
+    <text id="LabelB" class="B Label" x="115.0" y="115.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 100.0,113.5 H 107.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="45" y="137" width="45" height="25"/>
+    <text id="LabelC" class="C Label" x="115.5" y="151.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 100.5,149.5 H 107.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="45" y="172" width="44" height="25"/>
+    <text id="LabelD" class="D Label" x="115.0" y="186.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 100.0,184.5 H 107.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="45" y="229" width="44" height="26"/>
+    <text id="LabelE" class="E Label" x="115.0" y="244" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 100.0,242.0 H 107.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="45" y="265" width="44" height="25"/>
+    <text id="LabelF" class="F Label" x="115.0" y="279.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 100.0,277.5 H 107.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="45" y="301" width="44" height="24"/>
+    <text id="LabelG" class="G Label" x="115.0" y="315" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 100.0,313.0 H 107.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="45" y="337" width="44" height="24"/>
+    <text id="LabelH" class="H Label" x="115.0" y="351" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 100.0,349.0 H 107.0" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/huion-hc16.svg
+++ b/data/layouts/huion-hc16.svg
@@ -1,181 +1,71 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-hc16"
-        width="716"
-        height="430">
-    <title id="title">Huion HC16</title>
-    <rect x="141" y="52" width="517" height="324" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="33"
-                      y="62"
-                      width="29"
-                      height="22" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="45.5"
-                      y="75"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="66"
-                      y="62"
-                      width="29"
-                      height="22" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="78.5"
-                      y="75"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="33"
-                      y="95"
-                      width="29"
-                      height="22" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="45.5"
-                      y="108"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="66"
-                      y="95"
-                      width="29"
-                      height="22" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="78.5"
-                      y="108"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="33"
-                      y="126"
-                      width="29"
-                      height="22" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="45.5"
-                      y="139"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="66"
-                      y="126"
-                      width="29"
-                      height="22" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="78.5"
-                      y="139"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="34"
-                      y="283"
-                      width="29"
-                      height="22" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="46.5"
-                      y="296"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="67"
-                      y="283"
-                      width="29"
-                      height="22" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="79.5"
-                      y="296"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="34"
-                      y="315"
-                      width="29"
-                      height="22" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="46.5"
-                      y="328"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="67"
-                      y="315"
-                      width="29"
-                      height="22" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="79.5"
-                      y="328"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="34"
-                      y="347"
-                      width="29"
-                      height="22" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="46.5"
-                      y="360"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="67"
-                      y="347"
-                      width="29"
-                      height="22" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="79.5"
-                      y="360"
-                      style="text-anchor:start;">L</text>
-            </g>
-            <g>
-                <rect id="ButtonM"
-                      class="M Button"
-                      x="49"
-                      y="200"
-                      width="30"
-                      height="30" />
-                <text id="LabelM"
-                      class="M Label"
-                      x="62"
-                      y="217"
-                      style="text-anchor:start;">M</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-hc16" width="716" height="430">
+  <title id="title">Huion HC16</title>
+  <rect x="141" y="52" width="517" height="324"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="33" y="62" width="29" height="22"/>
+    <text id="LabelA" class="A Label" x="5.5" y="75" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 23.5,73.0 H 15.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="66" y="62" width="29" height="22"/>
+    <text id="LabelB" class="B Label" x="118.5" y="75" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 103.5,73.0 H 110.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="33" y="95" width="29" height="22"/>
+    <text id="LabelC" class="C Label" x="5.5" y="108" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 23.5,106.0 H 15.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="66" y="95" width="29" height="22"/>
+    <text id="LabelD" class="D Label" x="118.5" y="108" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 103.5,106.0 H 110.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="33" y="126" width="29" height="22"/>
+    <text id="LabelE" class="E Label" x="5.5" y="139" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 23.5,137.0 H 15.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="66" y="126" width="29" height="22"/>
+    <text id="LabelF" class="F Label" x="118.5" y="139" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 103.5,137.0 H 110.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="34" y="283" width="29" height="22"/>
+    <text id="LabelG" class="G Label" x="6.5" y="296" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 24.5,294.0 H 16.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="67" y="283" width="29" height="22"/>
+    <text id="LabelH" class="H Label" x="119.5" y="296" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 104.5,294.0 H 111.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="34" y="315" width="29" height="22"/>
+    <text id="LabelI" class="I Label" x="6.5" y="328" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 24.5,326.0 H 16.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="67" y="315" width="29" height="22"/>
+    <text id="LabelJ" class="J Label" x="119.5" y="328" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 104.5,326.0 H 111.5" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="34" y="347" width="29" height="22"/>
+    <text id="LabelK" class="K Label" x="6.5" y="360" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 24.5,358.0 H 16.5" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="67" y="347" width="29" height="22"/>
+    <text id="LabelL" class="L Label" x="119.5" y="360" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 104.5,358.0 H 111.5" id="LeaderL" class="Leader L"/>
+  </g>
+  <g>
+    <rect id="ButtonM" class="M Button" x="49" y="200" width="30" height="30"/>
+    <text id="LabelM" class="M Label" x="102.0" y="217" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 87.0,215.0 H 94.0" id="LeaderM" class="Leader M"/>
+  </g>
 </svg>

--- a/data/layouts/huion-hs610.svg
+++ b/data/layouts/huion-hs610.svg
@@ -1,181 +1,71 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-hs610"
-        width="716"
-        height="430">
-    <title id="title">Huion HS610</title>
-    <rect x="141" y="52" width="517" height="324" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="33"
-                      y="62"
-                      width="29"
-                      height="22" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="45.5"
-                      y="75"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="66"
-                      y="62"
-                      width="29"
-                      height="22" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="78.5"
-                      y="75"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="33"
-                      y="95"
-                      width="29"
-                      height="22" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="45.5"
-                      y="108"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="66"
-                      y="95"
-                      width="29"
-                      height="22" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="78.5"
-                      y="108"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="33"
-                      y="126"
-                      width="29"
-                      height="22" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="45.5"
-                      y="139"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="66"
-                      y="126"
-                      width="29"
-                      height="22" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="78.5"
-                      y="139"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="34"
-                      y="283"
-                      width="29"
-                      height="22" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="46.5"
-                      y="296"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="67"
-                      y="283"
-                      width="29"
-                      height="22" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="79.5"
-                      y="296"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="34"
-                      y="315"
-                      width="29"
-                      height="22" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="46.5"
-                      y="328"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="67"
-                      y="315"
-                      width="29"
-                      height="22" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="79.5"
-                      y="328"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="34"
-                      y="347"
-                      width="29"
-                      height="22" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="46.5"
-                      y="360"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="67"
-                      y="347"
-                      width="29"
-                      height="22" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="79.5"
-                      y="360"
-                      style="text-anchor:start;">L</text>
-            </g>
-            <g>
-                <rect id="ButtonM"
-                      class="M Button"
-                      x="49"
-                      y="200"
-                      width="30"
-                      height="30" />
-                <text id="LabelM"
-                      class="M Label"
-                      x="62"
-                      y="217"
-                      style="text-anchor:start;">M</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-hs610" width="716" height="430">
+  <title id="title">Huion HS610</title>
+  <rect x="141" y="52" width="517" height="324"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="33" y="62" width="29" height="22"/>
+    <text id="LabelA" class="A Label" x="5.5" y="75" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 23.5,73.0 H 15.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="66" y="62" width="29" height="22"/>
+    <text id="LabelB" class="B Label" x="118.5" y="75" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 103.5,73.0 H 110.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="33" y="95" width="29" height="22"/>
+    <text id="LabelC" class="C Label" x="5.5" y="108" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 23.5,106.0 H 15.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="66" y="95" width="29" height="22"/>
+    <text id="LabelD" class="D Label" x="118.5" y="108" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 103.5,106.0 H 110.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="33" y="126" width="29" height="22"/>
+    <text id="LabelE" class="E Label" x="5.5" y="139" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 23.5,137.0 H 15.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="66" y="126" width="29" height="22"/>
+    <text id="LabelF" class="F Label" x="118.5" y="139" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 103.5,137.0 H 110.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="34" y="283" width="29" height="22"/>
+    <text id="LabelG" class="G Label" x="6.5" y="296" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 24.5,294.0 H 16.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="67" y="283" width="29" height="22"/>
+    <text id="LabelH" class="H Label" x="119.5" y="296" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 104.5,294.0 H 111.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="34" y="315" width="29" height="22"/>
+    <text id="LabelI" class="I Label" x="6.5" y="328" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 24.5,326.0 H 16.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="67" y="315" width="29" height="22"/>
+    <text id="LabelJ" class="J Label" x="119.5" y="328" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 104.5,326.0 H 111.5" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="34" y="347" width="29" height="22"/>
+    <text id="LabelK" class="K Label" x="6.5" y="360" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 24.5,358.0 H 16.5" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="67" y="347" width="29" height="22"/>
+    <text id="LabelL" class="L Label" x="119.5" y="360" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 104.5,358.0 H 111.5" id="LeaderL" class="Leader L"/>
+  </g>
+  <g>
+    <rect id="ButtonM" class="M Button" x="49" y="200" width="30" height="30"/>
+    <text id="LabelM" class="M Label" x="102.0" y="217" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 87.0,215.0 H 94.0" id="LeaderM" class="Leader M"/>
+  </g>
 </svg>

--- a/data/layouts/huion-hs64.svg
+++ b/data/layouts/huion-hs64.svg
@@ -1,64 +1,26 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-hs64"
-        width="515"
-        height="430">
-    <title id="title">Huion HS64</title>
-    <rect x="48" y="116" width="415" height="266" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="37"
-                      y="31"
-                      width="36"
-                      height="29" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="53"
-                      y="47.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="38"
-                      y="72"
-                      width="34"
-                      height="29" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="53"
-                      y="88.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="439"
-                      y="31"
-                      width="38"
-                      height="27" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="456"
-                      y="46.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="440"
-                      y="72"
-                      width="39"
-                      height="28" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="457.5"
-                      y="88"
-                      style="text-anchor:start;">D</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-hs64" width="515" height="430">
+  <title id="title">Huion HS64</title>
+  <rect x="48" y="116" width="415" height="266"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="37" y="31" width="36" height="29"/>
+    <text id="LabelA" class="A Label" x="93.0" y="47.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 78.0,45.5 H 85.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="38" y="72" width="34" height="29"/>
+    <text id="LabelB" class="B Label" x="93.0" y="88.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 78.0,86.5 H 85.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="439" y="31" width="38" height="27"/>
+    <text id="LabelC" class="C Label" x="496.0" y="46.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 481.0,44.5 H 488.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="440" y="72" width="39" height="28"/>
+    <text id="LabelD" class="D Label" x="497.5" y="88" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 482.5,86.0 H 489.5" id="LeaderD" class="Leader D"/>
+  </g>
 </svg>

--- a/data/layouts/huion-hs95.svg
+++ b/data/layouts/huion-hs95.svg
@@ -1,90 +1,36 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-hs95"
-        width="682"
-        height="430">
-    <title id="title">Huion HS95</title>
-    <rect x="133" y="67" width="472" height="295" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="38"
-                      y="92"
-                      width="48"
-                      height="24" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="60"
-                      y="106"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="38"
-                      y="127"
-                      width="48"
-                      height="24" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="60"
-                      y="141"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="38"
-                      y="162"
-                      width="48"
-                      height="24" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="60"
-                      y="176"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="38"
-                      y="242"
-                      width="48"
-                      height="24" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="60"
-                      y="256"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="38"
-                      y="278"
-                      width="48"
-                      height="24" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="60"
-                      y="292"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="38"
-                      y="313"
-                      width="48"
-                      height="24" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="60"
-                      y="327"
-                      style="text-anchor:start;">F</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-hs95" width="682" height="430">
+  <title id="title">Huion HS95</title>
+  <rect x="133" y="67" width="472" height="295"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="38" y="92" width="48" height="24"/>
+    <text id="LabelA" class="A Label" x="110.0" y="106" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 95.0,104.0 H 102.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="38" y="127" width="48" height="24"/>
+    <text id="LabelB" class="B Label" x="110.0" y="141" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 95.0,139.0 H 102.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="38" y="162" width="48" height="24"/>
+    <text id="LabelC" class="C Label" x="110.0" y="176" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 95.0,174.0 H 102.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="38" y="242" width="48" height="24"/>
+    <text id="LabelD" class="D Label" x="110.0" y="256" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 95.0,254.0 H 102.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="38" y="278" width="48" height="24"/>
+    <text id="LabelE" class="E Label" x="110.0" y="292" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 95.0,290.0 H 102.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="38" y="313" width="48" height="24"/>
+    <text id="LabelF" class="F Label" x="110.0" y="327" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 95.0,325.0 H 102.0" id="LeaderF" class="Leader F"/>
+  </g>
 </svg>

--- a/data/layouts/huion-hst640.svg
+++ b/data/layouts/huion-hst640.svg
@@ -1,64 +1,26 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-hst640"
-        width="515"
-        height="430">
-    <title id="title">Huion HST640</title>
-    <rect x="48" y="116" width="415" height="266" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="39"
-                      y="31"
-                      width="34"
-                      height="29" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="54"
-                      y="47.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="39"
-                      y="72"
-                      width="34"
-                      height="29" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="54"
-                      y="88.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="441"
-                      y="31"
-                      width="34"
-                      height="29" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="456"
-                      y="47.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="441"
-                      y="72"
-                      width="34"
-                      height="29" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="456"
-                      y="88.5"
-                      style="text-anchor:start;">D</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-hst640" width="515" height="430">
+  <title id="title">Huion HST640</title>
+  <rect x="48" y="116" width="415" height="266"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="39" y="31" width="34" height="29"/>
+    <text id="LabelA" class="A Label" x="94.0" y="47.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 79.0,45.5 H 86.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="39" y="72" width="34" height="29"/>
+    <text id="LabelB" class="B Label" x="94.0" y="88.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 79.0,86.5 H 86.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="441" y="31" width="34" height="29"/>
+    <text id="LabelC" class="C Label" x="496.0" y="47.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 481.0,45.5 H 488.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="441" y="72" width="34" height="29"/>
+    <text id="LabelD" class="D Label" x="496.0" y="88.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 481.0,86.5 H 488.0" id="LeaderD" class="Leader D"/>
+  </g>
 </svg>

--- a/data/layouts/huion-inspiroy-2-l---h1061p.svg
+++ b/data/layouts/huion-inspiroy-2-l---h1061p.svg
@@ -1,155 +1,61 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-inspiroy-2-l---h1061p"
-        width="720"
-        height="426">
-    <title id="title">Inspiroy 2 L - H1061P</title>
-    <rect x="135" y="43" width="543" height="339" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="4"
-                      y="32"
-                      width="17"
-                      height="17" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="10.5"
-                      y="42.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="5"
-                      y="67"
-                      width="17"
-                      height="17" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="11.5"
-                      y="77.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="4"
-                      y="102"
-                      width="17"
-                      height="17" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="10.5"
-                      y="112.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="34"
-                      y="30"
-                      width="33"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="48.5"
-                      y="42"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="34"
-                      y="65"
-                      width="33"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="48.5"
-                      y="77"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="34"
-                      y="99"
-                      width="33"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="48.5"
-                      y="111"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="34"
-                      y="134"
-                      width="33"
-                      height="20" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="48.5"
-                      y="146"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="34"
-                      y="270"
-                      width="33"
-                      height="20" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="48.5"
-                      y="282"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="34"
-                      y="305"
-                      width="33"
-                      height="20" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="48.5"
-                      y="317"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="34"
-                      y="339"
-                      width="33"
-                      height="20" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="48.5"
-                      y="351"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="34"
-                      y="374"
-                      width="33"
-                      height="20" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="48.5"
-                      y="386"
-                      style="text-anchor:start;">K</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-inspiroy-2-l---h1061p" width="720" height="426">
+  <title id="title">Inspiroy 2 L - H1061P</title>
+  <rect x="135" y="43" width="543" height="339"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="4" y="32" width="17" height="17"/>
+    <text id="LabelA" class="A Label" x="10.5" y="62.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 12.5,47.5 V 54.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="5" y="67" width="17" height="17"/>
+    <text id="LabelB" class="B Label" x="11.5" y="97.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 13.5,82.5 V 89.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="4" y="102" width="17" height="17"/>
+    <text id="LabelC" class="C Label" x="10.5" y="132.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 12.5,117.5 V 124.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="34" y="30" width="33" height="20"/>
+    <text id="LabelD" class="D Label" x="88.5" y="42" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 73.5,40.0 H 80.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="34" y="65" width="33" height="20"/>
+    <text id="LabelE" class="E Label" x="88.5" y="77" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 73.5,75.0 H 80.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="34" y="99" width="33" height="20"/>
+    <text id="LabelF" class="F Label" x="88.5" y="111" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 73.5,109.0 H 80.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="34" y="134" width="33" height="20"/>
+    <text id="LabelG" class="G Label" x="88.5" y="146" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 73.5,144.0 H 80.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="34" y="270" width="33" height="20"/>
+    <text id="LabelH" class="H Label" x="88.5" y="282" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 73.5,280.0 H 80.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="34" y="305" width="33" height="20"/>
+    <text id="LabelI" class="I Label" x="88.5" y="317" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 73.5,315.0 H 80.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="34" y="339" width="33" height="20"/>
+    <text id="LabelJ" class="J Label" x="88.5" y="351" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 73.5,349.0 H 80.5" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="34" y="374" width="33" height="20"/>
+    <text id="LabelK" class="K Label" x="88.5" y="386" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 73.5,384.0 H 80.5" id="LeaderK" class="Leader K"/>
+  </g>
 </svg>

--- a/data/layouts/huion-inspiroy-2-m---h951p.svg
+++ b/data/layouts/huion-inspiroy-2-m---h951p.svg
@@ -1,155 +1,61 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-inspiroy-2-m---h951p"
-        width="720"
-        height="424">
-    <title id="title">Inspiroy 2 M - H951P</title>
-    <rect x="151" y="50" width="519" height="323" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="8"
-                      y="32"
-                      width="17"
-                      height="17" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="14.5"
-                      y="42.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="8"
-                      y="72"
-                      width="17"
-                      height="17" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="14.5"
-                      y="82.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="8"
-                      y="112"
-                      width="17"
-                      height="17" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="14.5"
-                      y="122.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="41"
-                      y="28"
-                      width="38"
-                      height="26" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="58"
-                      y="43"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="41"
-                      y="68"
-                      width="38"
-                      height="26" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="58"
-                      y="83"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="41"
-                      y="108"
-                      width="38"
-                      height="26" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="58"
-                      y="123"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="40"
-                      y="148"
-                      width="38"
-                      height="26" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="57"
-                      y="163"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="41"
-                      y="250"
-                      width="38"
-                      height="26" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="58"
-                      y="265"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="41"
-                      y="289"
-                      width="38"
-                      height="26" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="58"
-                      y="304"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="41"
-                      y="329"
-                      width="38"
-                      height="26" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="58"
-                      y="344"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="41"
-                      y="369"
-                      width="38"
-                      height="26" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="58"
-                      y="384"
-                      style="text-anchor:start;">K</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-inspiroy-2-m---h951p" width="720" height="424">
+  <title id="title">Inspiroy 2 M - H951P</title>
+  <rect x="151" y="50" width="519" height="323"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="8" y="32" width="17" height="17"/>
+    <text id="LabelA" class="A Label" x="14.5" y="62.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 16.5,47.5 V 54.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="8" y="72" width="17" height="17"/>
+    <text id="LabelB" class="B Label" x="14.5" y="102.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 16.5,87.5 V 94.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="8" y="112" width="17" height="17"/>
+    <text id="LabelC" class="C Label" x="14.5" y="142.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 16.5,127.5 V 134.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="41" y="28" width="38" height="26"/>
+    <text id="LabelD" class="D Label" x="98.0" y="43" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 83.0,41.0 H 90.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="41" y="68" width="38" height="26"/>
+    <text id="LabelE" class="E Label" x="98.0" y="83" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 83.0,81.0 H 90.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="41" y="108" width="38" height="26"/>
+    <text id="LabelF" class="F Label" x="98.0" y="123" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 83.0,121.0 H 90.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="40" y="148" width="38" height="26"/>
+    <text id="LabelG" class="G Label" x="97.0" y="163" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 82.0,161.0 H 89.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="41" y="250" width="38" height="26"/>
+    <text id="LabelH" class="H Label" x="98.0" y="265" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 83.0,263.0 H 90.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="41" y="289" width="38" height="26"/>
+    <text id="LabelI" class="I Label" x="98.0" y="304" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 83.0,302.0 H 90.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="41" y="329" width="38" height="26"/>
+    <text id="LabelJ" class="J Label" x="98.0" y="344" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 83.0,342.0 H 90.0" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="41" y="369" width="38" height="26"/>
+    <text id="LabelK" class="K Label" x="98.0" y="384" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 83.0,382.0 H 90.0" id="LeaderK" class="Leader K"/>
+  </g>
 </svg>

--- a/data/layouts/huion-inspiroy-dial-2.svg
+++ b/data/layouts/huion-inspiroy-dial-2.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-inspiroy-dial-2"
-        width="720"
-        height="419">
-    <title id="title">Inspiroy Dial 2</title>
-    <rect x="147" y="43" width="535" height="333" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="34"
-                      y="99"
-                      width="31"
-                      height="31" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="47.5"
-                      y="116.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="33"
-                      y="134"
-                      width="34"
-                      height="34" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="48"
-                      y="153"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="33"
-                      y="173"
-                      width="34"
-                      height="34" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="48"
-                      y="192"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="33"
-                      y="212"
-                      width="34"
-                      height="34" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="48"
-                      y="231"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="33"
-                      y="251"
-                      width="34"
-                      height="34" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="48"
-                      y="270"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="34"
-                      y="289"
-                      width="31"
-                      height="31" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="47.5"
-                      y="306.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="25"
-                      y="25"
-                      width="50"
-                      height="50" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="48"
-                      y="52"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="25"
-                      y="344"
-                      width="50"
-                      height="50" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="48"
-                      y="371"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-inspiroy-dial-2" width="720" height="419">
+  <title id="title">Inspiroy Dial 2</title>
+  <rect x="147" y="43" width="535" height="333"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="34" y="99" width="31" height="31"/>
+    <text id="LabelA" class="A Label" x="97.5" y="116.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 82.5,114.5 H 89.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="33" y="134" width="34" height="34"/>
+    <text id="LabelB" class="B Label" x="98.0" y="153" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 83.0,151.0 H 90.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="33" y="173" width="34" height="34"/>
+    <text id="LabelC" class="C Label" x="98.0" y="192" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 83.0,190.0 H 90.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="33" y="212" width="34" height="34"/>
+    <text id="LabelD" class="D Label" x="98.0" y="231" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 83.0,229.0 H 90.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="33" y="251" width="34" height="34"/>
+    <text id="LabelE" class="E Label" x="98.0" y="270" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 83.0,268.0 H 90.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="34" y="289" width="31" height="31"/>
+    <text id="LabelF" class="F Label" x="97.5" y="306.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 82.5,304.5 H 89.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="25" y="25" width="50" height="50"/>
+    <text id="LabelG" class="G Label" x="98.0" y="52" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 83.0,50.0 H 90.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="25" y="344" width="50" height="50"/>
+    <text id="LabelH" class="H Label" x="98.0" y="371" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 83.0,369.0 H 90.0" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/huion-inspiroy-dial-q620m.svg
+++ b/data/layouts/huion-inspiroy-dial-q620m.svg
@@ -1,129 +1,51 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-inspiroy-dial-q620m"
-        width="733"
-        height="430">
-    <title id="title">Inspiroy Dial Q620M</title>
-    <rect x="160" y="52" width="520" height="325" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="21"
-                      y="84"
-                      width="42"
-                      height="42" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="40"
-                      y="107"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="21"
-                      y="128"
-                      width="42"
-                      height="38" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="40"
-                      y="149"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="21"
-                      y="168"
-                      width="42"
-                      height="38" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="40"
-                      y="189"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="21"
-                      y="208"
-                      width="42"
-                      height="38" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="40"
-                      y="229"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="21"
-                      y="248"
-                      width="42"
-                      height="38" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="40"
-                      y="269"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="21"
-                      y="288"
-                      width="42"
-                      height="38" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="40"
-                      y="309"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="21"
-                      y="328"
-                      width="42"
-                      height="38" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="40"
-                      y="349"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="21"
-                      y="368"
-                      width="42"
-                      height="42" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="40"
-                      y="391"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="27"
-                      y="30"
-                      width="28"
-                      height="28" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="39"
-                      y="46"
-                      style="text-anchor:start;">I</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-inspiroy-dial-q620m" width="733" height="430">
+  <title id="title">Inspiroy Dial Q620M</title>
+  <rect x="160" y="52" width="520" height="325"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="21" y="84" width="42" height="42"/>
+    <text id="LabelA" class="A Label" x="90.0" y="107" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 75.0,105.0 H 82.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="21" y="128" width="42" height="38"/>
+    <text id="LabelB" class="B Label" x="90.0" y="149" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 75.0,147.0 H 82.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="21" y="168" width="42" height="38"/>
+    <text id="LabelC" class="C Label" x="90.0" y="189" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 75.0,187.0 H 82.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="21" y="208" width="42" height="38"/>
+    <text id="LabelD" class="D Label" x="90.0" y="229" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 75.0,227.0 H 82.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="21" y="248" width="42" height="38"/>
+    <text id="LabelE" class="E Label" x="90.0" y="269" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 75.0,267.0 H 82.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="21" y="288" width="42" height="38"/>
+    <text id="LabelF" class="F Label" x="90.0" y="309" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 75.0,307.0 H 82.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="21" y="328" width="42" height="38"/>
+    <text id="LabelG" class="G Label" x="90.0" y="349" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 75.0,347.0 H 82.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="21" y="368" width="42" height="42"/>
+    <text id="LabelH" class="H Label" x="90.0" y="391" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 75.0,389.0 H 82.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="27" y="30" width="28" height="28"/>
+    <text id="LabelI" class="I Label" x="89.0" y="46" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 74.0,44.0 H 81.0" id="LeaderI" class="Leader I"/>
+  </g>
 </svg>

--- a/data/layouts/huion-inspiroy-g10t.svg
+++ b/data/layouts/huion-inspiroy-g10t.svg
@@ -1,90 +1,36 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-inspiroy-g10t"
-        width="750"
-        height="355">
-    <title id="title">INSPIROY  G10T</title>
-    <rect x="216" y="21" width="510" height="314" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="28"
-                      y="94"
-                      width="47"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="49.5"
-                      y="106"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="92"
-                      y="94"
-                      width="32"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="106"
-                      y="106"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="140"
-                      y="94"
-                      width="47"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="161.5"
-                      y="106"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="28"
-                      y="238"
-                      width="47"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="49.5"
-                      y="250"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="92"
-                      y="238"
-                      width="32"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="106"
-                      y="250"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="141"
-                      y="239"
-                      width="47"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="162.5"
-                      y="251"
-                      style="text-anchor:start;">F</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-inspiroy-g10t" width="750" height="355">
+  <title id="title">INSPIROY  G10T</title>
+  <rect x="216" y="21" width="510" height="314"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="28" y="94" width="47" height="20"/>
+    <text id="LabelA" class="A Label" x="49.5" y="136.0" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 51.5,121.0 V 128.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="92" y="94" width="32" height="20"/>
+    <text id="LabelB" class="B Label" x="106" y="136.0" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 108.0,121.0 V 128.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="140" y="94" width="47" height="20"/>
+    <text id="LabelC" class="C Label" x="161.5" y="136.0" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 163.5,121.0 V 128.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="28" y="238" width="47" height="20"/>
+    <text id="LabelD" class="D Label" x="49.5" y="280.0" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 51.5,265.0 V 272.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="92" y="238" width="32" height="20"/>
+    <text id="LabelE" class="E Label" x="106" y="280.0" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 108.0,265.0 V 272.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="141" y="239" width="47" height="20"/>
+    <text id="LabelF" class="F Label" x="162.5" y="281.0" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 164.5,266.0 V 273.0" id="LeaderF" class="Leader F"/>
+  </g>
 </svg>

--- a/data/layouts/huion-inspiroy-giano.svg
+++ b/data/layouts/huion-inspiroy-giano.svg
@@ -1,90 +1,36 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-inspiroy-giano"
-        width="724"
-        height="430">
-    <title id="title">Inspiroy Giano</title>
-    <rect x="97" y="31" width="590" height="367" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="27"
-                      y="107"
-                      width="29"
-                      height="34" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="39.5"
-                      y="126"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="27"
-                      y="142"
-                      width="29"
-                      height="37" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="39.5"
-                      y="162.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="27"
-                      y="180"
-                      width="29"
-                      height="31" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="39.5"
-                      y="197.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="27"
-                      y="212"
-                      width="29"
-                      height="38" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="39.5"
-                      y="233"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="27"
-                      y="251"
-                      width="29"
-                      height="34" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="39.5"
-                      y="270"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="27"
-                      y="286"
-                      width="29"
-                      height="37" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="39.5"
-                      y="306.5"
-                      style="text-anchor:start;">F</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-inspiroy-giano" width="724" height="430">
+  <title id="title">Inspiroy Giano</title>
+  <rect x="97" y="31" width="590" height="367"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="27" y="107" width="29" height="34"/>
+    <text id="LabelA" class="A Label" x="79.5" y="126" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 64.5,124.0 H 71.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="27" y="142" width="29" height="37"/>
+    <text id="LabelB" class="B Label" x="79.5" y="162.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 64.5,160.5 H 71.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="27" y="180" width="29" height="31"/>
+    <text id="LabelC" class="C Label" x="79.5" y="197.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 64.5,195.5 H 71.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="27" y="212" width="29" height="38"/>
+    <text id="LabelD" class="D Label" x="79.5" y="233" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 64.5,231.0 H 71.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="27" y="251" width="29" height="34"/>
+    <text id="LabelE" class="E Label" x="79.5" y="270" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 64.5,268.0 H 71.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="27" y="286" width="29" height="37"/>
+    <text id="LabelF" class="F Label" x="79.5" y="306.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 64.5,304.5 H 71.5" id="LeaderF" class="Leader F"/>
+  </g>
 </svg>

--- a/data/layouts/huion-inspiroy-h1161.svg
+++ b/data/layouts/huion-inspiroy-h1161.svg
@@ -1,142 +1,56 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-inspiroy-h1161"
-        width="725"
-        height="430">
-    <title id="title">INSPIROY H1161</title>
-    <rect x="140" y="43" width="547" height="342" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="34"
-                      y="52"
-                      width="36"
-                      height="26" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="50"
-                      y="67"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="35"
-                      y="84"
-                      width="36"
-                      height="26" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="51"
-                      y="99"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="35"
-                      y="116"
-                      width="36"
-                      height="26" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="51"
-                      y="131"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="35"
-                      y="149"
-                      width="36"
-                      height="26" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="51"
-                      y="164"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="33"
-                      y="180"
-                      width="38"
-                      height="34" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="50"
-                      y="199"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="33"
-                      y="217"
-                      width="38"
-                      height="30" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="50"
-                      y="234"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="35"
-                      y="255"
-                      width="36"
-                      height="26" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="51"
-                      y="270"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="35"
-                      y="287"
-                      width="36"
-                      height="26" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="51"
-                      y="302"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="35"
-                      y="320"
-                      width="36"
-                      height="26" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="51"
-                      y="335"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="35"
-                      y="352"
-                      width="36"
-                      height="26" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="51"
-                      y="367"
-                      style="text-anchor:start;">J</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-inspiroy-h1161" width="725" height="430">
+  <title id="title">INSPIROY H1161</title>
+  <rect x="140" y="43" width="547" height="342"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="34" y="52" width="36" height="26"/>
+    <text id="LabelA" class="A Label" x="90.0" y="67" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 75.0,65.0 H 82.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="35" y="84" width="36" height="26"/>
+    <text id="LabelB" class="B Label" x="91.0" y="99" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 76.0,97.0 H 83.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="35" y="116" width="36" height="26"/>
+    <text id="LabelC" class="C Label" x="91.0" y="131" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 76.0,129.0 H 83.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="35" y="149" width="36" height="26"/>
+    <text id="LabelD" class="D Label" x="91.0" y="164" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 76.0,162.0 H 83.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="33" y="180" width="38" height="34"/>
+    <text id="LabelE" class="E Label" x="90.0" y="199" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 75.0,197.0 H 82.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="33" y="217" width="38" height="30"/>
+    <text id="LabelF" class="F Label" x="90.0" y="234" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 75.0,232.0 H 82.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="35" y="255" width="36" height="26"/>
+    <text id="LabelG" class="G Label" x="91.0" y="270" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 76.0,268.0 H 83.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="35" y="287" width="36" height="26"/>
+    <text id="LabelH" class="H Label" x="91.0" y="302" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 76.0,300.0 H 83.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="35" y="320" width="36" height="26"/>
+    <text id="LabelI" class="I Label" x="91.0" y="335" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 76.0,333.0 H 83.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="35" y="352" width="36" height="26"/>
+    <text id="LabelJ" class="J Label" x="91.0" y="367" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 76.0,365.0 H 83.0" id="LeaderJ" class="Leader J"/>
+  </g>
 </svg>

--- a/data/layouts/huion-inspiroy-h430p.svg
+++ b/data/layouts/huion-inspiroy-h430p.svg
@@ -1,64 +1,26 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-inspiroy-h430p"
-        width="576"
-        height="430">
-    <title id="title">INSPIROY H430P</title>
-    <rect x="97" y="132" width="381" height="238" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="46"
-                      y="33"
-                      width="36"
-                      height="38" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="62"
-                      y="54"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="46"
-                      y="87"
-                      width="36"
-                      height="38" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="62"
-                      y="108"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="494"
-                      y="33"
-                      width="36"
-                      height="38" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="510"
-                      y="54"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="494"
-                      y="87"
-                      width="36"
-                      height="38" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="510"
-                      y="108"
-                      style="text-anchor:start;">D</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-inspiroy-h430p" width="576" height="430">
+  <title id="title">INSPIROY H430P</title>
+  <rect x="97" y="132" width="381" height="238"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="46" y="33" width="36" height="38"/>
+    <text id="LabelA" class="A Label" x="102.0" y="54" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 87.0,52.0 H 94.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="46" y="87" width="36" height="38"/>
+    <text id="LabelB" class="B Label" x="102.0" y="108" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 87.0,106.0 H 94.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="494" y="33" width="36" height="38"/>
+    <text id="LabelC" class="C Label" x="550.0" y="54" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 535.0,52.0 H 542.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="494" y="87" width="36" height="38"/>
+    <text id="LabelD" class="D Label" x="550.0" y="108" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 535.0,106.0 H 542.0" id="LeaderD" class="Leader D"/>
+  </g>
 </svg>

--- a/data/layouts/huion-inspiroy-h580x.svg
+++ b/data/layouts/huion-inspiroy-h580x.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-inspiroy-h580x"
-        width="701"
-        height="430">
-    <title id="title">INSPIROY H580X</title>
-    <rect x="127" y="52" width="519" height="325" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="46"
-                      y="60"
-                      width="44"
-                      height="35" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="66"
-                      y="79.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="46"
-                      y="101"
-                      width="44"
-                      height="33" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="66"
-                      y="119.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="46"
-                      y="139"
-                      width="44"
-                      height="37" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="66"
-                      y="159.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="38"
-                      y="183"
-                      width="61"
-                      height="30" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="66.5"
-                      y="200"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="38"
-                      y="217"
-                      width="60"
-                      height="28" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="66"
-                      y="233"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="46"
-                      y="255"
-                      width="44"
-                      height="34" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="66"
-                      y="274"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="46"
-                      y="296"
-                      width="44"
-                      height="33" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="66"
-                      y="314.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="46"
-                      y="334"
-                      width="44"
-                      height="35" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="66"
-                      y="353.5"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-inspiroy-h580x" width="701" height="430">
+  <title id="title">INSPIROY H580X</title>
+  <rect x="127" y="52" width="519" height="325"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="46" y="60" width="44" height="35"/>
+    <text id="LabelA" class="A Label" x="106.0" y="79.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 91.0,77.5 H 98.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="46" y="101" width="44" height="33"/>
+    <text id="LabelB" class="B Label" x="106.0" y="119.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 91.0,117.5 H 98.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="46" y="139" width="44" height="37"/>
+    <text id="LabelC" class="C Label" x="106.0" y="159.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 91.0,157.5 H 98.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="38" y="183" width="61" height="30"/>
+    <text id="LabelD" class="D Label" x="106.5" y="200" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 91.5,198.0 H 98.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="38" y="217" width="60" height="28"/>
+    <text id="LabelE" class="E Label" x="106.0" y="233" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 91.0,231.0 H 98.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="46" y="255" width="44" height="34"/>
+    <text id="LabelF" class="F Label" x="106.0" y="274" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 91.0,272.0 H 98.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="46" y="296" width="44" height="33"/>
+    <text id="LabelG" class="G Label" x="106.0" y="314.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 91.0,312.5 H 98.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="46" y="334" width="44" height="35"/>
+    <text id="LabelH" class="H Label" x="106.0" y="353.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 91.0,351.5 H 98.0" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/huion-inspiroy-h610x.svg
+++ b/data/layouts/huion-inspiroy-h610x.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-inspiroy-h610x"
-        width="683"
-        height="430">
-    <title id="title">INSPIROY H610X</title>
-    <rect x="100" y="46" width="539" height="338" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="38"
-                      y="78"
-                      width="35"
-                      height="30" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="53.5"
-                      y="95"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="38"
-                      y="111"
-                      width="35"
-                      height="30" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="53.5"
-                      y="128"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="38"
-                      y="144"
-                      width="35"
-                      height="30" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="53.5"
-                      y="161"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="29"
-                      y="188"
-                      width="53"
-                      height="25" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="53.5"
-                      y="202.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="29"
-                      y="216"
-                      width="53"
-                      height="27" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="53.5"
-                      y="231.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="38"
-                      y="254"
-                      width="35"
-                      height="30" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="53.5"
-                      y="271"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="38"
-                      y="289"
-                      width="35"
-                      height="29" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="53.5"
-                      y="305.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="38"
-                      y="321"
-                      width="35"
-                      height="30" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="53.5"
-                      y="338"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-inspiroy-h610x" width="683" height="430">
+  <title id="title">INSPIROY H610X</title>
+  <rect x="100" y="46" width="539" height="338"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="38" y="78" width="35" height="30"/>
+    <text id="LabelA" class="A Label" x="93.5" y="95" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 78.5,93.0 H 85.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="38" y="111" width="35" height="30"/>
+    <text id="LabelB" class="B Label" x="93.5" y="128" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 78.5,126.0 H 85.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="38" y="144" width="35" height="30"/>
+    <text id="LabelC" class="C Label" x="93.5" y="161" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 78.5,159.0 H 85.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="29" y="188" width="53" height="25"/>
+    <text id="LabelD" class="D Label" x="93.5" y="202.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 78.5,200.5 H 85.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="29" y="216" width="53" height="27"/>
+    <text id="LabelE" class="E Label" x="93.5" y="231.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 78.5,229.5 H 85.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="38" y="254" width="35" height="30"/>
+    <text id="LabelF" class="F Label" x="93.5" y="271" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 78.5,269.0 H 85.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="38" y="289" width="35" height="29"/>
+    <text id="LabelG" class="G Label" x="93.5" y="305.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 78.5,303.5 H 85.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="38" y="321" width="35" height="30"/>
+    <text id="LabelH" class="H Label" x="93.5" y="338" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 78.5,336.0 H 85.5" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/huion-inspiroy-ink-h320m.svg
+++ b/data/layouts/huion-inspiroy-ink-h320m.svg
@@ -1,155 +1,61 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-inspiroy-ink-h320m"
-        width="732"
-        height="430">
-    <title id="title">INSPIROY Ink H320M</title>
-    <rect x="141" y="43" width="548" height="343" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="54"
-                      y="49"
-                      width="34"
-                      height="34" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="69"
-                      y="68"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="54"
-                      y="92"
-                      width="34"
-                      height="34" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="69"
-                      y="111"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="54"
-                      y="133"
-                      width="34"
-                      height="34" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="69"
-                      y="152"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="51"
-                      y="180"
-                      width="40"
-                      height="19" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="69"
-                      y="191.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="52"
-                      y="230"
-                      width="40"
-                      height="19" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="70"
-                      y="241.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="58"
-                      y="202"
-                      width="26"
-                      height="26" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="69"
-                      y="217"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="36"
-                      y="201"
-                      width="21"
-                      height="28" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="44.5"
-                      y="217"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="86"
-                      y="201"
-                      width="21"
-                      height="28" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="94.5"
-                      y="217"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="54"
-                      y="264"
-                      width="34"
-                      height="34" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="69"
-                      y="283"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="54"
-                      y="306"
-                      width="34"
-                      height="34" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="69"
-                      y="325"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="54"
-                      y="346"
-                      width="34"
-                      height="34" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="69"
-                      y="365"
-                      style="text-anchor:start;">K</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-inspiroy-ink-h320m" width="732" height="430">
+  <title id="title">INSPIROY Ink H320M</title>
+  <rect x="141" y="43" width="548" height="343"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="54" y="49" width="34" height="34"/>
+    <text id="LabelA" class="A Label" x="109.0" y="68" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 94.0,66.0 H 101.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="54" y="92" width="34" height="34"/>
+    <text id="LabelB" class="B Label" x="109.0" y="111" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 94.0,109.0 H 101.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="54" y="133" width="34" height="34"/>
+    <text id="LabelC" class="C Label" x="109.0" y="152" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 94.0,150.0 H 101.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="51" y="180" width="40" height="19"/>
+    <text id="LabelD" class="D Label" x="109.0" y="191.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 94.0,189.5 H 101.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="52" y="230" width="40" height="19"/>
+    <text id="LabelE" class="E Label" x="30.0" y="241.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 48.0,239.5 H 40.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="58" y="202" width="26" height="26"/>
+    <text id="LabelF" class="F Label" x="109.0" y="217" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 94.0,215.0 H 101.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="36" y="201" width="21" height="28"/>
+    <text id="LabelG" class="G Label" x="44.5" y="177.0" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 46.5,192.0 V 185.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="86" y="201" width="21" height="28"/>
+    <text id="LabelH" class="H Label" x="94.5" y="257.0" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 96.5,242.0 V 249.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="54" y="264" width="34" height="34"/>
+    <text id="LabelI" class="I Label" x="29.0" y="283" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 47.0,281.0 H 39.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="54" y="306" width="34" height="34"/>
+    <text id="LabelJ" class="J Label" x="29.0" y="325" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 47.0,323.0 H 39.0" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="54" y="346" width="34" height="34"/>
+    <text id="LabelK" class="K Label" x="29.0" y="365" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 47.0,363.0 H 39.0" id="LeaderK" class="Leader K"/>
+  </g>
 </svg>

--- a/data/layouts/huion-inspiroy-keydial-kd200.svg
+++ b/data/layouts/huion-inspiroy-keydial-kd200.svg
@@ -1,90 +1,36 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-inspiroy-keydial-kd200"
-        width="750"
-        height="357">
-    <title id="title">INSPIROY KeyDial KD200</title>
-    <rect x="287" y="31" width="432" height="273" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="63"
-                      y="71"
-                      width="30"
-                      height="30" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="76"
-                      y="88"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="95"
-                      y="71"
-                      width="30"
-                      height="30" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="108"
-                      y="88"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="127"
-                      y="71"
-                      width="30"
-                      height="30" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="140"
-                      y="88"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="159"
-                      y="71"
-                      width="30"
-                      height="30" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="172"
-                      y="88"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="191"
-                      y="71"
-                      width="30"
-                      height="30" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="204"
-                      y="88"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="150"
-                      y="19"
-                      width="40"
-                      height="31" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="168"
-                      y="36.5"
-                      style="text-anchor:start;">F</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-inspiroy-keydial-kd200" width="750" height="357">
+  <title id="title">INSPIROY KeyDial KD200</title>
+  <rect x="287" y="31" width="432" height="273"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="63" y="71" width="30" height="30"/>
+    <text id="LabelA" class="A Label" x="76" y="118.0" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 78.0,103.0 V 110.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="95" y="71" width="30" height="30"/>
+    <text id="LabelB" class="B Label" x="108" y="118.0" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 110.0,103.0 V 110.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="127" y="71" width="30" height="30"/>
+    <text id="LabelC" class="C Label" x="140" y="118.0" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 142.0,103.0 V 110.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="159" y="71" width="30" height="30"/>
+    <text id="LabelD" class="D Label" x="172" y="118.0" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 174.0,103.0 V 110.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="191" y="71" width="30" height="30"/>
+    <text id="LabelE" class="E Label" x="204" y="118.0" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 206.0,103.0 V 110.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="150" y="19" width="40" height="31"/>
+    <text id="LabelF" class="F Label" x="168" y="66.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 170.0,51.5 V 58.5" id="LeaderF" class="Leader F"/>
+  </g>
 </svg>

--- a/data/layouts/huion-inspiroy-q11k-v2.svg
+++ b/data/layouts/huion-inspiroy-q11k-v2.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-inspiroy-q11k-v2"
-        width="750"
-        height="427">
-    <title id="title">INSPIROY Q11K V2</title>
-    <rect x="150" y="41" width="539" height="339" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="48"
-                      y="45"
-                      width="36"
-                      height="24" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="64"
-                      y="59"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="48"
-                      y="78"
-                      width="36"
-                      height="24" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="64"
-                      y="92"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="48"
-                      y="112"
-                      width="36"
-                      height="24" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="64"
-                      y="126"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="48"
-                      y="146"
-                      width="36"
-                      height="24" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="64"
-                      y="160"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="48"
-                      y="250"
-                      width="36"
-                      height="24" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="64"
-                      y="264"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="48"
-                      y="284"
-                      width="36"
-                      height="24" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="64"
-                      y="298"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="49"
-                      y="317"
-                      width="36"
-                      height="24" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="65"
-                      y="331"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="48"
-                      y="351"
-                      width="36"
-                      height="24" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="64"
-                      y="365"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-inspiroy-q11k-v2" width="750" height="427">
+  <title id="title">INSPIROY Q11K V2</title>
+  <rect x="150" y="41" width="539" height="339"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="48" y="45" width="36" height="24"/>
+    <text id="LabelA" class="A Label" x="104.0" y="59" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 89.0,57.0 H 96.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="48" y="78" width="36" height="24"/>
+    <text id="LabelB" class="B Label" x="104.0" y="92" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 89.0,90.0 H 96.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="48" y="112" width="36" height="24"/>
+    <text id="LabelC" class="C Label" x="104.0" y="126" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 89.0,124.0 H 96.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="48" y="146" width="36" height="24"/>
+    <text id="LabelD" class="D Label" x="104.0" y="160" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 89.0,158.0 H 96.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="48" y="250" width="36" height="24"/>
+    <text id="LabelE" class="E Label" x="104.0" y="264" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 89.0,262.0 H 96.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="48" y="284" width="36" height="24"/>
+    <text id="LabelF" class="F Label" x="104.0" y="298" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 89.0,296.0 H 96.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="49" y="317" width="36" height="24"/>
+    <text id="LabelG" class="G Label" x="105.0" y="331" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 90.0,329.0 H 97.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="48" y="351" width="36" height="24"/>
+    <text id="LabelH" class="H Label" x="104.0" y="365" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 89.0,363.0 H 96.0" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/huion-inspiroy-q11k.svg
+++ b/data/layouts/huion-inspiroy-q11k.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-inspiroy-q11k"
-        width="750"
-        height="427">
-    <title id="title">INSPIROY Q11K</title>
-    <rect x="149" y="40" width="541" height="339" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="47"
-                      y="46"
-                      width="37"
-                      height="22" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="63.5"
-                      y="59"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="47"
-                      y="79"
-                      width="37"
-                      height="22" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="63.5"
-                      y="92"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="47"
-                      y="113"
-                      width="37"
-                      height="22" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="63.5"
-                      y="126"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="47"
-                      y="146"
-                      width="37"
-                      height="22" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="63.5"
-                      y="159"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="47"
-                      y="251"
-                      width="37"
-                      height="22" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="63.5"
-                      y="264"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="47"
-                      y="285"
-                      width="37"
-                      height="22" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="63.5"
-                      y="298"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="47"
-                      y="318"
-                      width="37"
-                      height="22" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="63.5"
-                      y="331"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="47"
-                      y="352"
-                      width="37"
-                      height="22" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="63.5"
-                      y="365"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-inspiroy-q11k" width="750" height="427">
+  <title id="title">INSPIROY Q11K</title>
+  <rect x="149" y="40" width="541" height="339"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="47" y="46" width="37" height="22"/>
+    <text id="LabelA" class="A Label" x="103.5" y="59" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 88.5,57.0 H 95.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="47" y="79" width="37" height="22"/>
+    <text id="LabelB" class="B Label" x="103.5" y="92" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 88.5,90.0 H 95.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="47" y="113" width="37" height="22"/>
+    <text id="LabelC" class="C Label" x="103.5" y="126" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 88.5,124.0 H 95.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="47" y="146" width="37" height="22"/>
+    <text id="LabelD" class="D Label" x="103.5" y="159" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 88.5,157.0 H 95.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="47" y="251" width="37" height="22"/>
+    <text id="LabelE" class="E Label" x="103.5" y="264" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 88.5,262.0 H 95.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="47" y="285" width="37" height="22"/>
+    <text id="LabelF" class="F Label" x="103.5" y="298" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 88.5,296.0 H 95.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="47" y="318" width="37" height="22"/>
+    <text id="LabelG" class="G Label" x="103.5" y="331" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 88.5,329.0 H 95.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="47" y="352" width="37" height="22"/>
+    <text id="LabelH" class="H Label" x="103.5" y="365" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 88.5,363.0 H 95.5" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/huion-inspiroy-q620m.svg
+++ b/data/layouts/huion-inspiroy-q620m.svg
@@ -1,129 +1,51 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-inspiroy-q620m"
-        width="733"
-        height="430">
-    <title id="title">INSPIROY Q620M</title>
-    <rect x="161" y="52" width="520" height="325" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="21"
-                      y="85"
-                      width="42"
-                      height="42" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="40"
-                      y="108"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="21"
-                      y="128"
-                      width="42"
-                      height="38" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="40"
-                      y="149"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="21"
-                      y="168"
-                      width="42"
-                      height="38" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="40"
-                      y="189"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="21"
-                      y="208"
-                      width="42"
-                      height="38" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="40"
-                      y="229"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="21"
-                      y="248"
-                      width="42"
-                      height="38" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="40"
-                      y="269"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="21"
-                      y="288"
-                      width="42"
-                      height="38" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="40"
-                      y="309"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="21"
-                      y="328"
-                      width="42"
-                      height="38" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="40"
-                      y="349"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="21"
-                      y="368"
-                      width="42"
-                      height="40" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="40"
-                      y="390"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="29"
-                      y="30"
-                      width="26"
-                      height="26" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="40"
-                      y="45"
-                      style="text-anchor:start;">I</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-inspiroy-q620m" width="733" height="430">
+  <title id="title">INSPIROY Q620M</title>
+  <rect x="161" y="52" width="520" height="325"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="21" y="85" width="42" height="42"/>
+    <text id="LabelA" class="A Label" x="80.0" y="108" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 65.0,106.0 H 72.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="21" y="128" width="42" height="38"/>
+    <text id="LabelB" class="B Label" x="80.0" y="149" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 65.0,147.0 H 72.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="21" y="168" width="42" height="38"/>
+    <text id="LabelC" class="C Label" x="80.0" y="189" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 65.0,187.0 H 72.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="21" y="208" width="42" height="38"/>
+    <text id="LabelD" class="D Label" x="80.0" y="229" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 65.0,227.0 H 72.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="21" y="248" width="42" height="38"/>
+    <text id="LabelE" class="E Label" x="80.0" y="269" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 65.0,267.0 H 72.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="21" y="288" width="42" height="38"/>
+    <text id="LabelF" class="F Label" x="80.0" y="309" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 65.0,307.0 H 72.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="21" y="328" width="42" height="38"/>
+    <text id="LabelG" class="G Label" x="80.0" y="349" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 65.0,347.0 H 72.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="21" y="368" width="42" height="40"/>
+    <text id="LabelH" class="H Label" x="80.0" y="390" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 65.0,388.0 H 72.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="29" y="30" width="26" height="26"/>
+    <text id="LabelI" class="I Label" x="80.0" y="45" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 65.0,43.0 H 72.0" id="LeaderI" class="Leader I"/>
+  </g>
 </svg>

--- a/data/layouts/huion-inspiroy-wh1409-v2.svg
+++ b/data/layouts/huion-inspiroy-wh1409-v2.svg
@@ -1,168 +1,66 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-inspiroy-wh1409-v2"
-        width="750"
-        height="437">
-    <title id="title">INSPIROY WH1409 V2</title>
-    <rect x="132" y="37" width="581" height="362" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="22"
-                      y="218"
-                      width="31"
-                      height="21" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="35.5"
-                      y="230.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="60"
-                      y="218"
-                      width="31"
-                      height="21" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="73.5"
-                      y="230.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="22"
-                      y="245"
-                      width="31"
-                      height="21" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="35.5"
-                      y="257.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="60"
-                      y="245"
-                      width="31"
-                      height="21" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="73.5"
-                      y="257.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="22"
-                      y="284"
-                      width="31"
-                      height="21" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="35.5"
-                      y="296.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="60"
-                      y="284"
-                      width="31"
-                      height="21" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="73.5"
-                      y="296.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="22"
-                      y="311"
-                      width="31"
-                      height="21" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="35.5"
-                      y="323.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="60"
-                      y="311"
-                      width="31"
-                      height="21" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="73.5"
-                      y="323.5"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="22"
-                      y="348"
-                      width="31"
-                      height="21" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="35.5"
-                      y="360.5"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="60"
-                      y="348"
-                      width="31"
-                      height="21" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="73.5"
-                      y="360.5"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="22"
-                      y="375"
-                      width="31"
-                      height="21" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="35.5"
-                      y="387.5"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="60"
-                      y="375"
-                      width="31"
-                      height="21" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="73.5"
-                      y="387.5"
-                      style="text-anchor:start;">L</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-inspiroy-wh1409-v2" width="750" height="437">
+  <title id="title">INSPIROY WH1409 V2</title>
+  <rect x="132" y="37" width="581" height="362"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="22" y="218" width="31" height="21"/>
+    <text id="LabelA" class="A Label" x="-4.5" y="230.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 13.5,228.5 H 5.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="60" y="218" width="31" height="21"/>
+    <text id="LabelB" class="B Label" x="113.5" y="230.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 98.5,228.5 H 105.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="22" y="245" width="31" height="21"/>
+    <text id="LabelC" class="C Label" x="-4.5" y="257.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 13.5,255.5 H 5.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="60" y="245" width="31" height="21"/>
+    <text id="LabelD" class="D Label" x="113.5" y="257.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 98.5,255.5 H 105.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="22" y="284" width="31" height="21"/>
+    <text id="LabelE" class="E Label" x="-4.5" y="296.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 13.5,294.5 H 5.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="60" y="284" width="31" height="21"/>
+    <text id="LabelF" class="F Label" x="113.5" y="296.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 98.5,294.5 H 105.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="22" y="311" width="31" height="21"/>
+    <text id="LabelG" class="G Label" x="-4.5" y="323.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 13.5,321.5 H 5.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="60" y="311" width="31" height="21"/>
+    <text id="LabelH" class="H Label" x="113.5" y="323.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 98.5,321.5 H 105.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="22" y="348" width="31" height="21"/>
+    <text id="LabelI" class="I Label" x="-4.5" y="360.5" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 13.5,358.5 H 5.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="60" y="348" width="31" height="21"/>
+    <text id="LabelJ" class="J Label" x="113.5" y="360.5" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 98.5,358.5 H 105.5" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="22" y="375" width="31" height="21"/>
+    <text id="LabelK" class="K Label" x="-4.5" y="387.5" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 13.5,385.5 H 5.5" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="60" y="375" width="31" height="21"/>
+    <text id="LabelL" class="L Label" x="113.5" y="387.5" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 98.5,385.5 H 105.5" id="LeaderL" class="Leader L"/>
+  </g>
 </svg>

--- a/data/layouts/huion-kamvas-12-gs1161.svg
+++ b/data/layouts/huion-kamvas-12-gs1161.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-kamvas-12-gs1161"
-        width="721"
-        height="430">
-    <title id="title">KAMVAS 12 GS1161</title>
-    <rect x="99" y="54" width="561" height="321" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="13"
-                      y="76"
-                      width="31"
-                      height="31" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="26.5"
-                      y="93.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="13"
-                      y="108"
-                      width="31"
-                      height="31" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="26.5"
-                      y="125.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="13"
-                      y="140"
-                      width="31"
-                      height="31" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="26.5"
-                      y="157.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="10"
-                      y="176"
-                      width="37"
-                      height="40" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="26.5"
-                      y="198"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="10"
-                      y="218"
-                      width="37"
-                      height="40" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="26.5"
-                      y="240"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="12"
-                      y="262"
-                      width="31"
-                      height="31" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="25.5"
-                      y="279.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="12"
-                      y="294"
-                      width="31"
-                      height="31" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="25.5"
-                      y="311.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="12"
-                      y="326"
-                      width="31"
-                      height="31" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="25.5"
-                      y="343.5"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-kamvas-12-gs1161" width="721" height="430">
+  <title id="title">KAMVAS 12 GS1161</title>
+  <rect x="99" y="54" width="561" height="321"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="13" y="76" width="31" height="31"/>
+    <text id="LabelA" class="A Label" x="66.5" y="93.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 51.5,91.5 H 58.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="13" y="108" width="31" height="31"/>
+    <text id="LabelB" class="B Label" x="66.5" y="125.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 51.5,123.5 H 58.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="13" y="140" width="31" height="31"/>
+    <text id="LabelC" class="C Label" x="66.5" y="157.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 51.5,155.5 H 58.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="10" y="176" width="37" height="40"/>
+    <text id="LabelD" class="D Label" x="66.5" y="198" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 51.5,196.0 H 58.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="10" y="218" width="37" height="40"/>
+    <text id="LabelE" class="E Label" x="66.5" y="240" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 51.5,238.0 H 58.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="12" y="262" width="31" height="31"/>
+    <text id="LabelF" class="F Label" x="65.5" y="279.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 50.5,277.5 H 57.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="12" y="294" width="31" height="31"/>
+    <text id="LabelG" class="G Label" x="65.5" y="311.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 50.5,309.5 H 57.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="12" y="326" width="31" height="31"/>
+    <text id="LabelH" class="H Label" x="65.5" y="343.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 50.5,341.5 H 57.5" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/huion-kamvas-16-gs1562.svg
+++ b/data/layouts/huion-kamvas-16-gs1562.svg
@@ -1,142 +1,56 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-kamvas-16-gs1562"
-        width="720"
-        height="430">
-    <title id="title">KAMVAS 16 GS1562</title>
-    <rect x="82" y="48" width="589" height="333" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="10"
-                      y="73"
-                      width="25"
-                      height="25" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="20.5"
-                      y="87.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="10"
-                      y="101"
-                      width="25"
-                      height="25" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="20.5"
-                      y="115.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="10"
-                      y="129"
-                      width="25"
-                      height="25" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="20.5"
-                      y="143.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="10"
-                      y="157"
-                      width="25"
-                      height="25" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="20.5"
-                      y="171.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="7"
-                      y="185"
-                      width="30"
-                      height="30" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="20"
-                      y="202"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="6"
-                      y="216"
-                      width="32"
-                      height="32" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="20"
-                      y="234"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="10"
-                      y="252"
-                      width="25"
-                      height="25" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="20.5"
-                      y="266.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="10"
-                      y="280"
-                      width="25"
-                      height="25" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="20.5"
-                      y="294.5"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="10"
-                      y="308"
-                      width="25"
-                      height="25" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="20.5"
-                      y="322.5"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="10"
-                      y="336"
-                      width="25"
-                      height="25" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="20.5"
-                      y="350.5"
-                      style="text-anchor:start;">J</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-kamvas-16-gs1562" width="720" height="430">
+  <title id="title">KAMVAS 16 GS1562</title>
+  <rect x="82" y="48" width="589" height="333"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="10" y="73" width="25" height="25"/>
+    <text id="LabelA" class="A Label" x="60.5" y="87.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 45.5,85.5 H 52.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="10" y="101" width="25" height="25"/>
+    <text id="LabelB" class="B Label" x="60.5" y="115.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 45.5,113.5 H 52.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="10" y="129" width="25" height="25"/>
+    <text id="LabelC" class="C Label" x="60.5" y="143.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 45.5,141.5 H 52.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="10" y="157" width="25" height="25"/>
+    <text id="LabelD" class="D Label" x="60.5" y="171.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 45.5,169.5 H 52.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="7" y="185" width="30" height="30"/>
+    <text id="LabelE" class="E Label" x="60.0" y="202" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 45.0,200.0 H 52.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="6" y="216" width="32" height="32"/>
+    <text id="LabelF" class="F Label" x="60.0" y="234" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 45.0,232.0 H 52.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="10" y="252" width="25" height="25"/>
+    <text id="LabelG" class="G Label" x="60.5" y="266.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 45.5,264.5 H 52.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="10" y="280" width="25" height="25"/>
+    <text id="LabelH" class="H Label" x="60.5" y="294.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 45.5,292.5 H 52.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="10" y="308" width="25" height="25"/>
+    <text id="LabelI" class="I Label" x="60.5" y="322.5" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 45.5,320.5 H 52.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="10" y="336" width="25" height="25"/>
+    <text id="LabelJ" class="J Label" x="60.5" y="350.5" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 45.5,348.5 H 52.5" id="LeaderJ" class="Leader J"/>
+  </g>
 </svg>

--- a/data/layouts/huion-kamvas-162019.svg
+++ b/data/layouts/huion-kamvas-162019.svg
@@ -1,194 +1,76 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-kamvas-162019"
-        width="704"
-        height="430">
-    <title id="title">KAMVAS 16(2019)</title>
-    <rect x="86" y="60" width="558" height="311" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="23"
-                      y="53"
-                      width="16"
-                      height="12" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="29"
-                      y="61"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="9"
-                      y="67"
-                      width="12"
-                      height="16" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="13"
-                      y="77"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="23"
-                      y="67"
-                      width="16"
-                      height="16" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="29"
-                      y="77"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="41"
-                      y="67"
-                      width="12"
-                      height="16" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="45"
-                      y="77"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="23"
-                      y="85"
-                      width="16"
-                      height="12" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="29"
-                      y="93"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="22"
-                      y="106"
-                      width="16"
-                      height="16" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="28"
-                      y="116"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="22"
-                      y="131"
-                      width="16"
-                      height="16" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="28"
-                      y="141"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="22"
-                      y="284"
-                      width="16"
-                      height="16" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="28"
-                      y="294"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="22"
-                      y="309"
-                      width="16"
-                      height="16" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="28"
-                      y="319"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="22"
-                      y="333"
-                      width="16"
-                      height="12" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="28"
-                      y="341"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="8"
-                      y="348"
-                      width="12"
-                      height="16" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="12"
-                      y="358"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="22"
-                      y="348"
-                      width="16"
-                      height="16" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="28"
-                      y="358"
-                      style="text-anchor:start;">L</text>
-            </g>
-            <g>
-                <rect id="ButtonM"
-                      class="M Button"
-                      x="40"
-                      y="348"
-                      width="12"
-                      height="16" />
-                <text id="LabelM"
-                      class="M Label"
-                      x="44"
-                      y="358"
-                      style="text-anchor:start;">M</text>
-            </g>
-            <g>
-                <rect id="ButtonN"
-                      class="N Button"
-                      x="22"
-                      y="367"
-                      width="16"
-                      height="12" />
-                <text id="LabelN"
-                      class="N Label"
-                      x="28"
-                      y="375"
-                      style="text-anchor:start;">N</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-kamvas-162019" width="704" height="430">
+  <title id="title">KAMVAS 16(2019)</title>
+  <rect x="86" y="60" width="558" height="311"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="23" y="53" width="16" height="12"/>
+    <text id="LabelA" class="A Label" x="29" y="31.0" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 31.0,46.0 V 39.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="9" y="67" width="12" height="16"/>
+    <text id="LabelB" class="B Label" x="13" y="47.0" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 15.0,62.0 V 55.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="23" y="67" width="16" height="16"/>
+    <text id="LabelC" class="C Label" x="69.0" y="77" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 54.0,75.0 H 61.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="41" y="67" width="12" height="16"/>
+    <text id="LabelD" class="D Label" x="45" y="47.0" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 47.0,62.0 V 55.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="23" y="85" width="16" height="12"/>
+    <text id="LabelE" class="E Label" x="69.0" y="93" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 54.0,91.0 H 61.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="22" y="106" width="16" height="16"/>
+    <text id="LabelF" class="F Label" x="68.0" y="116" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 53.0,114.0 H 60.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="22" y="131" width="16" height="16"/>
+    <text id="LabelG" class="G Label" x="68.0" y="141" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 53.0,139.0 H 60.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="22" y="284" width="16" height="16"/>
+    <text id="LabelH" class="H Label" x="68.0" y="294" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 53.0,292.0 H 60.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="22" y="309" width="16" height="16"/>
+    <text id="LabelI" class="I Label" x="68.0" y="319" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 53.0,317.0 H 60.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="22" y="333" width="16" height="12"/>
+    <text id="LabelJ" class="J Label" x="68.0" y="341" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 53.0,339.0 H 60.0" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="8" y="348" width="12" height="16"/>
+    <text id="LabelK" class="K Label" x="12" y="388.0" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 14.0,373.0 V 380.0" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="22" y="348" width="16" height="16"/>
+    <text id="LabelL" class="L Label" x="68.0" y="358" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 53.0,356.0 H 60.0" id="LeaderL" class="Leader L"/>
+  </g>
+  <g>
+    <rect id="ButtonM" class="M Button" x="40" y="348" width="12" height="16"/>
+    <text id="LabelM" class="M Label" x="44" y="388.0" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 46.0,373.0 V 380.0" id="LeaderM" class="Leader M"/>
+  </g>
+  <g>
+    <rect id="ButtonN" class="N Button" x="22" y="367" width="16" height="12"/>
+    <text id="LabelN" class="N Label" x="28" y="405.0" style="text-anchor:start;">N</text>
+    <path style="fill:none" d="M 30.0,390.0 V 397.0" id="LeaderN" class="Leader N"/>
+  </g>
 </svg>

--- a/data/layouts/huion-kamvas-gt-156-2021.svg
+++ b/data/layouts/huion-kamvas-gt-156-2021.svg
@@ -1,142 +1,56 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-kamvas-gt-156-2021"
-        width="719"
-        height="430">
-    <title id="title">KAMVAS GT-156 (2021)</title>
-    <rect x="81" y="50" width="590" height="328" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="8"
-                      y="72"
-                      width="26"
-                      height="26" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="19"
-                      y="87"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="8"
-                      y="99"
-                      width="26"
-                      height="26" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="19"
-                      y="114"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="8"
-                      y="126"
-                      width="26"
-                      height="26" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="19"
-                      y="141"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="8"
-                      y="153"
-                      width="26"
-                      height="26" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="19"
-                      y="168"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="8"
-                      y="189"
-                      width="26"
-                      height="26" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="19"
-                      y="204"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="8"
-                      y="218"
-                      width="26"
-                      height="26" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="19"
-                      y="233"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="8"
-                      y="252"
-                      width="26"
-                      height="26" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="19"
-                      y="267"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="8"
-                      y="279"
-                      width="26"
-                      height="26" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="19"
-                      y="294"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="8"
-                      y="306"
-                      width="26"
-                      height="26" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="19"
-                      y="321"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="8"
-                      y="333"
-                      width="26"
-                      height="26" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="19"
-                      y="348"
-                      style="text-anchor:start;">J</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-kamvas-gt-156-2021" width="719" height="430">
+  <title id="title">KAMVAS GT-156 (2021)</title>
+  <rect x="81" y="50" width="590" height="328"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="8" y="72" width="26" height="26"/>
+    <text id="LabelA" class="A Label" x="59.0" y="87" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 44.0,85.0 H 51.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="8" y="99" width="26" height="26"/>
+    <text id="LabelB" class="B Label" x="59.0" y="114" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 44.0,112.0 H 51.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="8" y="126" width="26" height="26"/>
+    <text id="LabelC" class="C Label" x="59.0" y="141" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 44.0,139.0 H 51.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="8" y="153" width="26" height="26"/>
+    <text id="LabelD" class="D Label" x="59.0" y="168" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 44.0,166.0 H 51.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="8" y="189" width="26" height="26"/>
+    <text id="LabelE" class="E Label" x="59.0" y="204" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 44.0,202.0 H 51.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="8" y="218" width="26" height="26"/>
+    <text id="LabelF" class="F Label" x="59.0" y="233" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 44.0,231.0 H 51.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="8" y="252" width="26" height="26"/>
+    <text id="LabelG" class="G Label" x="59.0" y="267" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 44.0,265.0 H 51.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="8" y="279" width="26" height="26"/>
+    <text id="LabelH" class="H Label" x="59.0" y="294" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 44.0,292.0 H 51.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="8" y="306" width="26" height="26"/>
+    <text id="LabelI" class="I Label" x="59.0" y="321" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 44.0,319.0 H 51.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="8" y="333" width="26" height="26"/>
+    <text id="LabelJ" class="J Label" x="59.0" y="348" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 44.0,346.0 H 51.0" id="LeaderJ" class="Leader J"/>
+  </g>
 </svg>

--- a/data/layouts/huion-kamvas-gt-156hd-v2.svg
+++ b/data/layouts/huion-kamvas-gt-156hd-v2.svg
@@ -1,194 +1,76 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-kamvas-gt-156hd-v2"
-        width="704"
-        height="430">
-    <title id="title">KAMVAS GT-156HD V2</title>
-    <rect x="86" y="60" width="558" height="311" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="23"
-                      y="53"
-                      width="16"
-                      height="12" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="29"
-                      y="61"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="9"
-                      y="67"
-                      width="12"
-                      height="16" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="13"
-                      y="77"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="23"
-                      y="67"
-                      width="16"
-                      height="16" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="29"
-                      y="77"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="41"
-                      y="67"
-                      width="12"
-                      height="16" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="45"
-                      y="77"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="23"
-                      y="85"
-                      width="16"
-                      height="12" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="29"
-                      y="93"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="22"
-                      y="106"
-                      width="16"
-                      height="16" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="28"
-                      y="116"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="22"
-                      y="131"
-                      width="16"
-                      height="16" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="28"
-                      y="141"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="22"
-                      y="284"
-                      width="16"
-                      height="16" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="28"
-                      y="294"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="22"
-                      y="309"
-                      width="16"
-                      height="16" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="28"
-                      y="319"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="22"
-                      y="333"
-                      width="16"
-                      height="12" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="28"
-                      y="341"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="8"
-                      y="348"
-                      width="12"
-                      height="16" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="12"
-                      y="358"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="22"
-                      y="348"
-                      width="16"
-                      height="16" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="28"
-                      y="358"
-                      style="text-anchor:start;">L</text>
-            </g>
-            <g>
-                <rect id="ButtonM"
-                      class="M Button"
-                      x="40"
-                      y="348"
-                      width="12"
-                      height="16" />
-                <text id="LabelM"
-                      class="M Label"
-                      x="44"
-                      y="358"
-                      style="text-anchor:start;">M</text>
-            </g>
-            <g>
-                <rect id="ButtonN"
-                      class="N Button"
-                      x="22"
-                      y="367"
-                      width="16"
-                      height="12" />
-                <text id="LabelN"
-                      class="N Label"
-                      x="28"
-                      y="375"
-                      style="text-anchor:start;">N</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-kamvas-gt-156hd-v2" width="704" height="430">
+  <title id="title">KAMVAS GT-156HD V2</title>
+  <rect x="86" y="60" width="558" height="311"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="23" y="53" width="16" height="12"/>
+    <text id="LabelA" class="A Label" x="29" y="31.0" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 31.0,46.0 V 39.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="9" y="67" width="12" height="16"/>
+    <text id="LabelB" class="B Label" x="13" y="47.0" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 15.0,62.0 V 55.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="23" y="67" width="16" height="16"/>
+    <text id="LabelC" class="C Label" x="69.0" y="77" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 54.0,75.0 H 61.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="41" y="67" width="12" height="16"/>
+    <text id="LabelD" class="D Label" x="45" y="47.0" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 47.0,62.0 V 55.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="23" y="85" width="16" height="12"/>
+    <text id="LabelE" class="E Label" x="69.0" y="93" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 54.0,91.0 H 61.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="22" y="106" width="16" height="16"/>
+    <text id="LabelF" class="F Label" x="68.0" y="116" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 53.0,114.0 H 60.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="22" y="131" width="16" height="16"/>
+    <text id="LabelG" class="G Label" x="68.0" y="141" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 53.0,139.0 H 60.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="22" y="284" width="16" height="16"/>
+    <text id="LabelH" class="H Label" x="68.0" y="294" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 53.0,292.0 H 60.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="22" y="309" width="16" height="16"/>
+    <text id="LabelI" class="I Label" x="68.0" y="319" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 53.0,317.0 H 60.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="22" y="333" width="16" height="12"/>
+    <text id="LabelJ" class="J Label" x="68.0" y="341" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 53.0,339.0 H 60.0" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="8" y="348" width="12" height="16"/>
+    <text id="LabelK" class="K Label" x="12" y="388.0" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 14.0,373.0 V 380.0" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="22" y="348" width="16" height="16"/>
+    <text id="LabelL" class="L Label" x="68.0" y="358" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 53.0,356.0 H 60.0" id="LeaderL" class="Leader L"/>
+  </g>
+  <g>
+    <rect id="ButtonM" class="M Button" x="40" y="348" width="12" height="16"/>
+    <text id="LabelM" class="M Label" x="44" y="388.0" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 46.0,373.0 V 380.0" id="LeaderM" class="Leader M"/>
+  </g>
+  <g>
+    <rect id="ButtonN" class="N Button" x="22" y="367" width="16" height="12"/>
+    <text id="LabelN" class="N Label" x="28" y="405.0" style="text-anchor:start;">N</text>
+    <path style="fill:none" d="M 30.0,390.0 V 397.0" id="LeaderN" class="Leader N"/>
+  </g>
 </svg>

--- a/data/layouts/huion-kamvas-gt-221-pro.svg
+++ b/data/layouts/huion-kamvas-gt-221-pro.svg
@@ -1,272 +1,106 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-kamvas-gt-221-pro"
-        width="736"
-        height="430">
-    <title id="title">KAMVAS  GT-221 Pro</title>
-    <rect x="69" y="43" width="598" height="338" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="12"
-                      y="68"
-                      width="28"
-                      height="14" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="24"
-                      y="77"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="12"
-                      y="86"
-                      width="28"
-                      height="14" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="24"
-                      y="95"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="12"
-                      y="105"
-                      width="28"
-                      height="14" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="24"
-                      y="114"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="12"
-                      y="123"
-                      width="28"
-                      height="14" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="24"
-                      y="132"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="12"
-                      y="143"
-                      width="28"
-                      height="14" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="24"
-                      y="152"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="11"
-                      y="268"
-                      width="28"
-                      height="14" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="23"
-                      y="277"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="11"
-                      y="288"
-                      width="28"
-                      height="14" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="23"
-                      y="297"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="11"
-                      y="307"
-                      width="28"
-                      height="14" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="23"
-                      y="316"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="11"
-                      y="325"
-                      width="28"
-                      height="14" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="23"
-                      y="334"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="11"
-                      y="344"
-                      width="28"
-                      height="14" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="23"
-                      y="353"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="696"
-                      y="68"
-                      width="28"
-                      height="14" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="708"
-                      y="77"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="696"
-                      y="87"
-                      width="28"
-                      height="14" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="708"
-                      y="96"
-                      style="text-anchor:start;">L</text>
-            </g>
-            <g>
-                <rect id="ButtonM"
-                      class="M Button"
-                      x="696"
-                      y="106"
-                      width="28"
-                      height="14" />
-                <text id="LabelM"
-                      class="M Label"
-                      x="708"
-                      y="115"
-                      style="text-anchor:start;">M</text>
-            </g>
-            <g>
-                <rect id="ButtonN"
-                      class="N Button"
-                      x="696"
-                      y="126"
-                      width="28"
-                      height="14" />
-                <text id="LabelN"
-                      class="N Label"
-                      x="708"
-                      y="135"
-                      style="text-anchor:start;">N</text>
-            </g>
-            <g>
-                <rect id="ButtonO"
-                      class="O Button"
-                      x="696"
-                      y="146"
-                      width="28"
-                      height="14" />
-                <text id="LabelO"
-                      class="O Label"
-                      x="708"
-                      y="155"
-                      style="text-anchor:start;">O</text>
-            </g>
-            <g>
-                <rect id="ButtonP"
-                      class="P Button"
-                      x="695"
-                      y="267"
-                      width="28"
-                      height="14" />
-                <text id="LabelP"
-                      class="P Label"
-                      x="707"
-                      y="276"
-                      style="text-anchor:start;">P</text>
-            </g>
-            <g>
-                <rect id="ButtonQ"
-                      class="Q Button"
-                      x="695"
-                      y="286"
-                      width="28"
-                      height="14" />
-                <text id="LabelQ"
-                      class="Q Label"
-                      x="707"
-                      y="295"
-                      style="text-anchor:start;">Q</text>
-            </g>
-            <g>
-                <rect id="ButtonR"
-                      class="R Button"
-                      x="695"
-                      y="306"
-                      width="28"
-                      height="14" />
-                <text id="LabelR"
-                      class="R Label"
-                      x="707"
-                      y="315"
-                      style="text-anchor:start;">R</text>
-            </g>
-            <g>
-                <rect id="ButtonS"
-                      class="S Button"
-                      x="695"
-                      y="325"
-                      width="28"
-                      height="14" />
-                <text id="LabelS"
-                      class="S Label"
-                      x="707"
-                      y="334"
-                      style="text-anchor:start;">S</text>
-            </g>
-            <g>
-                <rect id="ButtonT"
-                      class="T Button"
-                      x="695"
-                      y="345"
-                      width="28"
-                      height="14" />
-                <text id="LabelT"
-                      class="T Label"
-                      x="707"
-                      y="354"
-                      style="text-anchor:start;">T</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-kamvas-gt-221-pro" width="736" height="430">
+  <title id="title">KAMVAS  GT-221 Pro</title>
+  <rect x="69" y="43" width="598" height="338"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="12" y="68" width="28" height="14"/>
+    <text id="LabelA" class="A Label" x="64.0" y="77" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 49.0,75.0 H 56.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="12" y="86" width="28" height="14"/>
+    <text id="LabelB" class="B Label" x="64.0" y="95" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 49.0,93.0 H 56.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="12" y="105" width="28" height="14"/>
+    <text id="LabelC" class="C Label" x="64.0" y="114" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 49.0,112.0 H 56.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="12" y="123" width="28" height="14"/>
+    <text id="LabelD" class="D Label" x="64.0" y="132" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 49.0,130.0 H 56.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="12" y="143" width="28" height="14"/>
+    <text id="LabelE" class="E Label" x="64.0" y="152" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 49.0,150.0 H 56.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="11" y="268" width="28" height="14"/>
+    <text id="LabelF" class="F Label" x="63.0" y="277" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 48.0,275.0 H 55.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="11" y="288" width="28" height="14"/>
+    <text id="LabelG" class="G Label" x="63.0" y="297" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 48.0,295.0 H 55.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="11" y="307" width="28" height="14"/>
+    <text id="LabelH" class="H Label" x="63.0" y="316" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 48.0,314.0 H 55.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="11" y="325" width="28" height="14"/>
+    <text id="LabelI" class="I Label" x="63.0" y="334" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 48.0,332.0 H 55.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="11" y="344" width="28" height="14"/>
+    <text id="LabelJ" class="J Label" x="63.0" y="353" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 48.0,351.0 H 55.0" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="696" y="68" width="28" height="14"/>
+    <text id="LabelK" class="K Label" x="748.0" y="77" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 733.0,75.0 H 740.0" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="696" y="87" width="28" height="14"/>
+    <text id="LabelL" class="L Label" x="748.0" y="96" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 733.0,94.0 H 740.0" id="LeaderL" class="Leader L"/>
+  </g>
+  <g>
+    <rect id="ButtonM" class="M Button" x="696" y="106" width="28" height="14"/>
+    <text id="LabelM" class="M Label" x="748.0" y="115" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 733.0,113.0 H 740.0" id="LeaderM" class="Leader M"/>
+  </g>
+  <g>
+    <rect id="ButtonN" class="N Button" x="696" y="126" width="28" height="14"/>
+    <text id="LabelN" class="N Label" x="748.0" y="135" style="text-anchor:start;">N</text>
+    <path style="fill:none" d="M 733.0,133.0 H 740.0" id="LeaderN" class="Leader N"/>
+  </g>
+  <g>
+    <rect id="ButtonO" class="O Button" x="696" y="146" width="28" height="14"/>
+    <text id="LabelO" class="O Label" x="748.0" y="155" style="text-anchor:start;">O</text>
+    <path style="fill:none" d="M 733.0,153.0 H 740.0" id="LeaderO" class="Leader O"/>
+  </g>
+  <g>
+    <rect id="ButtonP" class="P Button" x="695" y="267" width="28" height="14"/>
+    <text id="LabelP" class="P Label" x="747.0" y="276" style="text-anchor:start;">P</text>
+    <path style="fill:none" d="M 732.0,274.0 H 739.0" id="LeaderP" class="Leader P"/>
+  </g>
+  <g>
+    <rect id="ButtonQ" class="Q Button" x="695" y="286" width="28" height="14"/>
+    <text id="LabelQ" class="Q Label" x="747.0" y="295" style="text-anchor:start;">Q</text>
+    <path style="fill:none" d="M 732.0,293.0 H 739.0" id="LeaderQ" class="Leader Q"/>
+  </g>
+  <g>
+    <rect id="ButtonR" class="R Button" x="695" y="306" width="28" height="14"/>
+    <text id="LabelR" class="R Label" x="747.0" y="315" style="text-anchor:start;">R</text>
+    <path style="fill:none" d="M 732.0,313.0 H 739.0" id="LeaderR" class="Leader R"/>
+  </g>
+  <g>
+    <rect id="ButtonS" class="S Button" x="695" y="325" width="28" height="14"/>
+    <text id="LabelS" class="S Label" x="747.0" y="334" style="text-anchor:start;">S</text>
+    <path style="fill:none" d="M 732.0,332.0 H 739.0" id="LeaderS" class="Leader S"/>
+  </g>
+  <g>
+    <rect id="ButtonT" class="T Button" x="695" y="345" width="28" height="14"/>
+    <text id="LabelT" class="T Label" x="747.0" y="354" style="text-anchor:start;">T</text>
+    <path style="fill:none" d="M 732.0,352.0 H 739.0" id="LeaderT" class="Leader T"/>
+  </g>
 </svg>

--- a/data/layouts/huion-kamvas-pro-12-gt-116.svg
+++ b/data/layouts/huion-kamvas-pro-12-gt-116.svg
@@ -1,77 +1,31 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-kamvas-pro-12-gt-116"
-        width="750"
-        height="426">
-    <title id="title">KAMVAS Pro 12 GT-116</title>
-    <rect x="110" y="51" width="574" height="319" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="32"
-                      y="90"
-                      width="21"
-                      height="21" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="40.5"
-                      y="102.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="32"
-                      y="118"
-                      width="21"
-                      height="21" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="40.5"
-                      y="130.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="32"
-                      y="287"
-                      width="21"
-                      height="21" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="40.5"
-                      y="299.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="32"
-                      y="316"
-                      width="21"
-                      height="21" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="40.5"
-                      y="328.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="29"
-                      y="343"
-                      width="27"
-                      height="27" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="40.5"
-                      y="358.5"
-                      style="text-anchor:start;">E</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-kamvas-pro-12-gt-116" width="750" height="426">
+  <title id="title">KAMVAS Pro 12 GT-116</title>
+  <rect x="110" y="51" width="574" height="319"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="32" y="90" width="21" height="21"/>
+    <text id="LabelA" class="A Label" x="80.5" y="102.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 65.5,100.5 H 72.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="32" y="118" width="21" height="21"/>
+    <text id="LabelB" class="B Label" x="80.5" y="130.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 65.5,128.5 H 72.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="32" y="287" width="21" height="21"/>
+    <text id="LabelC" class="C Label" x="80.5" y="299.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 65.5,297.5 H 72.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="32" y="316" width="21" height="21"/>
+    <text id="LabelD" class="D Label" x="80.5" y="328.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 65.5,326.5 H 72.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="29" y="343" width="27" height="27"/>
+    <text id="LabelE" class="E Label" x="80.5" y="358.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 65.5,356.5 H 72.5" id="LeaderE" class="Leader E"/>
+  </g>
 </svg>

--- a/data/layouts/huion-kamvas-pro-13-gt1302.svg
+++ b/data/layouts/huion-kamvas-pro-13-gt1302.svg
@@ -1,103 +1,41 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-kamvas-pro-13-gt1302"
-        width="698"
-        height="430">
-    <title id="title">KAMVAS Pro 13 GT1302</title>
-    <rect x="112" y="46" width="540" height="340" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="28"
-                      y="75"
-                      width="28"
-                      height="38" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="40"
-                      y="96"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="28"
-                      y="116"
-                      width="28"
-                      height="38" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="40"
-                      y="137"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="28"
-                      y="156"
-                      width="28"
-                      height="38" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="40"
-                      y="177"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="28"
-                      y="196"
-                      width="28"
-                      height="38" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="40"
-                      y="217"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="28"
-                      y="237"
-                      width="28"
-                      height="38" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="40"
-                      y="258"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="28"
-                      y="277"
-                      width="28"
-                      height="38" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="40"
-                      y="298"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="28"
-                      y="316"
-                      width="28"
-                      height="38" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="40"
-                      y="337"
-                      style="text-anchor:start;">G</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-kamvas-pro-13-gt1302" width="698" height="430">
+  <title id="title">KAMVAS Pro 13 GT1302</title>
+  <rect x="112" y="46" width="540" height="340"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="28" y="75" width="28" height="38"/>
+    <text id="LabelA" class="A Label" x="80.0" y="96" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 65.0,94.0 H 72.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="28" y="116" width="28" height="38"/>
+    <text id="LabelB" class="B Label" x="80.0" y="137" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 65.0,135.0 H 72.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="28" y="156" width="28" height="38"/>
+    <text id="LabelC" class="C Label" x="80.0" y="177" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 65.0,175.0 H 72.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="28" y="196" width="28" height="38"/>
+    <text id="LabelD" class="D Label" x="80.0" y="217" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 65.0,215.0 H 72.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="28" y="237" width="28" height="38"/>
+    <text id="LabelE" class="E Label" x="80.0" y="258" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 65.0,256.0 H 72.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="28" y="277" width="28" height="38"/>
+    <text id="LabelF" class="F Label" x="80.0" y="298" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 65.0,296.0 H 72.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="28" y="316" width="28" height="38"/>
+    <text id="LabelG" class="G Label" x="80.0" y="337" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 65.0,335.0 H 72.0" id="LeaderG" class="Leader G"/>
+  </g>
 </svg>

--- a/data/layouts/huion-kamvas-pro-16-gt-156.svg
+++ b/data/layouts/huion-kamvas-pro-16-gt-156.svg
@@ -1,103 +1,41 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-kamvas-pro-16-gt-156"
-        width="750"
-        height="430">
-    <title id="title">KAMVAS Pro 16 GT-156</title>
-    <rect x="99" y="47" width="593" height="334" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="28"
-                      y="87"
-                      width="19"
-                      height="19" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="35.5"
-                      y="98.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="28"
-                      y="112"
-                      width="19"
-                      height="19" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="35.5"
-                      y="123.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="28"
-                      y="136"
-                      width="19"
-                      height="19" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="35.5"
-                      y="147.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="28"
-                      y="276"
-                      width="19"
-                      height="19" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="35.5"
-                      y="287.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="28"
-                      y="300"
-                      width="19"
-                      height="19" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="35.5"
-                      y="311.5"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="28"
-                      y="324"
-                      width="19"
-                      height="19" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="35.5"
-                      y="335.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="26"
-                      y="347"
-                      width="24"
-                      height="24" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="36"
-                      y="361"
-                      style="text-anchor:start;">G</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-kamvas-pro-16-gt-156" width="750" height="430">
+  <title id="title">KAMVAS Pro 16 GT-156</title>
+  <rect x="99" y="47" width="593" height="334"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="28" y="87" width="19" height="19"/>
+    <text id="LabelA" class="A Label" x="75.5" y="98.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 60.5,96.5 H 67.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="28" y="112" width="19" height="19"/>
+    <text id="LabelB" class="B Label" x="75.5" y="123.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 60.5,121.5 H 67.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="28" y="136" width="19" height="19"/>
+    <text id="LabelC" class="C Label" x="75.5" y="147.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 60.5,145.5 H 67.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="28" y="276" width="19" height="19"/>
+    <text id="LabelD" class="D Label" x="75.5" y="287.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 60.5,285.5 H 67.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="28" y="300" width="19" height="19"/>
+    <text id="LabelE" class="E Label" x="75.5" y="311.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 60.5,309.5 H 67.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="28" y="324" width="19" height="19"/>
+    <text id="LabelF" class="F Label" x="75.5" y="335.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 60.5,333.5 H 67.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="26" y="347" width="24" height="24"/>
+    <text id="LabelG" class="G Label" x="76.0" y="361" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 61.0,359.0 H 68.0" id="LeaderG" class="Leader G"/>
+  </g>
 </svg>

--- a/data/layouts/huion-kamvas-pro-16-gt1602.svg
+++ b/data/layouts/huion-kamvas-pro-16-gt1602.svg
@@ -1,116 +1,46 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-kamvas-pro-16-gt1602"
-        width="750"
-        height="426">
-    <title id="title">KAMVAS Pro 16 GT1602</title>
-    <rect x="105" y="45" width="602" height="339" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="27"
-                      y="68"
-                      width="26"
-                      height="34" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="38"
-                      y="87"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="27"
-                      y="104"
-                      width="26"
-                      height="34" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="38"
-                      y="123"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="27"
-                      y="140"
-                      width="26"
-                      height="34" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="38"
-                      y="159"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="27"
-                      y="176"
-                      width="26"
-                      height="34" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="38"
-                      y="195"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="27"
-                      y="212"
-                      width="26"
-                      height="34" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="38"
-                      y="231"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="27"
-                      y="248"
-                      width="26"
-                      height="34" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="38"
-                      y="267"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="27"
-                      y="284"
-                      width="26"
-                      height="34" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="38"
-                      y="303"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="27"
-                      y="320"
-                      width="26"
-                      height="34" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="38"
-                      y="339"
-                      style="text-anchor:start;">H</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-kamvas-pro-16-gt1602" width="750" height="426">
+  <title id="title">KAMVAS Pro 16 GT1602</title>
+  <rect x="105" y="45" width="602" height="339"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="27" y="68" width="26" height="34"/>
+    <text id="LabelA" class="A Label" x="78.0" y="87" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 63.0,85.0 H 70.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="27" y="104" width="26" height="34"/>
+    <text id="LabelB" class="B Label" x="78.0" y="123" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 63.0,121.0 H 70.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="27" y="140" width="26" height="34"/>
+    <text id="LabelC" class="C Label" x="78.0" y="159" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 63.0,157.0 H 70.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="27" y="176" width="26" height="34"/>
+    <text id="LabelD" class="D Label" x="78.0" y="195" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 63.0,193.0 H 70.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="27" y="212" width="26" height="34"/>
+    <text id="LabelE" class="E Label" x="78.0" y="231" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 63.0,229.0 H 70.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="27" y="248" width="26" height="34"/>
+    <text id="LabelF" class="F Label" x="78.0" y="267" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 63.0,265.0 H 70.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="27" y="284" width="26" height="34"/>
+    <text id="LabelG" class="G Label" x="78.0" y="303" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 63.0,301.0 H 70.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="27" y="320" width="26" height="34"/>
+    <text id="LabelH" class="H Label" x="78.0" y="339" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 63.0,337.0 H 70.0" id="LeaderH" class="Leader H"/>
+  </g>
 </svg>

--- a/data/layouts/huion-kamvas-pro-20-gt-192.svg
+++ b/data/layouts/huion-kamvas-pro-20-gt-192.svg
@@ -1,220 +1,86 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-kamvas-pro-20-gt-192"
-        width="763"
-        height="430">
-    <title id="title">KAMVAS Pro 20 GT-192</title>
-    <rect x="86" y="52" width="591" height="325" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="15"
-                      y="72"
-                      width="33"
-                      height="21" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="29.5"
-                      y="84.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="15"
-                      y="95"
-                      width="33"
-                      height="19" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="29.5"
-                      y="106.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="15"
-                      y="117"
-                      width="33"
-                      height="19" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="29.5"
-                      y="128.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="15"
-                      y="139"
-                      width="33"
-                      height="19" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="29.5"
-                      y="150.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="14"
-                      y="278"
-                      width="33"
-                      height="18" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="28.5"
-                      y="289"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="14"
-                      y="298"
-                      width="33"
-                      height="19" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="28.5"
-                      y="309.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="14"
-                      y="319"
-                      width="33"
-                      height="19" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="28.5"
-                      y="330.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="14"
-                      y="340"
-                      width="33"
-                      height="19" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="28.5"
-                      y="351.5"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="719"
-                      y="71"
-                      width="33"
-                      height="21" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="733.5"
-                      y="83.5"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="719"
-                      y="94"
-                      width="33"
-                      height="19" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="733.5"
-                      y="105.5"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="719"
-                      y="115"
-                      width="33"
-                      height="19" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="733.5"
-                      y="126.5"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="719"
-                      y="136"
-                      width="33"
-                      height="21" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="733.5"
-                      y="148.5"
-                      style="text-anchor:start;">L</text>
-            </g>
-            <g>
-                <rect id="ButtonM"
-                      class="M Button"
-                      x="719"
-                      y="276"
-                      width="33"
-                      height="21" />
-                <text id="LabelM"
-                      class="M Label"
-                      x="733.5"
-                      y="288.5"
-                      style="text-anchor:start;">M</text>
-            </g>
-            <g>
-                <rect id="ButtonN"
-                      class="N Button"
-                      x="719"
-                      y="299"
-                      width="33"
-                      height="19" />
-                <text id="LabelN"
-                      class="N Label"
-                      x="733.5"
-                      y="310.5"
-                      style="text-anchor:start;">N</text>
-            </g>
-            <g>
-                <rect id="ButtonO"
-                      class="O Button"
-                      x="719"
-                      y="320"
-                      width="33"
-                      height="19" />
-                <text id="LabelO"
-                      class="O Label"
-                      x="733.5"
-                      y="331.5"
-                      style="text-anchor:start;">O</text>
-            </g>
-            <g>
-                <rect id="ButtonP"
-                      class="P Button"
-                      x="719"
-                      y="341"
-                      width="33"
-                      height="21" />
-                <text id="LabelP"
-                      class="P Label"
-                      x="733.5"
-                      y="353.5"
-                      style="text-anchor:start;">P</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-kamvas-pro-20-gt-192" width="763" height="430">
+  <title id="title">KAMVAS Pro 20 GT-192</title>
+  <rect x="86" y="52" width="591" height="325"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="15" y="72" width="33" height="21"/>
+    <text id="LabelA" class="A Label" x="69.5" y="84.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 54.5,82.5 H 61.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="15" y="95" width="33" height="19"/>
+    <text id="LabelB" class="B Label" x="69.5" y="106.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 54.5,104.5 H 61.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="15" y="117" width="33" height="19"/>
+    <text id="LabelC" class="C Label" x="69.5" y="128.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 54.5,126.5 H 61.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="15" y="139" width="33" height="19"/>
+    <text id="LabelD" class="D Label" x="69.5" y="150.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 54.5,148.5 H 61.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="14" y="278" width="33" height="18"/>
+    <text id="LabelE" class="E Label" x="68.5" y="289" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 53.5,287.0 H 60.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="14" y="298" width="33" height="19"/>
+    <text id="LabelF" class="F Label" x="68.5" y="309.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 53.5,307.5 H 60.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="14" y="319" width="33" height="19"/>
+    <text id="LabelG" class="G Label" x="68.5" y="330.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 53.5,328.5 H 60.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="14" y="340" width="33" height="19"/>
+    <text id="LabelH" class="H Label" x="68.5" y="351.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 53.5,349.5 H 60.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="719" y="71" width="33" height="21"/>
+    <text id="LabelI" class="I Label" x="693.5" y="83.5" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 711.5,81.5 H 703.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="719" y="94" width="33" height="19"/>
+    <text id="LabelJ" class="J Label" x="693.5" y="105.5" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 711.5,103.5 H 703.5" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="719" y="115" width="33" height="19"/>
+    <text id="LabelK" class="K Label" x="693.5" y="126.5" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 711.5,124.5 H 703.5" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="719" y="136" width="33" height="21"/>
+    <text id="LabelL" class="L Label" x="693.5" y="148.5" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 711.5,146.5 H 703.5" id="LeaderL" class="Leader L"/>
+  </g>
+  <g>
+    <rect id="ButtonM" class="M Button" x="719" y="276" width="33" height="21"/>
+    <text id="LabelM" class="M Label" x="693.5" y="288.5" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 711.5,286.5 H 703.5" id="LeaderM" class="Leader M"/>
+  </g>
+  <g>
+    <rect id="ButtonN" class="N Button" x="719" y="299" width="33" height="19"/>
+    <text id="LabelN" class="N Label" x="693.5" y="310.5" style="text-anchor:start;">N</text>
+    <path style="fill:none" d="M 711.5,308.5 H 703.5" id="LeaderN" class="Leader N"/>
+  </g>
+  <g>
+    <rect id="ButtonO" class="O Button" x="719" y="320" width="33" height="19"/>
+    <text id="LabelO" class="O Label" x="693.5" y="331.5" style="text-anchor:start;">O</text>
+    <path style="fill:none" d="M 711.5,329.5 H 703.5" id="LeaderO" class="Leader O"/>
+  </g>
+  <g>
+    <rect id="ButtonP" class="P Button" x="719" y="341" width="33" height="21"/>
+    <text id="LabelP" class="P Label" x="693.5" y="353.5" style="text-anchor:start;">P</text>
+    <path style="fill:none" d="M 711.5,351.5 H 703.5" id="LeaderP" class="Leader P"/>
+  </g>
 </svg>

--- a/data/layouts/huion-kamvas-pro-20-gt1901.svg
+++ b/data/layouts/huion-kamvas-pro-20-gt1901.svg
@@ -1,220 +1,86 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-kamvas-pro-20-gt1901"
-        width="763"
-        height="430">
-    <title id="title">KAMVAS Pro 20 GT1901</title>
-    <rect x="86" y="52" width="592" height="325" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="14"
-                      y="72"
-                      width="33"
-                      height="21" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="28.5"
-                      y="84.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="14"
-                      y="95"
-                      width="33"
-                      height="19" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="28.5"
-                      y="106.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="14"
-                      y="116"
-                      width="33"
-                      height="19" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="28.5"
-                      y="127.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="14"
-                      y="137"
-                      width="33"
-                      height="19" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="28.5"
-                      y="148.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="14"
-                      y="277"
-                      width="33"
-                      height="18" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="28.5"
-                      y="288"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="14"
-                      y="298"
-                      width="33"
-                      height="19" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="28.5"
-                      y="309.5"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="14"
-                      y="320"
-                      width="33"
-                      height="19" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="28.5"
-                      y="331.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="14"
-                      y="341"
-                      width="33"
-                      height="19" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="28.5"
-                      y="352.5"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="719"
-                      y="71"
-                      width="33"
-                      height="21" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="733.5"
-                      y="83.5"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="719"
-                      y="94"
-                      width="33"
-                      height="19" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="733.5"
-                      y="105.5"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="719"
-                      y="115"
-                      width="33"
-                      height="19" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="733.5"
-                      y="126.5"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="719"
-                      y="136"
-                      width="33"
-                      height="21" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="733.5"
-                      y="148.5"
-                      style="text-anchor:start;">L</text>
-            </g>
-            <g>
-                <rect id="ButtonM"
-                      class="M Button"
-                      x="718"
-                      y="275"
-                      width="33"
-                      height="21" />
-                <text id="LabelM"
-                      class="M Label"
-                      x="732.5"
-                      y="287.5"
-                      style="text-anchor:start;">M</text>
-            </g>
-            <g>
-                <rect id="ButtonN"
-                      class="N Button"
-                      x="718"
-                      y="299"
-                      width="33"
-                      height="19" />
-                <text id="LabelN"
-                      class="N Label"
-                      x="732.5"
-                      y="310.5"
-                      style="text-anchor:start;">N</text>
-            </g>
-            <g>
-                <rect id="ButtonO"
-                      class="O Button"
-                      x="718"
-                      y="321"
-                      width="33"
-                      height="19" />
-                <text id="LabelO"
-                      class="O Label"
-                      x="732.5"
-                      y="332.5"
-                      style="text-anchor:start;">O</text>
-            </g>
-            <g>
-                <rect id="ButtonP"
-                      class="P Button"
-                      x="718"
-                      y="343"
-                      width="33"
-                      height="21" />
-                <text id="LabelP"
-                      class="P Label"
-                      x="732.5"
-                      y="355.5"
-                      style="text-anchor:start;">P</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-kamvas-pro-20-gt1901" width="763" height="430">
+  <title id="title">KAMVAS Pro 20 GT1901</title>
+  <rect x="86" y="52" width="592" height="325"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="14" y="72" width="33" height="21"/>
+    <text id="LabelA" class="A Label" x="68.5" y="84.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 53.5,82.5 H 60.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="14" y="95" width="33" height="19"/>
+    <text id="LabelB" class="B Label" x="68.5" y="106.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 53.5,104.5 H 60.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="14" y="116" width="33" height="19"/>
+    <text id="LabelC" class="C Label" x="68.5" y="127.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 53.5,125.5 H 60.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="14" y="137" width="33" height="19"/>
+    <text id="LabelD" class="D Label" x="68.5" y="148.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 53.5,146.5 H 60.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="14" y="277" width="33" height="18"/>
+    <text id="LabelE" class="E Label" x="68.5" y="288" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 53.5,286.0 H 60.5" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="14" y="298" width="33" height="19"/>
+    <text id="LabelF" class="F Label" x="68.5" y="309.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 53.5,307.5 H 60.5" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="14" y="320" width="33" height="19"/>
+    <text id="LabelG" class="G Label" x="68.5" y="331.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 53.5,329.5 H 60.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="14" y="341" width="33" height="19"/>
+    <text id="LabelH" class="H Label" x="68.5" y="352.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 53.5,350.5 H 60.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="719" y="71" width="33" height="21"/>
+    <text id="LabelI" class="I Label" x="773.5" y="83.5" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 758.5,81.5 H 765.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="719" y="94" width="33" height="19"/>
+    <text id="LabelJ" class="J Label" x="773.5" y="105.5" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 758.5,103.5 H 765.5" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="719" y="115" width="33" height="19"/>
+    <text id="LabelK" class="K Label" x="773.5" y="126.5" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 758.5,124.5 H 765.5" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="719" y="136" width="33" height="21"/>
+    <text id="LabelL" class="L Label" x="773.5" y="148.5" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 758.5,146.5 H 765.5" id="LeaderL" class="Leader L"/>
+  </g>
+  <g>
+    <rect id="ButtonM" class="M Button" x="718" y="275" width="33" height="21"/>
+    <text id="LabelM" class="M Label" x="772.5" y="287.5" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 757.5,285.5 H 764.5" id="LeaderM" class="Leader M"/>
+  </g>
+  <g>
+    <rect id="ButtonN" class="N Button" x="718" y="299" width="33" height="19"/>
+    <text id="LabelN" class="N Label" x="772.5" y="310.5" style="text-anchor:start;">N</text>
+    <path style="fill:none" d="M 757.5,308.5 H 764.5" id="LeaderN" class="Leader N"/>
+  </g>
+  <g>
+    <rect id="ButtonO" class="O Button" x="718" y="321" width="33" height="19"/>
+    <text id="LabelO" class="O Label" x="772.5" y="332.5" style="text-anchor:start;">O</text>
+    <path style="fill:none" d="M 757.5,330.5 H 764.5" id="LeaderO" class="Leader O"/>
+  </g>
+  <g>
+    <rect id="ButtonP" class="P Button" x="718" y="343" width="33" height="21"/>
+    <text id="LabelP" class="P Label" x="772.5" y="355.5" style="text-anchor:start;">P</text>
+    <path style="fill:none" d="M 757.5,353.5 H 764.5" id="LeaderP" class="Leader P"/>
+  </g>
 </svg>

--- a/data/layouts/huion-kamvas-pro-22-gt-221.svg
+++ b/data/layouts/huion-kamvas-pro-22-gt-221.svg
@@ -1,272 +1,106 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-kamvas-pro-22-gt-221"
-        width="725"
-        height="430">
-    <title id="title">KAMVAS Pro 22 GT-221</title>
-    <rect x="72" y="48" width="582" height="327" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="10"
-                      y="82"
-                      width="28"
-                      height="14" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="22"
-                      y="91"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="10"
-                      y="100"
-                      width="28"
-                      height="14" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="22"
-                      y="109"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="10"
-                      y="117"
-                      width="28"
-                      height="14" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="22"
-                      y="126"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="10"
-                      y="134"
-                      width="28"
-                      height="14" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="22"
-                      y="143"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="10"
-                      y="152"
-                      width="28"
-                      height="14" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="22"
-                      y="161"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="10"
-                      y="257"
-                      width="28"
-                      height="14" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="22"
-                      y="266"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="10"
-                      y="275"
-                      width="28"
-                      height="14" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="22"
-                      y="284"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="10"
-                      y="292"
-                      width="28"
-                      height="14" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="22"
-                      y="301"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="10"
-                      y="309"
-                      width="28"
-                      height="14" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="22"
-                      y="318"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="10"
-                      y="327"
-                      width="28"
-                      height="14" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="22"
-                      y="336"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="687"
-                      y="82"
-                      width="28"
-                      height="14" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="699"
-                      y="91"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="687"
-                      y="100"
-                      width="28"
-                      height="14" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="699"
-                      y="109"
-                      style="text-anchor:start;">L</text>
-            </g>
-            <g>
-                <rect id="ButtonM"
-                      class="M Button"
-                      x="687"
-                      y="117"
-                      width="28"
-                      height="14" />
-                <text id="LabelM"
-                      class="M Label"
-                      x="699"
-                      y="126"
-                      style="text-anchor:start;">M</text>
-            </g>
-            <g>
-                <rect id="ButtonN"
-                      class="N Button"
-                      x="687"
-                      y="134"
-                      width="28"
-                      height="14" />
-                <text id="LabelN"
-                      class="N Label"
-                      x="699"
-                      y="143"
-                      style="text-anchor:start;">N</text>
-            </g>
-            <g>
-                <rect id="ButtonO"
-                      class="O Button"
-                      x="687"
-                      y="152"
-                      width="28"
-                      height="14" />
-                <text id="LabelO"
-                      class="O Label"
-                      x="699"
-                      y="161"
-                      style="text-anchor:start;">O</text>
-            </g>
-            <g>
-                <rect id="ButtonP"
-                      class="P Button"
-                      x="687"
-                      y="257"
-                      width="28"
-                      height="14" />
-                <text id="LabelP"
-                      class="P Label"
-                      x="699"
-                      y="266"
-                      style="text-anchor:start;">P</text>
-            </g>
-            <g>
-                <rect id="ButtonQ"
-                      class="Q Button"
-                      x="687"
-                      y="275"
-                      width="28"
-                      height="14" />
-                <text id="LabelQ"
-                      class="Q Label"
-                      x="699"
-                      y="284"
-                      style="text-anchor:start;">Q</text>
-            </g>
-            <g>
-                <rect id="ButtonR"
-                      class="R Button"
-                      x="687"
-                      y="292"
-                      width="28"
-                      height="14" />
-                <text id="LabelR"
-                      class="R Label"
-                      x="699"
-                      y="301"
-                      style="text-anchor:start;">R</text>
-            </g>
-            <g>
-                <rect id="ButtonS"
-                      class="S Button"
-                      x="687"
-                      y="309"
-                      width="28"
-                      height="14" />
-                <text id="LabelS"
-                      class="S Label"
-                      x="699"
-                      y="318"
-                      style="text-anchor:start;">S</text>
-            </g>
-            <g>
-                <rect id="ButtonT"
-                      class="T Button"
-                      x="687"
-                      y="327"
-                      width="28"
-                      height="14" />
-                <text id="LabelT"
-                      class="T Label"
-                      x="699"
-                      y="336"
-                      style="text-anchor:start;">T</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-kamvas-pro-22-gt-221" width="725" height="430">
+  <title id="title">KAMVAS Pro 22 GT-221</title>
+  <rect x="72" y="48" width="582" height="327"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="10" y="82" width="28" height="14"/>
+    <text id="LabelA" class="A Label" x="62.0" y="91" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 47.0,89.0 H 54.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="10" y="100" width="28" height="14"/>
+    <text id="LabelB" class="B Label" x="62.0" y="109" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 47.0,107.0 H 54.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="10" y="117" width="28" height="14"/>
+    <text id="LabelC" class="C Label" x="62.0" y="126" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 47.0,124.0 H 54.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="10" y="134" width="28" height="14"/>
+    <text id="LabelD" class="D Label" x="62.0" y="143" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 47.0,141.0 H 54.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="10" y="152" width="28" height="14"/>
+    <text id="LabelE" class="E Label" x="62.0" y="161" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 47.0,159.0 H 54.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="10" y="257" width="28" height="14"/>
+    <text id="LabelF" class="F Label" x="62.0" y="266" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 47.0,264.0 H 54.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="10" y="275" width="28" height="14"/>
+    <text id="LabelG" class="G Label" x="62.0" y="284" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 47.0,282.0 H 54.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="10" y="292" width="28" height="14"/>
+    <text id="LabelH" class="H Label" x="62.0" y="301" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 47.0,299.0 H 54.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="10" y="309" width="28" height="14"/>
+    <text id="LabelI" class="I Label" x="62.0" y="318" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 47.0,316.0 H 54.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="10" y="327" width="28" height="14"/>
+    <text id="LabelJ" class="J Label" x="62.0" y="336" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 47.0,334.0 H 54.0" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="687" y="82" width="28" height="14"/>
+    <text id="LabelK" class="K Label" x="659.0" y="91" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 677.0,89.0 H 669.0" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="687" y="100" width="28" height="14"/>
+    <text id="LabelL" class="L Label" x="659.0" y="109" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 677.0,107.0 H 669.0" id="LeaderL" class="Leader L"/>
+  </g>
+  <g>
+    <rect id="ButtonM" class="M Button" x="687" y="117" width="28" height="14"/>
+    <text id="LabelM" class="M Label" x="659.0" y="126" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 677.0,124.0 H 669.0" id="LeaderM" class="Leader M"/>
+  </g>
+  <g>
+    <rect id="ButtonN" class="N Button" x="687" y="134" width="28" height="14"/>
+    <text id="LabelN" class="N Label" x="659.0" y="143" style="text-anchor:start;">N</text>
+    <path style="fill:none" d="M 677.0,141.0 H 669.0" id="LeaderN" class="Leader N"/>
+  </g>
+  <g>
+    <rect id="ButtonO" class="O Button" x="687" y="152" width="28" height="14"/>
+    <text id="LabelO" class="O Label" x="659.0" y="161" style="text-anchor:start;">O</text>
+    <path style="fill:none" d="M 677.0,159.0 H 669.0" id="LeaderO" class="Leader O"/>
+  </g>
+  <g>
+    <rect id="ButtonP" class="P Button" x="687" y="257" width="28" height="14"/>
+    <text id="LabelP" class="P Label" x="659.0" y="266" style="text-anchor:start;">P</text>
+    <path style="fill:none" d="M 677.0,264.0 H 669.0" id="LeaderP" class="Leader P"/>
+  </g>
+  <g>
+    <rect id="ButtonQ" class="Q Button" x="687" y="275" width="28" height="14"/>
+    <text id="LabelQ" class="Q Label" x="659.0" y="284" style="text-anchor:start;">Q</text>
+    <path style="fill:none" d="M 677.0,282.0 H 669.0" id="LeaderQ" class="Leader Q"/>
+  </g>
+  <g>
+    <rect id="ButtonR" class="R Button" x="687" y="292" width="28" height="14"/>
+    <text id="LabelR" class="R Label" x="659.0" y="301" style="text-anchor:start;">R</text>
+    <path style="fill:none" d="M 677.0,299.0 H 669.0" id="LeaderR" class="Leader R"/>
+  </g>
+  <g>
+    <rect id="ButtonS" class="S Button" x="687" y="309" width="28" height="14"/>
+    <text id="LabelS" class="S Label" x="659.0" y="318" style="text-anchor:start;">S</text>
+    <path style="fill:none" d="M 677.0,316.0 H 669.0" id="LeaderS" class="Leader S"/>
+  </g>
+  <g>
+    <rect id="ButtonT" class="T Button" x="687" y="327" width="28" height="14"/>
+    <text id="LabelT" class="T Label" x="659.0" y="336" style="text-anchor:start;">T</text>
+    <path style="fill:none" d="M 677.0,334.0 H 669.0" id="LeaderT" class="Leader T"/>
+  </g>
 </svg>

--- a/data/layouts/huion-kamvas-pro-studio-22.svg
+++ b/data/layouts/huion-kamvas-pro-studio-22.svg
@@ -1,272 +1,106 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-kamvas-pro-studio-22"
-        width="725"
-        height="430">
-    <title id="title">KAMVAS Pro/Studio 22</title>
-    <rect x="72" y="48" width="582" height="327" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="10"
-                      y="82"
-                      width="28"
-                      height="14" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="22"
-                      y="91"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="10"
-                      y="100"
-                      width="28"
-                      height="14" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="22"
-                      y="109"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="10"
-                      y="117"
-                      width="28"
-                      height="14" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="22"
-                      y="126"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="10"
-                      y="134"
-                      width="28"
-                      height="14" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="22"
-                      y="143"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="10"
-                      y="152"
-                      width="28"
-                      height="14" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="22"
-                      y="161"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="10"
-                      y="257"
-                      width="28"
-                      height="14" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="22"
-                      y="266"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="10"
-                      y="275"
-                      width="28"
-                      height="14" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="22"
-                      y="284"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="10"
-                      y="292"
-                      width="28"
-                      height="14" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="22"
-                      y="301"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="10"
-                      y="309"
-                      width="28"
-                      height="14" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="22"
-                      y="318"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="10"
-                      y="327"
-                      width="28"
-                      height="14" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="22"
-                      y="336"
-                      style="text-anchor:start;">J</text>
-            </g>
-            <g>
-                <rect id="ButtonK"
-                      class="K Button"
-                      x="687"
-                      y="82"
-                      width="28"
-                      height="14" />
-                <text id="LabelK"
-                      class="K Label"
-                      x="699"
-                      y="91"
-                      style="text-anchor:start;">K</text>
-            </g>
-            <g>
-                <rect id="ButtonL"
-                      class="L Button"
-                      x="687"
-                      y="100"
-                      width="28"
-                      height="14" />
-                <text id="LabelL"
-                      class="L Label"
-                      x="699"
-                      y="109"
-                      style="text-anchor:start;">L</text>
-            </g>
-            <g>
-                <rect id="ButtonM"
-                      class="M Button"
-                      x="687"
-                      y="117"
-                      width="28"
-                      height="14" />
-                <text id="LabelM"
-                      class="M Label"
-                      x="699"
-                      y="126"
-                      style="text-anchor:start;">M</text>
-            </g>
-            <g>
-                <rect id="ButtonN"
-                      class="N Button"
-                      x="687"
-                      y="134"
-                      width="28"
-                      height="14" />
-                <text id="LabelN"
-                      class="N Label"
-                      x="699"
-                      y="143"
-                      style="text-anchor:start;">N</text>
-            </g>
-            <g>
-                <rect id="ButtonO"
-                      class="O Button"
-                      x="687"
-                      y="152"
-                      width="28"
-                      height="14" />
-                <text id="LabelO"
-                      class="O Label"
-                      x="699"
-                      y="161"
-                      style="text-anchor:start;">O</text>
-            </g>
-            <g>
-                <rect id="ButtonP"
-                      class="P Button"
-                      x="687"
-                      y="257"
-                      width="28"
-                      height="14" />
-                <text id="LabelP"
-                      class="P Label"
-                      x="699"
-                      y="266"
-                      style="text-anchor:start;">P</text>
-            </g>
-            <g>
-                <rect id="ButtonQ"
-                      class="Q Button"
-                      x="687"
-                      y="275"
-                      width="28"
-                      height="14" />
-                <text id="LabelQ"
-                      class="Q Label"
-                      x="699"
-                      y="284"
-                      style="text-anchor:start;">Q</text>
-            </g>
-            <g>
-                <rect id="ButtonR"
-                      class="R Button"
-                      x="687"
-                      y="292"
-                      width="28"
-                      height="14" />
-                <text id="LabelR"
-                      class="R Label"
-                      x="699"
-                      y="301"
-                      style="text-anchor:start;">R</text>
-            </g>
-            <g>
-                <rect id="ButtonS"
-                      class="S Button"
-                      x="687"
-                      y="309"
-                      width="28"
-                      height="14" />
-                <text id="LabelS"
-                      class="S Label"
-                      x="699"
-                      y="318"
-                      style="text-anchor:start;">S</text>
-            </g>
-            <g>
-                <rect id="ButtonT"
-                      class="T Button"
-                      x="687"
-                      y="327"
-                      width="28"
-                      height="14" />
-                <text id="LabelT"
-                      class="T Label"
-                      x="699"
-                      y="336"
-                      style="text-anchor:start;">T</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-kamvas-pro-studio-22" width="725" height="430">
+  <title id="title">KAMVAS Pro/Studio 22</title>
+  <rect x="72" y="48" width="582" height="327"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="10" y="82" width="28" height="14"/>
+    <text id="LabelA" class="A Label" x="62.0" y="91" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 47.0,89.0 H 54.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="10" y="100" width="28" height="14"/>
+    <text id="LabelB" class="B Label" x="62.0" y="109" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 47.0,107.0 H 54.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="10" y="117" width="28" height="14"/>
+    <text id="LabelC" class="C Label" x="62.0" y="126" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 47.0,124.0 H 54.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="10" y="134" width="28" height="14"/>
+    <text id="LabelD" class="D Label" x="62.0" y="143" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 47.0,141.0 H 54.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="10" y="152" width="28" height="14"/>
+    <text id="LabelE" class="E Label" x="62.0" y="161" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 47.0,159.0 H 54.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="10" y="257" width="28" height="14"/>
+    <text id="LabelF" class="F Label" x="62.0" y="266" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 47.0,264.0 H 54.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="10" y="275" width="28" height="14"/>
+    <text id="LabelG" class="G Label" x="62.0" y="284" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 47.0,282.0 H 54.0" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="10" y="292" width="28" height="14"/>
+    <text id="LabelH" class="H Label" x="62.0" y="301" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 47.0,299.0 H 54.0" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="10" y="309" width="28" height="14"/>
+    <text id="LabelI" class="I Label" x="62.0" y="318" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 47.0,316.0 H 54.0" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="10" y="327" width="28" height="14"/>
+    <text id="LabelJ" class="J Label" x="62.0" y="336" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 47.0,334.0 H 54.0" id="LeaderJ" class="Leader J"/>
+  </g>
+  <g>
+    <rect id="ButtonK" class="K Button" x="687" y="82" width="28" height="14"/>
+    <text id="LabelK" class="K Label" x="659.0" y="91" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 677.0,89.0 H 669.0" id="LeaderK" class="Leader K"/>
+  </g>
+  <g>
+    <rect id="ButtonL" class="L Button" x="687" y="100" width="28" height="14"/>
+    <text id="LabelL" class="L Label" x="659.0" y="109" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 677.0,107.0 H 669.0" id="LeaderL" class="Leader L"/>
+  </g>
+  <g>
+    <rect id="ButtonM" class="M Button" x="687" y="117" width="28" height="14"/>
+    <text id="LabelM" class="M Label" x="659.0" y="126" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 677.0,124.0 H 669.0" id="LeaderM" class="Leader M"/>
+  </g>
+  <g>
+    <rect id="ButtonN" class="N Button" x="687" y="134" width="28" height="14"/>
+    <text id="LabelN" class="N Label" x="659.0" y="143" style="text-anchor:start;">N</text>
+    <path style="fill:none" d="M 677.0,141.0 H 669.0" id="LeaderN" class="Leader N"/>
+  </g>
+  <g>
+    <rect id="ButtonO" class="O Button" x="687" y="152" width="28" height="14"/>
+    <text id="LabelO" class="O Label" x="659.0" y="161" style="text-anchor:start;">O</text>
+    <path style="fill:none" d="M 677.0,159.0 H 669.0" id="LeaderO" class="Leader O"/>
+  </g>
+  <g>
+    <rect id="ButtonP" class="P Button" x="687" y="257" width="28" height="14"/>
+    <text id="LabelP" class="P Label" x="659.0" y="266" style="text-anchor:start;">P</text>
+    <path style="fill:none" d="M 677.0,264.0 H 669.0" id="LeaderP" class="Leader P"/>
+  </g>
+  <g>
+    <rect id="ButtonQ" class="Q Button" x="687" y="275" width="28" height="14"/>
+    <text id="LabelQ" class="Q Label" x="659.0" y="284" style="text-anchor:start;">Q</text>
+    <path style="fill:none" d="M 677.0,282.0 H 669.0" id="LeaderQ" class="Leader Q"/>
+  </g>
+  <g>
+    <rect id="ButtonR" class="R Button" x="687" y="292" width="28" height="14"/>
+    <text id="LabelR" class="R Label" x="659.0" y="301" style="text-anchor:start;">R</text>
+    <path style="fill:none" d="M 677.0,299.0 H 669.0" id="LeaderR" class="Leader R"/>
+  </g>
+  <g>
+    <rect id="ButtonS" class="S Button" x="687" y="309" width="28" height="14"/>
+    <text id="LabelS" class="S Label" x="659.0" y="318" style="text-anchor:start;">S</text>
+    <path style="fill:none" d="M 677.0,316.0 H 669.0" id="LeaderS" class="Leader S"/>
+  </g>
+  <g>
+    <rect id="ButtonT" class="T Button" x="687" y="327" width="28" height="14"/>
+    <text id="LabelT" class="T Label" x="659.0" y="336" style="text-anchor:start;">T</text>
+    <path style="fill:none" d="M 677.0,334.0 H 669.0" id="LeaderT" class="Leader T"/>
+  </g>
 </svg>

--- a/data/layouts/huion-mini-keydial-kd100.svg
+++ b/data/layouts/huion-mini-keydial-kd100.svg
@@ -1,340 +1,102 @@
 <?xml version="1.0" standalone="no"?>
-<svg
-   version="1.1"
-   style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-   id="huion-mini-keydial-kd100"
-   width="275"
-   height="430"
-   sodipodi:docname="huion-mini-keydial-kd100.svg"
-   inkscape:version="1.5-dev (afb39433d1, 2024-05-12)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs19" />
-  <sodipodi:namedview
-     id="namedview19"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="3.355814"
-     inkscape:cx="137.52252"
-     inkscape:cy="215"
-     inkscape:window-width="3072"
-     inkscape:window-height="1696"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="huion-mini-keydial-kd100" />
-  <title
-     id="title">Mini KeyDial KD100</title>
-  <g
-     id="g1">
-    <rect
-       id="ButtonA"
-       class="A Button"
-       x="32"
-       y="135"
-       width="47"
-       height="47" />
-    <text
-       id="LabelA"
-       class="A Label"
-       x="53.5"
-       y="160.5"
-       style="text-anchor:start;">A</text>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-mini-keydial-kd100" width="275" height="430" sodipodi:docname="huion-mini-keydial-kd100.svg" inkscape:version="1.5-dev (afb39433d1, 2024-05-12)">
+  <defs id="defs19"/>
+  <sodipodi:namedview id="namedview19" pagecolor="#ffffff" bordercolor="#000000" borderopacity="0.25" inkscape:showpageshadow="2" inkscape:pageopacity="0.0" inkscape:pagecheckerboard="0" inkscape:deskcolor="#d1d1d1" inkscape:zoom="3.355814" inkscape:cx="137.52252" inkscape:cy="215" inkscape:window-width="3072" inkscape:window-height="1696" inkscape:window-x="0" inkscape:window-y="0" inkscape:window-maximized="1" inkscape:current-layer="huion-mini-keydial-kd100"/>
+  <title id="title">Mini KeyDial KD100</title>
+  <g id="g1">
+    <rect id="ButtonA" class="A Button" x="32" y="135" width="47" height="47"/>
+    <text id="LabelA" class="A Label" x="63.5" y="160.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 48.5,158.5 H 55.5" id="LeaderA" class="Leader A"/>
   </g>
-  <g
-     id="g2">
-    <rect
-       id="ButtonB"
-       class="B Button"
-       x="86"
-       y="135"
-       width="47"
-       height="47" />
-    <text
-       id="LabelB"
-       class="B Label"
-       x="107.5"
-       y="160.5"
-       style="text-anchor:start;">B</text>
+  <g id="g2">
+    <rect id="ButtonB" class="B Button" x="86" y="135" width="47" height="47"/>
+    <text id="LabelB" class="B Label" x="117.5" y="160.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 102.5,158.5 H 109.5" id="LeaderB" class="Leader B"/>
   </g>
-  <g
-     id="g3">
-    <rect
-       id="ButtonC"
-       class="C Button"
-       x="140"
-       y="135"
-       width="47"
-       height="47" />
-    <text
-       id="LabelC"
-       class="C Label"
-       x="161.5"
-       y="160.5"
-       style="text-anchor:start;">C</text>
+  <g id="g3">
+    <rect id="ButtonC" class="C Button" x="140" y="135" width="47" height="47"/>
+    <text id="LabelC" class="C Label" x="171.5" y="160.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 156.5,158.5 H 163.5" id="LeaderC" class="Leader C"/>
   </g>
-  <g
-     id="g4">
-    <rect
-       id="ButtonD"
-       class="D Button"
-       x="194"
-       y="135"
-       width="47"
-       height="47" />
-    <text
-       id="LabelD"
-       class="D Label"
-       x="215.5"
-       y="160.5"
-       style="text-anchor:start;">D</text>
+  <g id="g4">
+    <rect id="ButtonD" class="D Button" x="194" y="135" width="47" height="47"/>
+    <text id="LabelD" class="D Label" x="225.5" y="160.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 210.5,158.5 H 217.5" id="LeaderD" class="Leader D"/>
   </g>
-  <g
-     id="g5">
-    <rect
-       id="ButtonE"
-       class="E Button"
-       x="32"
-       y="190"
-       width="47"
-       height="47" />
-    <text
-       id="LabelE"
-       class="E Label"
-       x="53.5"
-       y="215.5"
-       style="text-anchor:start;">E</text>
+  <g id="g5">
+    <rect id="ButtonE" class="E Button" x="32" y="190" width="47" height="47"/>
+    <text id="LabelE" class="E Label" x="63.5" y="215.5" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 48.5,213.5 H 55.5" id="LeaderE" class="Leader E"/>
   </g>
-  <g
-     id="g6">
-    <rect
-       id="ButtonF"
-       class="F Button"
-       x="88"
-       y="190"
-       width="47"
-       height="47" />
-    <text
-       id="LabelF"
-       class="F Label"
-       x="109.5"
-       y="215.5"
-       style="text-anchor:start;">F</text>
+  <g id="g6">
+    <rect id="ButtonF" class="F Button" x="88" y="190" width="47" height="47"/>
+    <text id="LabelF" class="F Label" x="119.5" y="215.5" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 104.5,213.5 H 111.5" id="LeaderF" class="Leader F"/>
   </g>
-  <g
-     id="g7">
-    <rect
-       id="ButtonG"
-       class="G Button"
-       x="141"
-       y="190"
-       width="47"
-       height="47" />
-    <text
-       id="LabelG"
-       class="G Label"
-       x="162.5"
-       y="215.5"
-       style="text-anchor:start;">G</text>
+  <g id="g7">
+    <rect id="ButtonG" class="G Button" x="141" y="190" width="47" height="47"/>
+    <text id="LabelG" class="G Label" x="172.5" y="215.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 157.5,213.5 H 164.5" id="LeaderG" class="Leader G"/>
   </g>
-  <g
-     id="g8">
-    <rect
-       id="ButtonH"
-       class="H Button"
-       x="195"
-       y="190"
-       width="47"
-       height="47" />
-    <text
-       id="LabelH"
-       class="H Label"
-       x="216.5"
-       y="215.5"
-       style="text-anchor:start;">H</text>
+  <g id="g8">
+    <rect id="ButtonH" class="H Button" x="195" y="190" width="47" height="47"/>
+    <text id="LabelH" class="H Label" x="226.5" y="215.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 211.5,213.5 H 218.5" id="LeaderH" class="Leader H"/>
   </g>
-  <g
-     id="g9">
-    <rect
-       id="ButtonI"
-       class="I Button"
-       x="32"
-       y="242"
-       width="47"
-       height="47" />
-    <text
-       id="LabelI"
-       class="I Label"
-       x="53.5"
-       y="267.5"
-       style="text-anchor:start;">I</text>
+  <g id="g9">
+    <rect id="ButtonI" class="I Button" x="32" y="242" width="47" height="47"/>
+    <text id="LabelI" class="I Label" x="63.5" y="267.5" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 48.5,265.5 H 55.5" id="LeaderI" class="Leader I"/>
   </g>
-  <g
-     id="g10">
-    <rect
-       id="ButtonJ"
-       class="J Button"
-       x="87"
-       y="243"
-       width="47"
-       height="47" />
-    <text
-       id="LabelJ"
-       class="J Label"
-       x="108.5"
-       y="268.5"
-       style="text-anchor:start;">J</text>
+  <g id="g10">
+    <rect id="ButtonJ" class="J Button" x="87" y="243" width="47" height="47"/>
+    <text id="LabelJ" class="J Label" x="118.5" y="268.5" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 103.5,266.5 H 110.5" id="LeaderJ" class="Leader J"/>
   </g>
-  <g
-     id="g11">
-    <rect
-       id="ButtonK"
-       class="K Button"
-       x="140"
-       y="243"
-       width="47"
-       height="47" />
-    <text
-       id="LabelK"
-       class="K Label"
-       x="161.5"
-       y="268.5"
-       style="text-anchor:start;">K</text>
+  <g id="g11">
+    <rect id="ButtonK" class="K Button" x="140" y="243" width="47" height="47"/>
+    <text id="LabelK" class="K Label" x="171.5" y="268.5" style="text-anchor:start;">K</text>
+    <path style="fill:none" d="M 156.5,266.5 H 163.5" id="LeaderK" class="Leader K"/>
   </g>
-  <g
-     id="g12">
-    <rect
-       id="ButtonL"
-       class="L Button"
-       x="195"
-       y="243"
-       width="47"
-       height="47" />
-    <text
-       id="LabelL"
-       class="L Label"
-       x="216.5"
-       y="268.5"
-       style="text-anchor:start;">L</text>
+  <g id="g12">
+    <rect id="ButtonL" class="L Button" x="195" y="243" width="47" height="47"/>
+    <text id="LabelL" class="L Label" x="226.5" y="268.5" style="text-anchor:start;">L</text>
+    <path style="fill:none" d="M 211.5,266.5 H 218.5" id="LeaderL" class="Leader L"/>
   </g>
-  <g
-     id="g13">
-    <rect
-       id="ButtonM"
-       class="M Button"
-       x="32"
-       y="296"
-       width="47"
-       height="47" />
-    <text
-       id="LabelM"
-       class="M Label"
-       x="53.5"
-       y="321.5"
-       style="text-anchor:start;">M</text>
+  <g id="g13">
+    <rect id="ButtonM" class="M Button" x="32" y="296" width="47" height="47"/>
+    <text id="LabelM" class="M Label" x="63.5" y="321.5" style="text-anchor:start;">M</text>
+    <path style="fill:none" d="M 48.5,319.5 H 55.5" id="LeaderM" class="Leader M"/>
   </g>
-  <g
-     id="g14">
-    <rect
-       id="ButtonN"
-       class="N Button"
-       x="86"
-       y="296"
-       width="47"
-       height="47" />
-    <text
-       id="LabelN"
-       class="N Label"
-       x="107.5"
-       y="321.5"
-       style="text-anchor:start;">N</text>
+  <g id="g14">
+    <rect id="ButtonN" class="N Button" x="86" y="296" width="47" height="47"/>
+    <text id="LabelN" class="N Label" x="117.5" y="321.5" style="text-anchor:start;">N</text>
+    <path style="fill:none" d="M 102.5,319.5 H 109.5" id="LeaderN" class="Leader N"/>
   </g>
-  <g
-     id="g15">
-    <rect
-       id="ButtonO"
-       class="O Button"
-       x="140"
-       y="296"
-       width="47"
-       height="47" />
-    <text
-       id="LabelO"
-       class="O Label"
-       x="161.5"
-       y="321.5"
-       style="text-anchor:start;">O</text>
+  <g id="g15">
+    <rect id="ButtonO" class="O Button" x="140" y="296" width="47" height="47"/>
+    <text id="LabelO" class="O Label" x="171.5" y="321.5" style="text-anchor:start;">O</text>
+    <path style="fill:none" d="M 156.5,319.5 H 163.5" id="LeaderO" class="Leader O"/>
   </g>
-  <g
-     id="g16">
-    <rect
-       id="ButtonP"
-       class="P Button"
-       x="195"
-       y="296"
-       width="45"
-       height="99" />
-    <text
-       id="LabelP"
-       class="P Label"
-       x="215.5"
-       y="347.5"
-       style="text-anchor:start;">P</text>
+  <g id="g16">
+    <rect id="ButtonP" class="P Button" x="195" y="296" width="45" height="99"/>
+    <text id="LabelP" class="P Label" x="225.5" y="347.5" style="text-anchor:start;">P</text>
+    <path style="fill:none" d="M 210.5,345.5 H 217.5" id="LeaderP" class="Leader P"/>
   </g>
-  <g
-     id="g17">
-    <rect
-       id="ButtonQ"
-       class="Q Button"
-       x="32"
-       y="350"
-       width="99"
-       height="45" />
-    <text
-       id="LabelQ"
-       class="Q Label"
-       x="79.5"
-       y="374.5"
-       style="text-anchor:start;">Q</text>
+  <g id="g17">
+    <rect id="ButtonQ" class="Q Button" x="32" y="350" width="99" height="45"/>
+    <text id="LabelQ" class="Q Label" x="89.5" y="374.5" style="text-anchor:start;">Q</text>
+    <path style="fill:none" d="M 74.5,372.5 H 81.5" id="LeaderQ" class="Leader Q"/>
   </g>
-  <g
-     id="g18">
-    <rect
-       id="ButtonR"
-       class="R Button"
-       x="140"
-       y="349"
-       width="47"
-       height="47" />
-    <text
-       id="LabelR"
-       class="R Label"
-       x="161.5"
-       y="374.5"
-       style="text-anchor:start;">R</text>
+  <g id="g18">
+    <rect id="ButtonR" class="R Button" x="140" y="349" width="47" height="47"/>
+    <text id="LabelR" class="R Label" x="171.5" y="374.5" style="text-anchor:start;">R</text>
+    <path style="fill:none" d="M 156.5,372.5 H 163.5" id="LeaderR" class="Leader R"/>
   </g>
-  <g
-     id="g19">
-    <rect
-       id="ButtonS"
-       class="S Button"
-       x="42"
-       y="43"
-       width="39"
-       height="39" />
-    <text
-       id="LabelS"
-       class="S Label"
-       x="59.5"
-       y="64.5"
-       style="text-anchor:start;">S</text>
+  <g id="g19">
+    <rect id="ButtonS" class="S Button" x="42" y="43" width="39" height="39"/>
+    <text id="LabelS" class="S Label" x="69.5" y="64.5" style="text-anchor:start;">S</text>
+    <path style="fill:none" d="M 54.5,62.5 H 61.5" id="LeaderS" class="Leader S"/>
   </g>
 </svg>

--- a/data/layouts/huion-rds-160.svg
+++ b/data/layouts/huion-rds-160.svg
@@ -1,142 +1,56 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-rds-160"
-        width="720"
-        height="430">
-    <title id="title">Huion RDS-160</title>
-    <rect x="82" y="48" width="589" height="333" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="10"
-                      y="73"
-                      width="25"
-                      height="25" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="20.5"
-                      y="87.5"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="10"
-                      y="101"
-                      width="25"
-                      height="25" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="20.5"
-                      y="115.5"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="10"
-                      y="129"
-                      width="25"
-                      height="25" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="20.5"
-                      y="143.5"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="10"
-                      y="157"
-                      width="25"
-                      height="25" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="20.5"
-                      y="171.5"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="7"
-                      y="185"
-                      width="30"
-                      height="30" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="20"
-                      y="202"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="6"
-                      y="216"
-                      width="32"
-                      height="32" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="20"
-                      y="234"
-                      style="text-anchor:start;">F</text>
-            </g>
-            <g>
-                <rect id="ButtonG"
-                      class="G Button"
-                      x="10"
-                      y="252"
-                      width="25"
-                      height="25" />
-                <text id="LabelG"
-                      class="G Label"
-                      x="20.5"
-                      y="266.5"
-                      style="text-anchor:start;">G</text>
-            </g>
-            <g>
-                <rect id="ButtonH"
-                      class="H Button"
-                      x="10"
-                      y="280"
-                      width="25"
-                      height="25" />
-                <text id="LabelH"
-                      class="H Label"
-                      x="20.5"
-                      y="294.5"
-                      style="text-anchor:start;">H</text>
-            </g>
-            <g>
-                <rect id="ButtonI"
-                      class="I Button"
-                      x="10"
-                      y="308"
-                      width="25"
-                      height="25" />
-                <text id="LabelI"
-                      class="I Label"
-                      x="20.5"
-                      y="322.5"
-                      style="text-anchor:start;">I</text>
-            </g>
-            <g>
-                <rect id="ButtonJ"
-                      class="J Button"
-                      x="10"
-                      y="336"
-                      width="25"
-                      height="25" />
-                <text id="LabelJ"
-                      class="J Label"
-                      x="20.5"
-                      y="350.5"
-                      style="text-anchor:start;">J</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-rds-160" width="720" height="430">
+  <title id="title">Huion RDS-160</title>
+  <rect x="82" y="48" width="589" height="333"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="10" y="73" width="25" height="25"/>
+    <text id="LabelA" class="A Label" x="60.5" y="87.5" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 45.5,85.5 H 52.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="10" y="101" width="25" height="25"/>
+    <text id="LabelB" class="B Label" x="60.5" y="115.5" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 45.5,113.5 H 52.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="10" y="129" width="25" height="25"/>
+    <text id="LabelC" class="C Label" x="60.5" y="143.5" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 45.5,141.5 H 52.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="10" y="157" width="25" height="25"/>
+    <text id="LabelD" class="D Label" x="60.5" y="171.5" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 45.5,169.5 H 52.5" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="7" y="185" width="30" height="30"/>
+    <text id="LabelE" class="E Label" x="60.0" y="202" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 45.0,200.0 H 52.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="6" y="216" width="32" height="32"/>
+    <text id="LabelF" class="F Label" x="60.0" y="234" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 45.0,232.0 H 52.0" id="LeaderF" class="Leader F"/>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="10" y="252" width="25" height="25"/>
+    <text id="LabelG" class="G Label" x="60.5" y="266.5" style="text-anchor:start;">G</text>
+    <path style="fill:none" d="M 45.5,264.5 H 52.5" id="LeaderG" class="Leader G"/>
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="10" y="280" width="25" height="25"/>
+    <text id="LabelH" class="H Label" x="60.5" y="294.5" style="text-anchor:start;">H</text>
+    <path style="fill:none" d="M 45.5,292.5 H 52.5" id="LeaderH" class="Leader H"/>
+  </g>
+  <g>
+    <rect id="ButtonI" class="I Button" x="10" y="308" width="25" height="25"/>
+    <text id="LabelI" class="I Label" x="60.5" y="322.5" style="text-anchor:start;">I</text>
+    <path style="fill:none" d="M 45.5,320.5 H 52.5" id="LeaderI" class="Leader I"/>
+  </g>
+  <g>
+    <rect id="ButtonJ" class="J Button" x="10" y="336" width="25" height="25"/>
+    <text id="LabelJ" class="J Label" x="60.5" y="350.5" style="text-anchor:start;">J</text>
+    <path style="fill:none" d="M 45.5,348.5 H 52.5" id="LeaderJ" class="Leader J"/>
+  </g>
 </svg>

--- a/data/layouts/huion-rte-100.svg
+++ b/data/layouts/huion-rte-100.svg
@@ -1,64 +1,26 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-rte-100"
-        width="576"
-        height="430">
-    <title id="title">Huion RTE-100</title>
-    <rect x="97" y="130" width="381" height="244" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="35"
-                      y="39"
-                      width="57"
-                      height="28" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="61.5"
-                      y="55"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="35"
-                      y="90"
-                      width="57"
-                      height="28" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="61.5"
-                      y="106"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="483"
-                      y="40"
-                      width="57"
-                      height="28" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="509.5"
-                      y="56"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="483"
-                      y="90"
-                      width="57"
-                      height="28" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="509.5"
-                      y="106"
-                      style="text-anchor:start;">D</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-rte-100" width="576" height="430">
+  <title id="title">Huion RTE-100</title>
+  <rect x="97" y="130" width="381" height="244"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="35" y="39" width="57" height="28"/>
+    <text id="LabelA" class="A Label" x="111.5" y="55" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 96.5,53.0 H 103.5" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="35" y="90" width="57" height="28"/>
+    <text id="LabelB" class="B Label" x="111.5" y="106" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 96.5,104.0 H 103.5" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="483" y="40" width="57" height="28"/>
+    <text id="LabelC" class="C Label" x="559.5" y="56" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 544.5,54.0 H 551.5" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="483" y="90" width="57" height="28"/>
+    <text id="LabelD" class="D Label" x="559.5" y="106" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 544.5,104.0 H 551.5" id="LeaderD" class="Leader D"/>
+  </g>
 </svg>

--- a/data/layouts/huion-rtm-500.svg
+++ b/data/layouts/huion-rtm-500.svg
@@ -1,64 +1,26 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-rtm-500"
-        width="732"
-        height="430">
-    <title id="title">Huion RTM-500</title>
-    <rect x="108" y="45" width="539" height="337" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="47"
-                      y="42"
-                      width="20"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="55"
-                      y="54"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="47"
-                      y="89"
-                      width="20"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="55"
-                      y="101"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="47"
-                      y="321"
-                      width="20"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="55"
-                      y="333"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="47"
-                      y="368"
-                      width="20"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="55"
-                      y="380"
-                      style="text-anchor:start;">D</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-rtm-500" width="732" height="430">
+  <title id="title">Huion RTM-500</title>
+  <rect x="108" y="45" width="539" height="337"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="47" y="42" width="20" height="20"/>
+    <text id="LabelA" class="A Label" x="95.0" y="54" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 80.0,52.0 H 87.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="47" y="89" width="20" height="20"/>
+    <text id="LabelB" class="B Label" x="95.0" y="101" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 80.0,99.0 H 87.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="47" y="321" width="20" height="20"/>
+    <text id="LabelC" class="C Label" x="95.0" y="333" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 80.0,331.0 H 87.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="47" y="368" width="20" height="20"/>
+    <text id="LabelD" class="D Label" x="95.0" y="380" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 80.0,378.0 H 87.0" id="LeaderD" class="Leader D"/>
+  </g>
 </svg>

--- a/data/layouts/huion-rtp-700.svg
+++ b/data/layouts/huion-rtp-700.svg
@@ -1,90 +1,36 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-rtp-700"
-        width="726"
-        height="430">
-    <title id="title">Huion RTP-700</title>
-    <rect x="86" y="38" width="566" height="352" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="37"
-                      y="32"
-                      width="20"
-                      height="20" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="45"
-                      y="44"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="37"
-                      y="70"
-                      width="20"
-                      height="20" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="45"
-                      y="82"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="37"
-                      y="110"
-                      width="20"
-                      height="20" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="45"
-                      y="122"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="37"
-                      y="300"
-                      width="20"
-                      height="20" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="45"
-                      y="312"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="37"
-                      y="340"
-                      width="20"
-                      height="20" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="45"
-                      y="352"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="37"
-                      y="379"
-                      width="20"
-                      height="20" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="45"
-                      y="391"
-                      style="text-anchor:start;">F</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-rtp-700" width="726" height="430">
+  <title id="title">Huion RTP-700</title>
+  <rect x="86" y="38" width="566" height="352"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="37" y="32" width="20" height="20"/>
+    <text id="LabelA" class="A Label" x="85.0" y="44" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 70.0,42.0 H 77.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="37" y="70" width="20" height="20"/>
+    <text id="LabelB" class="B Label" x="85.0" y="82" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 70.0,80.0 H 77.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="37" y="110" width="20" height="20"/>
+    <text id="LabelC" class="C Label" x="85.0" y="122" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 70.0,120.0 H 77.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="37" y="300" width="20" height="20"/>
+    <text id="LabelD" class="D Label" x="85.0" y="312" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 70.0,310.0 H 77.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="37" y="340" width="20" height="20"/>
+    <text id="LabelE" class="E Label" x="85.0" y="352" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 70.0,350.0 H 77.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="37" y="379" width="20" height="20"/>
+    <text id="LabelF" class="F Label" x="85.0" y="391" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 70.0,389.0 H 77.0" id="LeaderF" class="Leader F"/>
+  </g>
 </svg>

--- a/data/layouts/huion-rts-300.svg
+++ b/data/layouts/huion-rts-300.svg
@@ -1,90 +1,36 @@
-<?xml version="1.0" standalone="no"?>
+<?xml version='1.0' encoding='ASCII'?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-        id="huion-rts-300"
-        width="479"
-        height="430">
-    <title id="title">Huion RTS-300</title>
-    <rect x="47" y="131" width="387" height="242" />
-
-            <g>
-                <rect id="ButtonA"
-                      class="A Button"
-                      x="65"
-                      y="49"
-                      width="42"
-                      height="18" />
-                <text id="LabelA"
-                      class="A Label"
-                      x="84"
-                      y="60"
-                      style="text-anchor:start;">A</text>
-            </g>
-            <g>
-                <rect id="ButtonB"
-                      class="B Button"
-                      x="113"
-                      y="49"
-                      width="42"
-                      height="18" />
-                <text id="LabelB"
-                      class="B Label"
-                      x="132"
-                      y="60"
-                      style="text-anchor:start;">B</text>
-            </g>
-            <g>
-                <rect id="ButtonC"
-                      class="C Button"
-                      x="160"
-                      y="49"
-                      width="42"
-                      height="18" />
-                <text id="LabelC"
-                      class="C Label"
-                      x="179"
-                      y="60"
-                      style="text-anchor:start;">C</text>
-            </g>
-            <g>
-                <rect id="ButtonD"
-                      class="D Button"
-                      x="276"
-                      y="49"
-                      width="42"
-                      height="18" />
-                <text id="LabelD"
-                      class="D Label"
-                      x="295"
-                      y="60"
-                      style="text-anchor:start;">D</text>
-            </g>
-            <g>
-                <rect id="ButtonE"
-                      class="E Button"
-                      x="322"
-                      y="49"
-                      width="42"
-                      height="18" />
-                <text id="LabelE"
-                      class="E Label"
-                      x="341"
-                      y="60"
-                      style="text-anchor:start;">E</text>
-            </g>
-            <g>
-                <rect id="ButtonF"
-                      class="F Button"
-                      x="370"
-                      y="49"
-                      width="42"
-                      height="18" />
-                <text id="LabelF"
-                      class="F Label"
-                      x="389"
-                      y="60"
-                      style="text-anchor:start;">F</text>
-            </g>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="huion-rts-300" width="479" height="430">
+  <title id="title">Huion RTS-300</title>
+  <rect x="47" y="131" width="387" height="242"/>
+  <g>
+    <rect id="ButtonA" class="A Button" x="65" y="49" width="42" height="18"/>
+    <text id="LabelA" class="A Label" x="84" y="90.0" style="text-anchor:start;">A</text>
+    <path style="fill:none" d="M 86.0,75.0 V 82.0" id="LeaderA" class="Leader A"/>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="113" y="49" width="42" height="18"/>
+    <text id="LabelB" class="B Label" x="132" y="90.0" style="text-anchor:start;">B</text>
+    <path style="fill:none" d="M 134.0,75.0 V 82.0" id="LeaderB" class="Leader B"/>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="160" y="49" width="42" height="18"/>
+    <text id="LabelC" class="C Label" x="179" y="90.0" style="text-anchor:start;">C</text>
+    <path style="fill:none" d="M 181.0,75.0 V 82.0" id="LeaderC" class="Leader C"/>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="276" y="49" width="42" height="18"/>
+    <text id="LabelD" class="D Label" x="295" y="90.0" style="text-anchor:start;">D</text>
+    <path style="fill:none" d="M 297.0,75.0 V 82.0" id="LeaderD" class="Leader D"/>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="322" y="49" width="42" height="18"/>
+    <text id="LabelE" class="E Label" x="341" y="90.0" style="text-anchor:start;">E</text>
+    <path style="fill:none" d="M 343.0,75.0 V 82.0" id="LeaderE" class="Leader E"/>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="370" y="49" width="42" height="18"/>
+    <text id="LabelF" class="F Label" x="389" y="90.0" style="text-anchor:start;">F</text>
+    <path style="fill:none" d="M 391.0,75.0 V 82.0" id="LeaderF" class="Leader F"/>
+  </g>
 </svg>


### PR DESCRIPTION
libwacom's SVG format requires that we have an element with
id="ButtonA", one with id="LabelA" and one with id="LeaderA".

The latter is the line pointing to the button. Since OSDs mostly fill in
the button rect when the button is pressed we need the label to be
outside the button and a leader pointing to it.

This patch was (supervised but) generated from a Python script:
all labels are moved to the right and a leader with the right id and
class was inserted. The script supports moving buttons (and adding
leaders) in all four directions, most tablets are ok now. Some tablets
have a less-than optimal layout (e.g. the Huion Mini Keypad) but that
can be fixed by someone with more time and motivation.

Script source:
https://gist.github.com/whot/8f3dbc09908862775b61f7d0a71fd5ed

Fixes: https://github.com/linuxwacom/libwacom/commit/c80bd7f7bfdfec63a70c0081c13f433854b103b9 ("Add auto generated GAOMON tablet description files")
Fixes: https://github.com/linuxwacom/libwacom/commit/ce093e730fb1901dad7b6bc259b0269bb4ca9a13 ("Add auto generated HUION tablet description files")

---

Related to #659, cc @JoseExposito 

Not all SVGs are great, arguably the original format with the button inside is better but unfortunately this is a change to how everything is set up. For now we need the leader lines (and probably someone to fix the various files that are going to be messy in the OSD).
