### PR TITLE
StarLabs Starlite Mk V Support

### DIFF
--- a/data/starlabs-starlite-v.tablet
+++ b/data/starlabs-starlite-v.tablet
@@ -1,0 +1,14 @@
+# This is for the StarLabs Starlite Mk V
+#
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/392
+# sysinfo.UkQ9Px1eOS
+
+[Device]
+Name=StarLabs Starlite V
+Class=ISDV4
+DeviceMatch=i2c:27C6:0111
+IntegratedIn=Display;System;
+
+[Features]
+Stylus=true
+Touch=true


### PR DESCRIPTION
Adds support for StarLabs Starlite Mk V Tablet Device. Tested with official pen. 

Descriptors: https://github.com/linuxwacom/wacom-hid-descriptors/issues/392

This PR is marked as a draft as there is two versions of the starlabs MK V, The first batch which I have which has a 3k screen and the second batch which has a 2k screen. I have no clue if this changes the touch screen hardware so I am waiting on a test before marking this as ready.