### PR TITLE
Add a new IntegratedIn=Remote flag

### DIFF
--- a/data/wacom-ek-remote.tablet
+++ b/data/wacom-ek-remote.tablet
@@ -17,6 +17,7 @@ ModelName=ACK-411050
 DeviceMatch=usb|056a|0331
 Layout=wacom-ek-remote.svg
 Class=Remote
+IntegratedIn=Remote
 
 [Features]
 Stylus=false

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -448,7 +448,8 @@ static const struct {
 	WacomIntegrationFlags   value;
 } integration_flags[] = {
 	{ "Display",		WACOM_DEVICE_INTEGRATED_DISPLAY },
-	{ "System",		WACOM_DEVICE_INTEGRATED_SYSTEM }
+	{ "System",		WACOM_DEVICE_INTEGRATED_SYSTEM },
+	{ "Remote",		WACOM_DEVICE_INTEGRATED_REMOTE }
 };
 
 static void

--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -1009,6 +1009,8 @@ static void print_integrated_flags_for_device (int fd, const WacomDevice *device
 		dprintf(fd, "Display;");
 	if (device->integration_flags & WACOM_DEVICE_INTEGRATED_SYSTEM)
 		dprintf(fd, "System;");
+	if (device->integration_flags & WACOM_DEVICE_INTEGRATED_REMOTE)
+		dprintf(fd, "Remote;");
 	dprintf(fd, "\n");
 }
 

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -163,8 +163,24 @@ typedef enum {
  */
 typedef enum {
 	WACOM_DEVICE_INTEGRATED_NONE    = 0,
+	/**
+	 * The device is integrated into a display
+	 * like the Wacom Cintiq series.
+	 */
 	WACOM_DEVICE_INTEGRATED_DISPLAY = (1 << 0),
-	WACOM_DEVICE_INTEGRATED_SYSTEM  = (1 << 1)
+	/**
+	 * This flag is almost always used together
+	 * with @ref WACOM_DEVICE_INTEGRATED_DISPLAY
+	 * and indicates that the device is a built-in
+	 * device such as a Wacom tablet in the screen
+	 * of a laptop.
+	 */
+	WACOM_DEVICE_INTEGRATED_SYSTEM  = (1 << 1),
+	/**
+	 * The device is an external pad
+	 * like the Wacom ExpressKey Remote.
+	 */
+	WACOM_DEVICE_INTEGRATED_REMOTE  = (1 << 2),
 } WacomIntegrationFlags;
 
 /**


### PR DESCRIPTION
In commit 2dd3501fd3dd ("Deprecate the WacomClass in the API") libwacom_get_class() was deprecated. But that function remains the only way to reliably identify the ExpressKey Remote as remote. This didn't really matter since at least GNOME identifies that by PID/VID rather than class.

Other vendors now make their own remotes (XP Pen ACK05, Huion Keypad mini) so let's add an integration flag for those.


Related #777 