### PR TITLE
data: add the XP-Pen ACK05 Remote

### DIFF
--- a/data/xp-pen-ack05-remote.tablet
+++ b/data/xp-pen-ack05-remote.tablet
@@ -1,0 +1,35 @@
+# XP-Pen
+# ACK05 Remote
+#
+# Reports as UGTABLET Artist Pro 16 (Gen2), for recordings
+# etc. see https://gitlab.freedesktop.org/libevdev/udev-hid-bpf/-/issues/32
+#
+#  ┌────────┐────────────────────────┐
+# /  ┌────┐  \   ┌───┐┌───┐┌───┐┌───┐│
+# │  │Dial│  │   │ A ││ B ││ C ││   ││
+# │  └────┘  │   └───┘└───┘└───┘│ G ││
+# │\________/    ┌───┐┌───┐┌───┐│   ││
+# │              │ D ││ E ││ F ││   ││
+# │              └───┘└───┘└───┘└───┘│
+# │              ┌───┐┌────────┐┌───┐│
+# │              │ H ││    I   ││ J ││
+# │              └───┘└────────┘└───┘│
+# └──────────────────────────────────┘
+
+[Device]
+Name=UGTABLET Artist Pro 16 (Gen2)
+ModelName=
+DeviceMatch=usb|28bd|095b
+Layout=xp-pen-ack05-remote.svg
+Class=Remote
+
+[Features]
+Stylus=false
+NumDials=1
+NumRings=0
+NumStrips=0
+StatusLEDs=Ring
+
+[Buttons]
+Left=A;B;C;D;E;F;G;H;I;J;
+EvdevCodes=BTN_0;BTN_1;BTN_2;BTN_3;BTN_4;BTN_5;BTN_6;BTN_7;BTN_8;BTN_9;


### PR DESCRIPTION
Draft because currently missing:
- sysinfo information (see what the bot says below)
- the SVG

I'm going to punt both to @Deevad :)

@Deevad - if you save the SVG file as `data/layouts/xp-pen-ack05-remote.svg` then things should magically work once you install everything[^1]. the [layouts README](https://github.com/linuxwacom/libwacom/blob/master/data/layouts/README.md) has a list of things that are expected and it mostly relates to naming of leader lines etc.

You can use this file as-is on libwacom <= 2.11  but you'll have to change to this line:
```
DeviceMatch=usb:28bd:095b
```
(pipe `|` replaced to the older version with `:`)



[^1]: for testing you can also drop it directly into `/usr/share/libwacom/layouts/` after dropping this `.tablet` file into `/usr/share/libwacom`.