### PR TITLE
data: drop the firmware match from the Huion Inspiroy 2 S

### DIFF
--- a/data/huion-inspiroy-2-s---h641p.tablet
+++ b/data/huion-inspiroy-2-s---h641p.tablet
@@ -34,7 +34,7 @@
 Name=Inspiroy 2 S
 ModelName=H641P
 Class=Bamboo
-DeviceMatch=usb|256c|0066||HUION_T21j;
+DeviceMatch=usb|256c|0066;
 Width=6
 Height=4
 Layout=huion-inspiroy-2-s---h641p.svg


### PR DESCRIPTION
This devices appears to have its own unique PID so we don't need the firmware match here. This matches the M and L version which also have a unique PID.

If Huion or Gaomon end up releasing devices that share this PID we'll have to re-instated the firmware match but for now let's drop it.


---

Slightly improves #718 since at least the udev properties are no longer needed