### PR TITLE
Set the device name for a fallback device

### DIFF
--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -818,6 +818,7 @@ libwacom_new_from_path(const WacomDeviceDatabase *db, const char *path, WacomFal
 
 	builder = libwacom_builder_new();
 	libwacom_builder_set_match_name(builder, name);
+	libwacom_builder_set_device_name(builder, name);
 	libwacom_builder_set_bustype(builder, bus);
 	libwacom_builder_set_uniq(builder, uniq);
 	libwacom_builder_set_usbid(builder, vendor_id, product_id);

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -698,6 +698,12 @@ class WacomDatabase:
         device = self.libwacom_new_from_name(name.encode("utf-8"), 0)
         return WacomDevice(device) if device else None
 
+    def new_from_path(
+        self, path: str, fallback: Fallback = Fallback.NONE
+    ) -> Optional[WacomDevice]:
+        device = self.libwacom_new_from_path(path.encode("utf-8"), fallback, 0)
+        return WacomDevice(device) if device else None
+
     def new_from_usbid(self, vid: int, pid: int) -> Optional[WacomDevice]:
         device = self.libwacom_new_from_usbid(vid, pid, 0)
         return WacomDevice(device) if device else None

--- a/test/test_libwacom.py
+++ b/test/test_libwacom.py
@@ -379,8 +379,11 @@ def test_dont_ignore_exact_matches(custom_datadir):
     assert device is None
 
 
-# Emulates the behavior of new_from_path for an unknown device
-@pytest.mark.parametrize("fallback", (WacomDatabase.Fallback.NONE, WacomDatabase.Fallback.GENERIC))
+# Emulates the behavior of new_from_path for an unknown device but without
+# uinput devices
+@pytest.mark.parametrize(
+    "fallback", (WacomDatabase.Fallback.NONE, WacomDatabase.Fallback.GENERIC)
+)
 @pytest.mark.parametrize("bustype", (WacomBustype.USB, WacomBustype.BLUETOOTH))
 def test_new_unknown_device_with_fallback(custom_datadir, fallback, bustype):
     USBID = (0x1234, 0x5678)
@@ -402,3 +405,65 @@ def test_new_unknown_device_with_fallback(custom_datadir, fallback, bustype):
         assert device.name == NAME
     else:
         assert device is None
+
+
+def create_uinput(name, vid, pid):
+    libevdev = pytest.importorskip("libevdev")
+    dev = libevdev.Device()
+    dev.name = name
+    dev.id = {"bustype": 0x3, "vendor": vid, "product": pid}
+    dev.enable(
+        libevdev.EV_ABS.ABS_X,
+        libevdev.InputAbsInfo(minimum=0, maximum=10000, resolution=200),
+    )
+    dev.enable(
+        libevdev.EV_ABS.ABS_Y,
+        libevdev.InputAbsInfo(minimum=0, maximum=10000, resolution=200),
+    )
+    dev.enable(libevdev.EV_KEY.BTN_STYLUS)
+    dev.enable(libevdev.EV_KEY.BTN_TOOL_PEN)
+    try:
+        return dev.create_uinput_device()
+    except OSError as e:
+        pytest.skip(f"Failed to create uinput device: {e}")
+
+
+@pytest.mark.parametrize(
+    "fallback", (WacomDatabase.Fallback.NONE, WacomDatabase.Fallback.GENERIC)
+)
+def test_new_from_path_known_device(fallback):
+    name = "Wacom Intuos4 WL"
+    vid = 0x056A
+    pid = 0x00BC
+    uinput = create_uinput(name, vid, pid)
+
+    db = WacomDatabase()
+    dev = db.new_from_path(
+        uinput.devnode, fallback=fallback
+    )  # fallback has no effect here
+    assert dev is not None
+    assert dev.name == name
+    assert dev.vendor_id == vid
+    assert dev.product_id == pid
+
+
+@pytest.mark.parametrize(
+    "fallback", (WacomDatabase.Fallback.NONE, WacomDatabase.Fallback.GENERIC)
+)
+def test_new_from_path_unknown_device(fallback):
+    name = "Unknown device"
+    vid = 0x1234
+    pid = 0xABAC
+    uinput = create_uinput(name, vid, pid)
+
+    db = WacomDatabase()
+    dev = db.new_from_path(
+        uinput.devnode, fallback=fallback
+    )  # fallback has no effect here
+    if fallback == WacomDatabase.Fallback.NONE:
+        assert dev is None
+    else:
+        assert dev is not None
+        assert dev.name == name
+        assert dev.vendor_id == 0
+        assert dev.product_id == 0

--- a/test/test_libwacom.py
+++ b/test/test_libwacom.py
@@ -386,7 +386,9 @@ def test_new_unknown_device_with_fallback(custom_datadir, fallback, bustype):
     USBID = (0x1234, 0x5678)
     NAME = "nameval"
     db = WacomDatabase(path=custom_datadir)
-    builder = WacomBuilder.create(usbid=USBID, bus=bustype, match_name=NAME)
+    builder = WacomBuilder.create(
+        usbid=USBID, bus=bustype, match_name=NAME, device_name=NAME
+    )
 
     device = db.new_from_builder(builder, fallback=fallback)
     if fallback:
@@ -397,5 +399,6 @@ def test_new_unknown_device_with_fallback(custom_datadir, fallback, bustype):
         assert device.bustype == WacomBustype.UNKNOWN
         assert device.vendor_id == 0
         assert device.product_id == 0
+        assert device.name == NAME
     else:
         assert device is None


### PR DESCRIPTION
Regression as a result of the switch to use the builder