### PR TITLE
Fix error in clean_svg.py and allow it to run on `.tablet` files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,6 +194,22 @@ jobs:
           test $(libwacom-list-devices --format=yaml | yq -r '.devices[] | select(.bus == "usb") | select(.vid == "0x056a") | select(.pid == "0x0358") | .name' | wc -l) -eq 1
           test $(libwacom-list-devices --format=yaml | yq -r '.devices[] | select(.bus == "usb") | select(.vid == "0x056a") | select(.pid == "0x032a") | .name' | wc -l) -eq 1
 
+  ####
+  # make sure clean_svg.py works on our layout files
+  clean-svg-check:
+    needs: build-and-dist
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: run clean-svg on all .tablet files
+        run: |
+          for tabletfile in data/*.tablet; do
+            ./tools/clean_svg.py --ignore-missing "$tabletfile" ""
+          done
+
   ###
   #
   # tarball verification

--- a/tools/clean_svg.py
+++ b/tools/clean_svg.py
@@ -261,7 +261,7 @@ def apply_id_and_class_from_group(group_node):
     _id = group_node.attrib.get("id")
     if _id is None:
         return
-    for child in group_node.getchildren():
+    for child in group_node:
         if child.tag == "rect" or child.tag == "circle":
             if button_assigned:
                 continue

--- a/tools/clean_svg.py
+++ b/tools/clean_svg.py
@@ -302,11 +302,10 @@ def clean_svg(root, tabletname):
 if __name__ == "__main__":
     parser = ArgumentParser(description="Clean SVG files for libwacom")
     parser.add_argument(
-        "filename", nargs=1, type=str, help="SVG file to clean", metavar="FILE"
+        "filename", type=str, help="SVG file to clean", metavar="FILE"
     )
     parser.add_argument(
         "tabletname",
-        nargs=1,
         type=str,
         help="The name of the tablet",
         metavar="TABLET_NAME",
@@ -315,10 +314,10 @@ if __name__ == "__main__":
 
     ET.register_namespace("", NAMESPACE)
     try:
-        tree = ET.parse(args.filename[0])
+        tree = ET.parse(args.filename)
     except Exception as e:
         sys.stderr.write(str(e) + "\n")
         sys.exit(1)
     root = tree.getroot()
-    clean_svg(root, args.tabletname[0])
+    clean_svg(root, args.tabletname)
     print(to_string(root))


### PR DESCRIPTION
Fixes the crasher reported by @Deevad in https://github.com/linuxwacom/libwacom/pull/777#issuecomment-2405806463