### PR TITLE
Add support for Lenovo Yoga 9 14IAP7

### DIFF
--- a/data/isdv4-52c2.tablet
+++ b/data/isdv4-52c2.tablet
@@ -1,0 +1,21 @@
+# Lenovo Yoga 9 14IAP7
+
+# sysinfo.ZNsVJXAt44.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/227
+
+[Device]
+Name=Wacom HID 52C2 Pen
+ModelName=WACF2200
+DeviceMatch=i2c|056a|52c2
+Class=ISDV4
+Width=12
+Height=7
+IntegratedIn=Display;System
+
+[Features]
+Reversible=false
+Stylus=true
+Touch=true
+Ring=false
+Buttons=0
+BuiltIn=true


### PR DESCRIPTION
I don't think this is complete yet, but since just creating issues is discouraged, I thought I'd get started and then finish the PR according to the changes requests. This is trying to add support for the Wacom HID 52C2 in the Lenovo Yoga 9 14IAP7. I don't think `sysinfo.sh` succeeded in creating a .tablet file (at least I couldn't find one), so I tried adapting a similar one, and it seems to at least get recognized by `libwacom-list-local-devices` now. But I wasn't sure about all values and how to adapt them, I tried following the "Adding a new device" guide.

One thing I'm not sure how to handle is this device shows a "Finger" and "Pen" device, are these supposed to go in the same file or is the "Finger" device not meant to be in this repo any way? Also, the initial reason why I stumbled upon here is that one of the buttons on my stylus (Lenovo Precision Pen 2) randomly had a different action assigned, and now I have no idea how to reconfigure that, not sure if this will help. I saw some .tablet files have a styli field, but I couldn't find out what values I'd have to add in there.

Relevant descriptor issues:
- https://github.com/linuxwacom/wacom-hid-descriptors/issues/227
- https://github.com/linuxwacom/wacom-hid-descriptors/issues/406