### PR TITLE
ci: make /etc/udev/hwdb.d writable in the valgrind job too

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,10 @@ jobs:
         with:
           apt: $UBUNTU_PACKAGES
           pip: $PIP_PACKAGES
+      - name: make /etc/udev/hwdb.d writable
+        run: |
+          sudo mkdir -p /etc/udev/hwdb.d
+          sudo chmod o+rwx /etc/udev/hwdb.d
       # for the valgrind case, we need custom setup, the matrix isn't
       # flexible enough for this
       - name: valgrind - meson test


### PR DESCRIPTION
Some of of our tests dump temporary hwdbs there, let's make this writable (it's already done for the non-valgrind job).

Closes #701