### PR TITLE
Generate the class given in class if not explicitly given

### DIFF
--- a/data/wacom-cintiq-24hd-touch.tablet
+++ b/data/wacom-cintiq-24hd-touch.tablet
@@ -44,7 +44,6 @@ Name=Wacom Cintiq 24HD touch
 ModelName=DTH-2400
 DeviceMatch=usb|056a|00f8
 PairedID=usb|056a|00f6
-Class=Cintiq
 Width=21
 Height=13
 Layout=wacom-cintiq-24hd.svg

--- a/data/wacom-cintiq-27hdt.tablet
+++ b/data/wacom-cintiq-27hdt.tablet
@@ -9,7 +9,6 @@ Name=Wacom Cintiq 27QHD touch
 ModelName=DTH-2700
 DeviceMatch=usb|056a|032b
 PairedID=usb|056a|032c
-Class=Cintiq
 Width=24
 Height=12
 Styli=@intuos5;@propengen2;

--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -1362,7 +1362,17 @@ libwacom_get_height(const WacomDevice *device)
 LIBWACOM_EXPORT WacomClass
 libwacom_get_class(const WacomDevice *device)
 {
-	return device->cls;
+	if (device->cls != WCLASS_UNKNOWN) {
+		return device->cls;
+	}
+	if (device->integration_flags & WACOM_DEVICE_INTEGRATED_DISPLAY &&
+		device->integration_flags & WACOM_DEVICE_INTEGRATED_SYSTEM) {
+		return WCLASS_ISDV4;
+	}
+	if (device->integration_flags & WACOM_DEVICE_INTEGRATED_DISPLAY) {
+		return WCLASS_CINTIQ;
+	}
+	return WCLASS_BAMBOO;
 }
 
 LIBWACOM_EXPORT int

--- a/test/test-load.c
+++ b/test/test-load.c
@@ -202,6 +202,10 @@ test_cintiq24hdt(struct fixture *f, gconstpointer user_data)
 	const WacomMatch *match;
 
 	g_assert_nonnull(device);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+	g_assert_cmpint(libwacom_get_class(device), ==, WCLASS_CINTIQ);
+#pragma GCC diagnostic pop
 
 	/* 24HDT has one paired device */
 	match = libwacom_get_paired_device(device);


### PR DESCRIPTION
This is still a part of the API, and thus have required even new .tablet files to fill this out even though it's superseded by `IntegratedIn`. So let's generate them programmatically.

This turns devices that are `IntegratedIn=Display` to the `Cintiq` class, `IntegratedIn=Display;System` into the `ISDV4` class, and everything else into the `Bamboo` class.

(This definitely needs more test cases)