### PR TITLE
data: Update comment header for 1st- and 2nd-gen Intuos Pro

### DIFF
--- a/data/wacom-intuos-pro-2-l.tablet
+++ b/data/wacom-intuos-pro-2-l.tablet
@@ -1,6 +1,7 @@
 # Wacom
-# Intuos Pro 2 L
+# Intuos Pro L
 # PTH-860
+# (Second Generation)
 #
 # Button Map:
 # (A=1, B=2, C=3, ...)

--- a/data/wacom-intuos-pro-2-m.tablet
+++ b/data/wacom-intuos-pro-2-m.tablet
@@ -1,6 +1,7 @@
 # Wacom
-# Intuos Pro 2 M
+# Intuos Pro M
 # PTH-660
+# (Second Generation)
 #
 # Button Map:
 # (A=1, B=2, C=3, ...)

--- a/data/wacom-intuos-pro-2-s.tablet
+++ b/data/wacom-intuos-pro-2-s.tablet
@@ -1,6 +1,7 @@
 # Wacom
-# Intuos Pro 2 S
+# Intuos Pro S
 # PTH-460
+# (Second Generation)
 #
 # Button Map:
 # (A=1, B=2, C=3, ...)

--- a/data/wacom-intuos-pro-l.tablet
+++ b/data/wacom-intuos-pro-l.tablet
@@ -1,6 +1,7 @@
 # Wacom
 # Intuos Pro L
 # PTH-851
+# (First Generation)
 #
 # Button Map:
 # (A=1, B=2, C=3, ...)

--- a/data/wacom-intuos-pro-m.tablet
+++ b/data/wacom-intuos-pro-m.tablet
@@ -1,6 +1,7 @@
 # Wacom
 # Intuos Pro M
 # PTH-651
+# (First Generation)
 #
 # Button Map:
 # (A=1, B=2, C=3, ...)

--- a/data/wacom-intuos-pro-s.tablet
+++ b/data/wacom-intuos-pro-s.tablet
@@ -1,6 +1,7 @@
 # Wacom
 # Intuos Pro S
 # PTH-451
+# (First Generation)
 #
 # Button Map:
 # (A=1, B=2, C=3, ...)


### PR DESCRIPTION
Updates the comment headers for these devices to use the marketing name (already properly set in the "Name" field) and move the generation information to its own separate line).