### PR TITLE
CI: create and make the hwdb.d directory writeable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,8 @@ jobs:
         run: |
           sudo mkdir -p /etc/udev/hwdb.d
           sudo chmod o+rwx /etc/udev/hwdb.d
+      - name: make systemd-hwdb sticky
+        run: sudo chmod +s /usr/bin/systemd-hwdb
       - name: meson test ${{matrix.meson_options}}
         uses: ./.github/actions/meson
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,10 @@ jobs:
         with:
           apt: $UBUNTU_PACKAGES
           pip: $PIP_PACKAGES
+      - name: make /etc/udev/hwdb.d writable
+        run: |
+          sudo mkdir -p /etc/udev/hwdb.d
+          sudo chmod o+rwx /etc/udev/hwdb.d
       - name: meson test ${{matrix.meson_options}}
         uses: ./.github/actions/meson
         with:


### PR DESCRIPTION
We want to drop our hwdb file into that directory, so let's make sure we can do that. Unlike gitlab, we're not running as root.

And by making `sytemd-hwdb` sticky, we can call it as user from our tests and voila, finally the hwdb tests are run in the CI too.