### PR TITLE
Don't mark Keyboard and Mouse devices as ID_INPUT_TABLET or ID_INPUT_TABLET_PAD

### DIFF
--- a/tools/libwacom-update-db.py
+++ b/tools/libwacom-update-db.py
@@ -86,6 +86,7 @@ class HWDBFile:
         # Keyboard device name.
         if int(vid, 16) != 0x56A:
             entries["* Keyboard"] = ["ID_INPUT_TABLET=0", "ID_INPUT_TABLET_PAD=0"]
+            entries["* Mouse"] = ["ID_INPUT_TABLET=0", "ID_INPUT_TABLET_PAD=0"]
 
         lines = [f"# {tablet.name}"]
         for name, props in entries.items():

--- a/tools/libwacom-update-db.py
+++ b/tools/libwacom-update-db.py
@@ -85,7 +85,7 @@ class HWDBFile:
         # Let's add a generic exclusion rule for anything we know of with a
         # Keyboard device name.
         if int(vid, 16) != 0x56A:
-            entries["* Keyboard"] = ["ID_INPUT_TABLET=0"]
+            entries["* Keyboard"] = ["ID_INPUT_TABLET=0", "ID_INPUT_TABLET_PAD=0"]
 
         lines = [f"# {tablet.name}"]
         for name, props in entries.items():


### PR DESCRIPTION
This should cut down on false positives or at least the ones caused by us.


Related https://github.com/DIGImend/digimend-kernel-drivers/pull/695, cc @JoseExposito 