### PR TITLE
Add support for styli from vendors other than Wacom

### DIFF
--- a/data/libwacom.stylus
+++ b/data/libwacom.stylus
@@ -1,22 +1,22 @@
 # Some generic fallback styli
-[0xfffff]
+[0x0:0xfffff]
 Name=General Pen
 Group=generic-with-eraser
-PairedStylusIds=0xffffe;
+PairedStylusIds=0x0:0xffffe;
 Buttons=2
 Axes=Tilt;Pressure;Distance;
 Type=General
 
-[0xffffe]
+[0x0:0xffffe]
 Name=General Pen Eraser
 Group=generic-with-eraser
-PairedStylusIds=0xfffff;
+PairedStylusIds=0x0:0xfffff;
 EraserType=Invert
 Buttons=2
 Axes=Tilt;Pressure;Distance;
 Type=General
 
-[0xffffd]
+[0x0:0xffffd]
 Name=General Pen with no Eraser
 Group=generic-no-eraser
 Buttons=2

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -271,17 +271,17 @@ libwacom_parse_stylus_keyfile(WacomDeviceDatabase *db, const char *path)
 		WacomStylus *stylus;
 		GError *error = NULL;
 		char *eraser_type, *type;
-		int id;
+		int tool_id;
 		char **string_list;
 
-		if (!safe_atoi_base (groups[i], &id, 16)) {
+		if (!safe_atoi_base (groups[i], &tool_id, 16)) {
 			g_warning ("Failed to parse stylus ID '%s'", groups[i]);
 			continue;
 		}
 
 		stylus = g_new0 (WacomStylus, 1);
 		stylus->refcnt = 1;
-		stylus->id = id;
+		stylus->tool_id = tool_id;
 		stylus->name = g_key_file_get_string(keyfile, groups[i], "Name", NULL);
 		stylus->group = g_key_file_get_string(keyfile, groups[i], "Group", NULL);
 
@@ -346,10 +346,10 @@ libwacom_parse_stylus_keyfile(WacomDeviceDatabase *db, const char *path)
 		stylus->type = type_from_str (type);
 		g_clear_pointer(&type, g_free);
 
-		if (g_hash_table_lookup (db->stylus_ht, GINT_TO_POINTER (id)) != NULL)
-			g_warning ("Duplicate definition for stylus ID '%#x'", id);
+		if (g_hash_table_lookup (db->stylus_ht, GINT_TO_POINTER (tool_id)) != NULL)
+			g_warning ("Duplicate definition for stylus ID '%#x'", tool_id);
 
-		g_hash_table_insert (db->stylus_ht, GINT_TO_POINTER (id), stylus);
+		g_hash_table_insert (db->stylus_ht, GINT_TO_POINTER (tool_id), stylus);
 	}
 	g_clear_pointer(&groups, g_strfreev);
 	g_clear_pointer(&keyfile, g_key_file_free);
@@ -721,7 +721,7 @@ libwacom_parse_styli_list(WacomDeviceDatabase *db, WacomDevice *device,
 			while (g_hash_table_iter_next (&iter, &key, &value)) {
 				WacomStylus *stylus = value;
 				if (stylus->group && g_str_equal(group, stylus->group)) {
-					g_array_append_val (array, stylus->id);
+					g_array_append_val (array, stylus->tool_id);
 				}
 			}
 		} else {

--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -1543,7 +1543,7 @@ libwacom_stylus_get_for_id (const WacomDeviceDatabase *db, int id)
 LIBWACOM_EXPORT int
 libwacom_stylus_get_id (const WacomStylus *stylus)
 {
-	return stylus->id;
+	return stylus->tool_id;
 }
 
 LIBWACOM_EXPORT const char *
@@ -1564,7 +1564,7 @@ LIBWACOM_EXPORT int
 libwacom_stylus_get_num_buttons (const WacomStylus *stylus)
 {
 	if (stylus->num_buttons == -1) {
-		g_warning ("Stylus '0x%x' has no number of buttons defined, falling back to 2", stylus->id);
+		g_warning ("Stylus '0x%x' has no number of buttons defined, falling back to 2", stylus->tool_id);
 		return 2;
 	}
 	return stylus->num_buttons;
@@ -1604,7 +1604,7 @@ LIBWACOM_EXPORT WacomStylusType
 libwacom_stylus_get_type (const WacomStylus *stylus)
 {
 	if (stylus->type == WSTYLUS_UNKNOWN) {
-		g_warning ("Stylus '0x%x' has no type defined, falling back to 'General'", stylus->id);
+		g_warning ("Stylus '0x%x' has no type defined, falling back to 'General'", stylus->tool_id);
 		return WSTYLUS_GENERAL;
 	}
 	return stylus->type;

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -648,8 +648,25 @@ int libwacom_get_num_keys(const WacomDevice *device);
  * @return an array of Styli IDs supported by the device
  *
  * @ingroup styli
+ * @deprecated 2.14 Use libwacom_get_styli() instead.
  */
+LIBWACOM_DEPRECATED
 const int *libwacom_get_supported_styli(const WacomDevice *device, int *num_styli);
+
+/**
+ * @param device The tablet to query
+ * @param[out] num_styli Optional return location for the number of listed styli,
+ *			 excluding the NULL terminator.
+ * @return A null-terminated array of WacomStylus that are supported by this
+ *	   device
+ *
+ * The content of the list is owned by the database and must not be
+ * modified or freed. Use free() to free the list.
+ *
+ * @since 2.14
+ * @ingroup styli
+ */
+const WacomStylus ** libwacom_get_styli(const WacomDevice *device, int *num_styli);
 
 /**
  * @param device The tablet to query
@@ -824,12 +841,17 @@ int libwacom_get_button_evdev_code(const WacomDevice *device,
 /**
  * Get the WacomStylus for the given tool ID.
  *
+ * The vendor ID is assumed to be the Wacom vendor id 0x56a.
+ *
  * @param db A Tablet and Stylus database.
  * @param id The Tool ID for this stylus
  * @return A WacomStylus representing the stylus. Do not free.
  *
  * @ingroup styli
+ * @deprecated 2.14 Use libwacom_get_styli() and
+ * libwacom_stylus_get_paired_styli() to obtain the WacomStylus directly
  */
+LIBWACOM_DEPRECATED
 const WacomStylus *libwacom_stylus_get_for_id (const WacomDeviceDatabase *db, int id);
 
 /**
@@ -839,6 +861,15 @@ const WacomStylus *libwacom_stylus_get_for_id (const WacomDeviceDatabase *db, in
  * @ingroup styli
  */
 int         libwacom_stylus_get_id (const WacomStylus *stylus);
+
+/**
+ * @param stylus The stylus to query
+ * @return the vendor ID of the tool
+ *
+ * @ingroup styli
+ * @since 2.14
+ */
+int         libwacom_stylus_get_vendor_id (const WacomStylus *stylus);
 
 /**
  * @param stylus The stylus to query
@@ -853,9 +884,29 @@ const char *libwacom_stylus_get_name (const WacomStylus *stylus);
  * @param num_paired_ids The length of the returned list
  * @return The list of other IDs paired to this stylus
  *
+ * For historical reasons this function will only return paired ids that
+ * match Wacom's vendor ID 0x56a. Callers should use
+ * libwacom_stylus_get_paired_styli() instead.
+ *
  * @ingroup styli
+ * @deprecated 2.14 Use libwacom_stylus_get_paired_styli() instead
  */
+LIBWACOM_DEPRECATED
 const int *libwacom_stylus_get_paired_ids(const WacomStylus *stylus, int *num_paired_ids);
+
+/**
+ * @param stylus The stylus to query
+ * @param[out] num_paired Optional return location for the length of the
+ * returned list, excluding the NULL terminator
+ * @return A NULL-terminated list contain the styli paired with this stylus
+ *
+ * The content of the list is owned by the database and must not be
+ * modified or freed. Use free() to free the list.
+ *
+ * @ingroup styli
+ * @since 2.14
+ */
+const WacomStylus **libwacom_stylus_get_paired_styli(const WacomStylus *stylus, int *num_paired);
 
 /**
  * @param stylus The stylus to query

--- a/libwacom/libwacom.sym
+++ b/libwacom/libwacom.sym
@@ -88,3 +88,9 @@ LIBWACOM_2.12 {
     libwacom_builder_set_usbid;
     libwacom_new_from_builder;
 } LIBWACOM_2.9;
+
+LIBWACOM_2.14 {
+    libwacom_get_styli;
+    libwacom_stylus_get_paired_styli;
+    libwacom_stylus_get_vendor_id;
+} LIBWACOM_2.12;

--- a/libwacom/libwacomint.h
+++ b/libwacom/libwacomint.h
@@ -121,7 +121,7 @@ struct _WacomDevice {
 
 struct _WacomStylus {
 	gint refcnt;
-	int id;
+	int tool_id;
 	char *name;
 	char *group;
 	int num_buttons;

--- a/test/test-dbverify.c
+++ b/test/test-dbverify.c
@@ -179,7 +179,7 @@ duplicate_database(WacomDeviceDatabase *db, const char *dirname)
 		int fd;
 		char *path = NULL;
 		int nstyli;
-		const int *styli;
+		const WacomStylus **styli;
 
 		g_assert(asprintf(&path, "%s/%s.tablet", dirname,
 				libwacom_get_match(*device)) != -1);
@@ -193,20 +193,19 @@ duplicate_database(WacomDeviceDatabase *db, const char *dirname)
 		if (!libwacom_has_stylus(*device))
 			continue;
 
-		styli = libwacom_get_supported_styli(*device, &nstyli);
+		styli = libwacom_get_styli(*device, &nstyli);
 		for (i = 0; i < nstyli; i++) {
 			int fd_stylus;
-			const WacomStylus *stylus;
+			const WacomStylus *stylus = styli[i];
 
-			g_assert(asprintf(&path, "%s/%#x.stylus", dirname, styli[i]) != -1);
-			stylus = libwacom_stylus_get_for_id(db, styli[i]);
-			g_assert(stylus);
+			g_assert(asprintf(&path, "%s/%#x.stylus", dirname, libwacom_stylus_get_id(stylus)) != -1);
 			fd_stylus = open(path, O_WRONLY|O_CREAT, S_IRWXU);
 			g_assert(fd_stylus >= 0);
 			libwacom_print_stylus_description(fd_stylus, stylus);
 			close(fd_stylus);
 			free(path);
 		}
+		free(styli);
 	}
 
 	free(devices);

--- a/tools/list-compatible-styli.c
+++ b/tools/list-compatible-styli.c
@@ -38,7 +38,7 @@
 static void
 print_device_info(const WacomDeviceDatabase *db, const WacomDevice *device)
 {
-	const int *styli;
+	WacomStylus const **styli;
 	int nstyli;
 
 	printf("- name: '%s'\n", libwacom_get_name(device));
@@ -52,17 +52,17 @@ print_device_info(const WacomDeviceDatabase *db, const WacomDevice *device)
 
 	printf("  styli:\n");
 
-	styli = libwacom_get_supported_styli(device, &nstyli);
+	styli = libwacom_get_styli(device, &nstyli);
 	for (int i = 0; i < nstyli; i++) {
-		const WacomStylus *s;
+		const WacomStylus *s = styli[i];
 		char id[64];
 
-		s = libwacom_stylus_get_for_id(db, styli[i]);
 		snprintf(id, sizeof(id), "0x%x", libwacom_stylus_get_id(s));
 		printf("    - { id: %*s'%s', name: '%s' }\n",
 		       (int)(7 - strlen(id)), " ", id,
 		       libwacom_stylus_get_name(s));
 	}
+	g_free(styli);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
This adds support for styli that aren't implicitly wacom styli.

Right now our API supports two types of styli: the few generic ones with IDs that wacom doesn't (hopefully won't ever) use. And all other real styli with actual ids but those are assumed to be Wacom styli - if any other vendor starts using IDs (possibly the one in #636 but it's not fully clear whether it is a true stylus id) we are running into issues because we won't be able to differentiate.

This patch adds a vendor id to the `WacomStylus` and the associated APIs. The generic pens have a vendor id of 0, everything else defaults to 0x56a unless explicitly specified otherwise.
The current set of APIs is deprecated and replaced with an API that returns a `WacomStylus` instead of just an id, e.g. `const int * libwacom_get_supported_styli()` is superseded by `const WacomStylus ** libwacom_get_styli()` and the same approach for the `get_paired` API.

Unlike the previous APIs the return value is an allocated list that must be freed by the caller (but not the list contents). It's IMO the better API and clients should switch to that because "here is $thing" is a lot more sane than "here's a magic number, now look it up so I can give you $thing" even if the actual functionality doesn't matter for now :) 

Closes #639

---
Not 100% if returning this as `const WacomStylus` is the right idea, it effectively prohibits us from ever doing anything with the stylus in the future, even if it's just `wacom_stylus_ref()` (if we add this). OTOH doing even that would require a major rework of libwacom's internals and the use of that is quite limited - callers can copy the few properties that they need.