### PR TITLE
Add support for Huion WH1409

### DIFF
--- a/data/huion-wh1409.tablet
+++ b/data/huion-wh1409.tablet
@@ -21,7 +21,7 @@
 [Device]
 Name=TABLET Pen Tablet
 ModelName=
-DeviceMatch=usb|256c|006e|TABLET Pen Tablet Pad;usb|256c|006e|TABLET Pen Tablet Pen;usb|256c|006e|TABLET Pen Tablet Touch Strip;usb|256c|006e|TABLET Pen Tablet Dial
+DeviceMatch=usb|256c|006e||HUION_T153;usb|256c|006e|TABLET Pen Tablet Pad;usb|256c|006e|TABLET Pen Tablet Pen;usb|256c|006e|TABLET Pen Tablet Touch Strip;usb|256c|006e|TABLET Pen Tablet Dial
 Class=Bamboo
 Width=14
 Height=9

--- a/data/huion-wh1409.tablet
+++ b/data/huion-wh1409.tablet
@@ -1,0 +1,40 @@
+# HUION
+# WH1409
+#
+# sysinfo.DFvHUfcRjW.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/385
+#
+# Button Map:
+# (A=1, B=2, C=3, ...)
+#
+#         *----------------------------*
+#    A B  |                            |
+#    c D  |                            |
+#         |                            |
+#    E F  |           TABLET           |
+#    G H  |                            |
+#         |                            |
+#    I J  |                            |
+#    K L  |                            |
+#         *----------------------------*
+
+[Device]
+Name=TABLET Pen Tablet
+ModelName=
+DeviceMatch=usb|256c|006e|TABLET Pen Tablet Pad;usb|256c|006e|TABLET Pen Tablet Pen;usb|256c|006e|TABLET Pen Tablet Touch Strip;usb|256c|006e|TABLET Pen Tablet Dial
+Class=Bamboo
+Width=14
+Height=9
+IntegratedIn=
+Layout=huion-wh1409.svg
+Styli=@generic-no-eraser;
+
+[Features]
+Stylus=true
+Reversible=true
+Touch=false
+NumStrips=0
+
+[Buttons]
+Left=A;B;C;D;E;F;G;H;I;J;K;L
+EvdevCodes=BTN_0;BTN_1;BTN_2;BTN_3;BTN_4;BTN_5;BTN_6;BTN_7;BTN_8;BTN_9;BTN_SOUTH;BTN_EAST

--- a/data/huion-wh1409.tablet
+++ b/data/huion-wh1409.tablet
@@ -19,7 +19,7 @@
 #         *----------------------------*
 
 [Device]
-Name=TABLET Pen Tablet
+Name=Huion WH1409
 ModelName=
 DeviceMatch=usb|256c|006e||HUION_T153;usb|256c|006e|TABLET Pen Tablet Pad;usb|256c|006e|TABLET Pen Tablet Pen;usb|256c|006e|TABLET Pen Tablet Touch Strip;usb|256c|006e|TABLET Pen Tablet Dial
 Class=Bamboo

--- a/data/layouts/huion-wh1409.svg
+++ b/data/layouts/huion-wh1409.svg
@@ -1,0 +1,276 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg
+   version="1.1"
+   style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
+   id="huion-wh1409"
+   width="385"
+   height="226"
+   xmlns="http://www.w3.org/2000/svg">
+  <title
+     id="title">Huion WH1409</title>
+  <g
+     id="g1">
+    <rect
+       id="ButtonA"
+       class="A ModeSwitch Button"
+       width="16"
+       height="10"
+       x="10"
+       y="114"
+       ry="1" />
+    <path
+       id="LeaderA"
+       class="A ModeSwitch Leader"
+       d="M 7,121 H 9" />
+    <text
+       id="LabelA"
+       class="A ModeSwitch Label"
+       x="1"
+       y="121"
+       style="text-anchor:start">A</text>
+  </g>
+  <g
+     id="g2"
+     style="display:inline">
+    <rect
+       id="ButtonB"
+       class="B ModeSwitch Button"
+       width="16"
+       height="10"
+       x="28"
+       y="114"
+       ry="1" />
+    <path
+       id="LeaderB"
+       class="B ModeSwitch Leader"
+       d="m 45,121 h 2" />
+    <text
+       id="LabelB"
+       class="B ModeSwitch Label"
+       x="47"
+       y="121"
+       style="text-anchor:start">B</text>
+  </g>
+  <g
+     id="g3"
+     style="display:inline">
+    <rect
+       id="ButtonC"
+       class="C ModeSwitch Button"
+       width="16"
+       height="10"
+       x="10"
+       y="126"
+       ry="1" />
+    <path
+       id="LeaderC"
+       class="C ModeSwitch Leader"
+       d="M 7,133 H 9" />
+    <text
+       id="LabelC"
+       class="C ModeSwitch Label"
+       x="1"
+       y="133"
+       style="text-anchor:start">C</text>
+  </g>
+  <g
+     id="g4"
+     style="display:inline">
+    <rect
+       id="ButtonD"
+       class="D ModeSwitch Button"
+       width="16"
+       height="10"
+       x="28"
+       y="126"
+       ry="1" />
+    <path
+       id="LeaderD"
+       class="D ModeSwitch Leader"
+       d="m 45,133 h 2" />
+    <text
+       id="LabelD"
+       class="D ModeSwitch Label"
+       x="47"
+       y="133"
+       style="text-anchor:start">D</text>
+  </g>
+  <g
+     id="g5"
+     style="display:inline">
+    <rect
+       id="ButtonE"
+       class="E ModeSwitch Button"
+       width="16"
+       height="10"
+       x="10"
+       y="148"
+       ry="1" />
+    <path
+       id="LeaderE"
+       class="E ModeSwitch Leader"
+       d="M 7,155 H 9" />
+    <text
+       id="LabelE"
+       class="E ModeSwitch Label"
+       x="1"
+       y="155"
+       style="text-anchor:start">E</text>
+  </g>
+  <g
+     id="g6"
+     style="display:inline">
+    <rect
+       id="ButtonF"
+       class="F ModeSwitch Button"
+       width="16"
+       height="10"
+       x="28"
+       y="148"
+       ry="1" />
+    <path
+       id="LeaderF"
+       class="F ModeSwitch Leader"
+       d="m 45,155 h 2" />
+    <text
+       id="LabelF"
+       class="F ModeSwitch Label"
+       x="47"
+       y="155"
+       style="text-anchor:start">F</text>
+  </g>
+  <g
+     id="g7"
+     style="display:inline">
+    <rect
+       id="ButtonG"
+       class="G ModeSwitch Button"
+       width="16"
+       height="10"
+       x="10"
+       y="160"
+       ry="1" />
+    <path
+       id="LeaderG"
+       class="G ModeSwitch Leader"
+       d="M 7,167 H 9" />
+    <text
+       id="LabelG"
+       class="G ModeSwitch Label"
+       x="1"
+       y="167"
+       style="text-anchor:start">G</text>
+  </g>
+  <g
+     id="g8"
+     style="display:inline">
+    <rect
+       id="ButtonH"
+       class="H ModeSwitch Button"
+       width="16"
+       height="10"
+       x="28"
+       y="160"
+       ry="1" />
+    <path
+       id="LeaderH"
+       class="H ModeSwitch Leader"
+       d="m 45,167 h 2" />
+    <text
+       id="LabelH"
+       class="H ModeSwitch Label"
+       x="47"
+       y="167"
+       style="text-anchor:start">H</text>
+  </g>
+  <g
+     id="g9"
+     style="display:inline">
+    <rect
+       id="ButtonI"
+       class="I ModeSwitch Button"
+       width="16"
+       height="10"
+       x="10"
+       y="182"
+       ry="1" />
+    <path
+       id="LeaderI"
+       class="I ModeSwitch Leader"
+       d="M 7,189 H 9" />
+    <text
+       id="LabelI"
+       class="I ModeSwitch Label"
+       x="4"
+       y="189"
+       style="text-anchor:start">I</text>
+  </g>
+  <g
+     id="g10"
+     style="display:inline">
+    <rect
+       id="ButtonJ"
+       class="J ModeSwitch Button"
+       width="16"
+       height="10"
+       x="28"
+       y="182"
+       ry="1" />
+    <path
+       id="LeaderJ"
+       class="J ModeSwitch Leader"
+       d="m 45,189 h 2" />
+    <text
+       id="LabelJ"
+       class="J ModeSwitch Label"
+       x="48"
+       y="189"
+       style="text-anchor:start">J</text>
+  </g>
+  <g
+     id="g11"
+     style="display:inline">
+    <rect
+       id="ButtonK"
+       class="K ModeSwitch Button"
+       width="16"
+       height="10"
+       x="10"
+       y="194"
+       ry="1" />
+    <path
+       id="LeaderK"
+       class="K ModeSwitch Leader"
+       d="M 7,201 H 9" />
+    <text
+       id="LabelK"
+       class="K ModeSwitch Label"
+       x="1"
+       y="201"
+       style="text-anchor:start">K</text>
+  </g>
+  <g
+     id="g12"
+     style="display:inline">
+    <rect
+       id="ButtonL"
+       class="L ModeSwitch Button"
+       width="16"
+       height="10"
+       x="28"
+       y="194"
+       ry="1" />
+    <path
+       id="LeaderL"
+       class="L ModeSwitch Leader"
+       d="m 45,201 h 2" />
+    <text
+       id="LabelL"
+       class="L ModeSwitch Label"
+       x="48"
+       y="201"
+       style="text-anchor:start">L</text>
+  </g>
+</svg>


### PR DESCRIPTION
Hello!

These are the two files (.tablet and .svg) to add support to the [Huion WH1409](https://www.huion.com/pen_tablet/Inspiroy/WH1409(8192).html). You can find the link to the sysinfo tarball within the .tablet file, or over [here](https://github.com/linuxwacom/wacom-hid-descriptors/issues/385).

Just for clarity, this is **not** the V2 version of the tablet.

I also need to state that while `libwacom-list-local-devices` shows the device correctly, KDE Tablet Settings, at least under X11, does not currently pick it up. Actually it picks the tablet up as a game controller, which is odd. I don't know if that bit of information is useful or not. Otherwise the tablet, including pen pressure, works just fine.

If you have any concerns about my pull request or anything regarding the last point, please let me know!

Thanks!