### PR TITLE
Id and group modifications

### DIFF
--- a/data/libwacom.stylus
+++ b/data/libwacom.stylus
@@ -303,14 +303,6 @@ Buttons=3
 Axes=Tilt;Pressure;Distance;
 Type=General
 
-[0x40200]
-# Cintiq Pro 2022
-Name=Pro Pen 3
-Group=cintiqpro2022
-Buttons=3
-Axes=Tilt;Pressure;Distance;
-Type=General
-
 [0x80842]
 # MobileStudio Pro
 Name=Pro Pen 3D

--- a/data/wacom-movink.tablet
+++ b/data/wacom-movink.tablet
@@ -35,7 +35,7 @@ DeviceMatch=usb|056a|03f0
 Class=Cintiq
 Width=11
 Height=8
-Styli=@udpen;
+Styli=@udpen;@mobilestudio;@propengen2;
 IntegratedIn=Display
 Layout=wacom-movink.svg
 


### PR DESCRIPTION
We found that there was the unnecessary ID remained on libwacom.stylus
and Movink supports more groups for libwacom to work properly.