### PR TITLE
Movink naming modification

### DIFF
--- a/data/layouts/wacom-movink-13.svg
+++ b/data/layouts/wacom-movink-13.svg
@@ -2,10 +2,10 @@
 <svg
    version="1.1"
    style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
-   id="movink"
+   id="movink-13"
    width="410"
    height="264"
-   sodipodi:docname="movink.svg"
+   sodipodi:docname="movink-13.svg"
    inkscape:version="1.3.2 (1:1.3.2+202311252150+091e20ef0f)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -61,7 +61,7 @@
        inkscape:locked="false" />
   </sodipodi:namedview>
   <title
-     id="title">Wacom Movink</title>
+     id="title">Wacom Movink 13</title>
   <g
      id="g8">
     <rect
@@ -114,7 +114,7 @@
     <rdf:RDF>
       <cc:Work
          rdf:about="">
-        <dc:title>Wacom Movink</dc:title>
+        <dc:title>Wacom Movink 13</dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/data/libwacom.stylus
+++ b/data/libwacom.stylus
@@ -743,7 +743,7 @@ HasWheel=true
 Buttons=5
 
 [0x10002]
-# Movink
+# Wacom Movink 13
 Name=UD Pen
 Group=udpen
 PairedStylusIds=0x1000a;
@@ -752,7 +752,7 @@ Axes=Tilt;Pressure;Distance;
 Type=General
 
 [0x1000a]
-# Movink
+# Wacom Movink 13
 Name=UD Pen Eraser
 Group=udpen
 PairedStylusIds=0x10002;

--- a/data/wacom-movink-13.tablet
+++ b/data/wacom-movink-13.tablet
@@ -1,4 +1,5 @@
-# Wacom Movink DTH135K0C
+# Wacom Movink 13
+# Model Name: DTH135K0C
 # Sensor Type: EMR
 # Features: Touch (Integrated), Tilt
 #
@@ -29,7 +30,7 @@
 # sysinfo.4XIn8KkXzp
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/376#issue-2270545906
 [Device]
-Name=Wacom Movink
+Name=Wacom Movink 13
 ModelName=DTH-135K0C
 DeviceMatch=usb|056a|03f0
 Class=Cintiq
@@ -37,7 +38,7 @@ Width=11
 Height=8
 Styli=@udpen;@mobilestudio;@propengen2;
 IntegratedIn=Display
-Layout=wacom-movink.svg
+Layout=wacom-movink-13.svg
 
 [Features]
 Stylus=true


### PR DESCRIPTION
Previously uploaded files for Wacom Movink 13 had slightly a wrong name, which was "Wacom Movink".
Therefore, the names such as "movink" and "Movink" were corrected to "movink-13" and "Movink 13" reflecting more appropriate product name.
The commits involved with deletions, so please let me know if there's something wrong.