### PR TITLE
Minor adjustments for Lenovo Yoga 9 14IAP7

### DIFF
--- a/data/wacom-isdv4-52c2.tablet
+++ b/data/wacom-isdv4-52c2.tablet
@@ -4,18 +4,15 @@
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/227
 
 [Device]
-Name=Wacom HID 52C2 Pen
+Name=Wacom HID 52C2
 ModelName=WACF2200
 DeviceMatch=i2c|056a|52c2
 Class=ISDV4
 Width=12
 Height=7
 IntegratedIn=Display;System
+Styli=@isdv4-aes
 
 [Features]
-Reversible=false
 Stylus=true
 Touch=true
-Ring=false
-Buttons=0
-BuiltIn=true


### PR DESCRIPTION
This is a follow-up to my previous PR, which just removes some old properties that still are present in the [wiki](https://github.com/linuxwacom/libwacom/wiki/Tablet-Definition-Files) but not needed any more according to the example file. I also renamed the file to fit with other similar devices and removed the Pen suffix for the Name property since both devices are handled with the same tablet definition.
Last but not least I added the Styli property, not sure if that changes anything, but it should be correct according to all the other Lenovo tablet definitions.