### PR TITLE
tools: de-duplicate and regroup identical hwdb entries

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -150,12 +150,12 @@ updatedb = configure_file(input: 'tools/libwacom-update-db.py',
 			  copy: true,
 			  install: true,
 			  install_dir: dir_bin)
-custom_target('hwdb',
-	      command: [python, updatedb, '--buildsystem-mode', dir_src_data],
-	      capture: true,
-	      output: '65-libwacom.hwdb',
-	      install: true,
-	      install_dir: dir_udev / 'hwdb.d')
+hwdb = custom_target('hwdb',
+	             command: [python, updatedb, '--buildsystem-mode', dir_src_data],
+	             capture: true,
+	             output: '65-libwacom.hwdb',
+	             install: true,
+	             install_dir: dir_udev / 'hwdb.d')
 
 configure_file(input: 'tools/65-libwacom.rules.in',
 	       output: '65-libwacom.rules',
@@ -287,6 +287,7 @@ if get_option('tests').enabled()
 
 	env = environment()
 	env.set('MESON_SOURCE_ROOT', meson.current_source_dir())
+	env.set('LIBWACOM_HWDB', hwdb.full_path())
 	env.set('LD_LIBRARY_PATH', fs.parent(lib_libwacom.full_path()))
 	pymod.find_installation(modules: ['libevdev', 'pyudev', 'pytest'])
 	pytest = find_program('pytest-3', 'pytest')

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -24,7 +24,9 @@ def load_test_db() -> WacomDatabase:
             logger.info(f"Defaulting to MESON_SOURCE_ROOT={dbpath}")
         return WacomDatabase(path=Path(dbpath) / "data" if dbpath else None)
     except AttributeError as e:
-        pytest.exit(f"Failed to initialize and wrap libwacom.so: {e}. You may need to set LD_LIBRARY_PATH and optionally MESON_SOURCE_ROOT")
+        pytest.exit(
+            f"Failed to initialize and wrap libwacom.so: {e}. You may need to set LD_LIBRARY_PATH and optionally MESON_SOURCE_ROOT"
+        )
 
 
 @pytest.fixture()

--- a/test/test_udev_rules.py
+++ b/test/test_udev_rules.py
@@ -9,12 +9,9 @@
 # - check if that device has the udev properties set we expect
 
 import configparser
-import libevdev
 import os
 from pathlib import Path
-import pyudev
 import pytest
-import time
 import logging
 import sys
 import subprocess
@@ -114,58 +111,39 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("tablet", tablets, ids=[t.name for t in tablets])
 
 
-@pytest.fixture
-def uinput(tablet):
-    dev = libevdev.Device()
-    dev.name = tablet.name
-    dev.id = {"vendor": tablet.vid, "product": tablet.pid, "bustype": tablet.bus}
-    # Our rules match on pid/vid, so purposely make this look like a
-    # non-tablet to verify that our rules apply anyway and not others
-    dev.enable(libevdev.EV_REL.REL_X)
-    dev.enable(libevdev.EV_REL.REL_Y)
-    dev.enable(libevdev.EV_KEY.BTN_LEFT)
-    dev.enable(libevdev.EV_KEY.BTN_RIGHT)
-
-    try:
-        uinput = dev.create_uinput_device()
-        # We'll need the is_touchscreen later, so let's hide it in the
-        # uinput device to pass it to the actual test
-        try:
-            uinput.is_touchscreen = tablet.is_touchscreen
-        except AttributeError:
-            pass
-        time.sleep(0.3)
-        return uinput
-    except OSError:
-        raise pytest.skip()
-
-
 @pytest.mark.skipif(sys.platform != "linux", reason="This test requires udev")
-def test_hwdb_files(uinput):
-    logging.debug(
-        "{:04x}:{:04x} {}".format(
-            uinput.id["vendor"], uinput.id["product"], uinput.name
-        )
+def test_hwdb_files(tablet):
+    # Note: the name doesn't matter, all our hwdb files use either "*"
+    # or "* Finger", etc.
+    query = f"libwacom:name:{tablet.name or '.'}:input:b{tablet.bus:04X}v{tablet.vid:04X}p{tablet.pid:04X}"
+    logging.debug(query)
+
+    r = subprocess.run(
+        ["systemd-hwdb", "query", query], check=True, capture_output=True
     )
-    udev = pyudev.Context()
-    dev = pyudev.Devices.from_device_file(udev, uinput.devnode)
-    props = list(dev.properties)  # convert to list for better error messages
+    logging.debug(r.stdout.decode("utf-8"))
+    props = {}
+    for l in filter(lambda l: len(l) > 1, r.stdout.decode("utf-8").strip().split("\n")):
+        print(l)
+        k, v = l.split("=")
+        props[k] = v
 
     assert "ID_INPUT" in props
-    assert dev.properties["ID_INPUT"] == "1"
+    assert props["ID_INPUT"] == "1"
 
     assert "ID_INPUT_TABLET" in props
-    assert dev.properties["ID_INPUT_TABLET"] == "1"
+    assert props["ID_INPUT_TABLET"] == "1"
 
-    assert "ID_INPUT_JOYSTICK" not in props
+    if "ID_INPUT_JOYSTICK" not in props:
+        assert props["ID_INPUT_JOYSTICK"] == "0"
 
-    if "Finger" in uinput.name:
-        if uinput.is_touchscreen:
+    if "Finger" in tablet.name:
+        if tablet.is_touchscreen:
             assert "ID_INPUT_TOUCHSCREEN" in props
         else:
             assert "ID_INPUT_TOUCHPAD" in props
 
     # For the Wacom Bamboo Pad we check for "Pad Pad" in the device name
-    if "Pad" in uinput.name:
-        if "Wacom Bamboo Pad" not in uinput.name or "Pad Pad" in uinput.name:
+    if "Pad" in tablet.name:
+        if "Wacom Bamboo Pad" not in tablet.name or "Pad Pad" in tablet.name:
             assert "ID_INPUT_TABLET_PAD" in props

--- a/test/test_udev_rules.py
+++ b/test/test_udev_rules.py
@@ -17,16 +17,35 @@ import pytest
 import time
 import logging
 import sys
+import subprocess
+import shutil
 
 
 @pytest.fixture(scope="session", autouse=True)
 def systemd_reload():
     """Make sure our hwdb and udev rules are up-to-date"""
-    import subprocess
 
     try:
+        hwdb = os.environ.get("LIBWACOM_HWDB_FILE")
+        target = Path("/etc/udev/hwdb.d/99-libwacom-pytest.hwdb")
+        if hwdb:
+            shutil.copyfile(hwdb, target)
+        else:
+            import warnings
+
+            warnings.warn("LIBWACOM_HWDB_FILE is not set, using already installed hwdb")
+
         subprocess.run(["systemd-hwdb", "update"], check=True)
         subprocess.run(["systemctl", "daemon-reload"], check=True)
+
+        yield
+
+        if hwdb:
+            os.unlink(target)
+
+        subprocess.run(["systemd-hwdb", "update"], check=True)
+        subprocess.run(["systemctl", "daemon-reload"], check=True)
+
     except (FileNotFoundError, subprocess.CalledProcessError):
         # If any of the commands above are not found (most likely the system
         # simply does not use systemd), just skip.


### PR DESCRIPTION
This sit on top of #694, only the last commit matters.

This should have no functional effect but it reduces the hwdb file from
~10k lines to under 700 non-comment lines.

Entries with identical properties are now grouped together into one
list of fallthrough-match strings with the property assignments once the
VID changes.

Entries with identical match strings (Huion, Gaomon, etc.) are grouped
together into one list of tablet name comments followed by the match
string.

Entries are now visually separated by VID too to make it easier to spot
the grouping, and the entries are now in this form:
```
  libwacom:name:*:input:b0003v056Ap5222*                       # ISDv4 5222
  libwacom:name:*:input:b0003v056Ap5229*                       # ISDv4 5229
  libwacom:name:*:input:b0003v056Ap522A*                       # ISDv4 5229
   ID_INPUT=1
   ID_INPUT_TABLET=1
   ID_INPUT_JOYSTICK=0
```
Or for where multiple tablets share the same hwdb match:
```
  #                                                             TM156W
  #                                                             U16 TP(4K)
  #                                                             U16(4K)
  #                                                             WH850
  libwacom:name:*:input:b0003v256Cp0064*                       # WH851
  libwacom:name:*:input:b0003v256Cp0066*                       # Inspiroy 2 S
  libwacom:name:*:input:b0003v256Cp0067*                       # Inspiroy 2 M - H951P
  libwacom:name:*:input:b0003v256Cp0068*                       # Inspiroy 2 L - H1061P
```