### PR TITLE
data: Add stylus definition for Pro Pen 3E

### DIFF
--- a/data/libwacom.stylus
+++ b/data/libwacom.stylus
@@ -298,7 +298,16 @@ Type=General
 [0x200]
 # Cintiq Pro 2022
 Name=Pro Pen 3
-Group=cintiqpro2022
+Group=propen3
+Buttons=3
+Axes=Tilt;Pressure;Distance;
+Type=General
+
+[0x202]
+# Wacom Movink 13
+Name=Pro Pen 3E
+Group=propen3
+PairedStylusIds=0x20a;
 Buttons=3
 Axes=Tilt;Pressure;Distance;
 Type=General
@@ -453,6 +462,16 @@ Group=mobilestudio
 PairedStylusIds=0x842;
 EraserType=Invert
 Buttons=2
+Axes=Tilt;Pressure;Distance;
+Type=General
+
+[0x20A]
+# Wacom Movink 13
+Name=Pro Pen 3E Eraser
+Group=propen3
+PairedStylusIds=0x202;
+EraserType=Invert
+Buttons=3
 Axes=Tilt;Pressure;Distance;
 Type=General
 

--- a/data/wacom-cintiq-pro-17.tablet
+++ b/data/wacom-cintiq-pro-17.tablet
@@ -33,7 +33,7 @@ DeviceMatch=usb|056a|03c4
 Width=15
 Height=8
 Layout=wacom-cintiq-pro-17.svg
-Styli=@cintiqpro2022;@mobilestudio;@propengen2;
+Styli=@propen3;@mobilestudio;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/wacom-cintiq-pro-22.tablet
+++ b/data/wacom-cintiq-pro-22.tablet
@@ -33,7 +33,7 @@ DeviceMatch=usb|056a|03d0
 Width=18
 Height=10
 Layout=wacom-cintiq-pro-22.svg
-Styli=@cintiqpro2022;@mobilestudio;@propengen2;
+Styli=@propen3;@mobilestudio;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/wacom-cintiq-pro-27.tablet
+++ b/data/wacom-cintiq-pro-27.tablet
@@ -33,7 +33,7 @@ DeviceMatch=usb|056a|03c0
 Width=24
 Height=13
 Layout=wacom-cintiq-pro-27.svg
-Styli=@cintiqpro2022;@mobilestudio;@propengen2;
+Styli=@propen3;@mobilestudio;@propengen2;
 IntegratedIn=Display
 
 [Features]

--- a/data/wacom-movink-13.tablet
+++ b/data/wacom-movink-13.tablet
@@ -36,7 +36,7 @@ DeviceMatch=usb|056a|03f0
 Class=Cintiq
 Width=11
 Height=8
-Styli=@udpen;@mobilestudio;@propengen2;
+Styli=@udpen;@mobilestudio;@propengen2;@propen3;
 IntegratedIn=Display
 Layout=wacom-movink-13.svg
 


### PR DESCRIPTION
The Pro Pen 3E is a version of the Pro Pen 3 which includes an eraser and is compatible with the same devices. This patch also adds the propen3 group to Movink, which should have had it.