### PR TITLE
Remove testing instructions from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,59 +29,7 @@ device in the kernel (see `/proc/bus/input/devices`) and in the X session (see
 Use the `libwacom-list-devices` tool to list all known devices and verify
 the tablet is not in that list.
 
-See the [wiki page on adding a new device](https://github.com/linuxwacom/libwacom/wiki/Adding-a-new-device).
-
-## To add support for a tablet to an installed libwacom
-
-If the system-provided libwacom does not include a `.tablet` file, it is
-possible to "backport" that `.tablet` file to the system-provided libwacom.
-
-### libwacom 1.10 and newer
-
-Copy the `.tablet` file into `/etc/libwacom` and run the
-`libwacom-update-db` tool. Copy the tablet's `.svg` layout file
-to `/etc/libwacom/layouts`.
-
-```
-$ cp my-tablet-file-from-upstream.tablet /etc/libwacom/
-$ cp my-tablet-file-layout.svg /etc/libwacom/layouts/
-$ libwacom-update-db /etc/libwacom
-```
-
-The tool will take care of updating udev, the hwdb, etc.
-
-### libwacom 1.9 and earlier
-
-For versions of libwacom <= 1.9, the file must be copied to
-`/usr/share/libwacom`. It may be overwritten on updates.
-
-You must update udev after installing the file. The simplest (and broadest)
-way to do this is outlined below:
-
-```
-# create the hwdb file
-$ cat <EOF > /etc/udev/hwdb.d/66-libwacom.hwdb
-# WARNING: change "Your Device Name" to the actual name of your device
-libwacom:name:Your Device Name*:input:*
- ID_INPUT=1
- ID_INPUT_TABLET=1
- ID_INPUT_JOYSTICK=0
-
-libwacom:name:Your Device Name Pad:input:*
- ID_INPUT_TABLET_PAD=1
-
-# Use this if the device is an external tablet
-libwacom:name:Your Device Name Finger:input:*
- ID_INPUT_TOUCHPAD=1
-
-# Use this if the device is a screen tablet
-libwacom:name:Your Device Name Finger:input:*
- ID_INPUT_TOUCHSCREEN=1
-
-EOF
-$ systemd-hwdb --update
-```
-Now disconnect and reconnect the device and it should be detected by libwacom.
+See [this wiki page on adding a new device and how to test it](https://github.com/linuxwacom/libwacom/wiki/Adding-a-new-device).
 
 # API Documentation
 


### PR DESCRIPTION
These are now maintained alongside the rest of the building instructions on the wiki. The text for the current version of libwacom is kept.

Closes #785 