### PR TITLE
test: Replace the uinput-based hwdb test with a direct query

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ permissions:
 
 env:
   CFLAGS: "-Werror -Wno-error=missing-field-initializers"
-  UBUNTU_PACKAGES: libgudev-1.0-dev libxml++2.6-dev valgrind tree python3-pip python3-setuptools libevdev-dev
+  UBUNTU_PACKAGES: libgudev-1.0-dev libxml++2.6-dev valgrind tree python3-pip python3-setuptools libevdev-dev udev
   PIP_PACKAGES: meson ninja libevdev pyudev pytest yq
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,8 +50,7 @@ jobs:
         with:
           name: meson test logs-${{matrix.compiler}} ${{matrix.meson_options}}
           path: |
-            builddir/meson-logs/testlog*.txt
-            builddir/meson-logs/meson-log.txt
+            builddir/meson-logs/*
       # move the tarball to the top level
       - name: move tarballs to top level
         run: mv builddir/meson-dist/libwacom-*tar.xz .

--- a/meson.build
+++ b/meson.build
@@ -150,12 +150,12 @@ updatedb = configure_file(input: 'tools/libwacom-update-db.py',
 			  copy: true,
 			  install: true,
 			  install_dir: dir_bin)
-custom_target('hwdb',
-	      command: [python, updatedb, '--buildsystem-mode', dir_src_data],
-	      capture: true,
-	      output: '65-libwacom.hwdb',
-	      install: true,
-	      install_dir: dir_udev / 'hwdb.d')
+hwdb = custom_target('hwdb',
+	             command: [python, updatedb, '--buildsystem-mode', dir_src_data],
+	             capture: true,
+	             output: '65-libwacom.hwdb',
+	             install: true,
+	             install_dir: dir_udev / 'hwdb.d')
 
 configure_file(input: 'tools/65-libwacom.rules.in',
 	       output: '65-libwacom.rules',
@@ -287,6 +287,7 @@ if get_option('tests').enabled()
 
 	env = environment()
 	env.set('MESON_SOURCE_ROOT', meson.current_source_dir())
+	env.set('LIBWACOM_HWDB_FILE', hwdb.full_path())
 	env.set('LD_LIBRARY_PATH', fs.parent(lib_libwacom.full_path()))
 	pymod.find_installation(modules: ['libevdev', 'pyudev', 'pytest'])
 	pytest = find_program('pytest-3', 'pytest')

--- a/meson.build
+++ b/meson.build
@@ -293,7 +293,13 @@ if get_option('tests').enabled()
 	pytest = find_program('pytest-3', 'pytest')
 	test('pytest',
 	     pytest,
-	     args: ['--verbose', '--log-level=DEBUG', meson.current_source_dir()],
+	     args: ['--verbose',
+		     '-rfES',
+		     '--log-level=DEBUG',
+		     '--log-file', meson.project_build_root() / 'meson-logs' / 'pytest.log',
+		     '--log-file-level=DEBUG',
+		     meson.current_source_dir()
+	     ],
 	     env: env,
 	     suite: ['all'])
 endif

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -24,7 +24,9 @@ def load_test_db() -> WacomDatabase:
             logger.info(f"Defaulting to MESON_SOURCE_ROOT={dbpath}")
         return WacomDatabase(path=Path(dbpath) / "data" if dbpath else None)
     except AttributeError as e:
-        pytest.exit(f"Failed to initialize and wrap libwacom.so: {e}. You may need to set LD_LIBRARY_PATH and optionally MESON_SOURCE_ROOT")
+        pytest.exit(
+            f"Failed to initialize and wrap libwacom.so: {e}. You may need to set LD_LIBRARY_PATH and optionally MESON_SOURCE_ROOT"
+        )
 
 
 @pytest.fixture()

--- a/test/test_udev_rules.py
+++ b/test/test_udev_rules.py
@@ -47,10 +47,14 @@ def systemd_reload():
         subprocess.run(["systemd-hwdb", "update"], check=True)
         subprocess.run(["systemctl", "daemon-reload"], check=True)
 
-    except (IOError, FileNotFoundError, subprocess.CalledProcessError):
+    except (IOError, FileNotFoundError, subprocess.CalledProcessError) as e:
         # If any of the commands above are not found (most likely the system
         # simply does not use systemd), just skip.
-        raise pytest.skip()
+        logging.critical(f"{e}")
+        pytest.skip(f"Skipping test: {e}")
+    except Exception as e:
+        logging.critical(f"{e}")
+        pytest.fail(f"Aborting test: {e}")
 
 
 def pytest_generate_tests(metafunc):

--- a/test/test_udev_rules.py
+++ b/test/test_udev_rules.py
@@ -34,7 +34,6 @@ def systemd_reload():
             warnings.warn("LIBWACOM_HWDB_FILE is not set, using already installed hwdb")
 
         subprocess.run(["systemd-hwdb", "update"], check=True)
-        subprocess.run(["systemctl", "daemon-reload"], check=True)
 
         yield
 
@@ -42,7 +41,6 @@ def systemd_reload():
             os.unlink(target)
 
         subprocess.run(["systemd-hwdb", "update"], check=True)
-        subprocess.run(["systemctl", "daemon-reload"], check=True)
 
     except (IOError, FileNotFoundError, subprocess.CalledProcessError) as e:
         # If any of the commands above are not found (most likely the system


### PR DESCRIPTION
Previously we'd create a uinput device for each of our tablets, then
query udev if the property is set. This takes a long time, in parts
thanks to the 300ms sleep to wait for the uinput device to be ready.

With now over 500 tablet files and most of those having multiple matches
we're looking at at minimum 500*0.3 seconds for a test run which isn't
really useful for a test like this.

Instead - let's query systemd-hwdb directly: construct a query string
our udev rule and query systemd-hwdb for the properties, then ensure we
have the ones we expect.

Closes #675

cc @alyssais


