### PR TITLE
Create wacom-hid-52c6.tablet

### DIFF
--- a/data/wacom-hid-52c6.tablet
+++ b/data/wacom-hid-52c6.tablet
@@ -1,0 +1,22 @@
+# Wacom
+# Wacom HID 52C6 Pen
+# AES sensor used by the Lenovo Ideapad Flex 5 14ALC7
+#
+# sysinfo.6QHqFdEfjw
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/413
+
+[Device]
+Name=Wacom HID 52C6 Pen,Wacom HID 52C6 Finger
+ModelName=
+Class=ISDV4
+DeviceMatch=i2c:056a:52c6;
+Width=11
+Height=7
+# No pad buttons, so no layout
+IntegratedIn=Display;System
+Styli=@isdv4-aes
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0

--- a/data/wacom-hid-52c6.tablet
+++ b/data/wacom-hid-52c6.tablet
@@ -6,7 +6,7 @@
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/413
 
 [Device]
-Name=Wacom HID 52C6 Pen,Wacom HID 52C6 Finger
+Name=Wacom HID 52C6
 ModelName=
 Class=ISDV4
 DeviceMatch=i2c:056a:52c6;

--- a/data/wacom-hid-52c6.tablet
+++ b/data/wacom-hid-52c6.tablet
@@ -9,7 +9,7 @@
 Name=Wacom HID 52C6
 ModelName=
 Class=ISDV4
-DeviceMatch=i2c:056a:52c6;
+DeviceMatch=i2c|056a|52c6;
 Width=11
 Height=7
 # No pad buttons, so no layout


### PR DESCRIPTION
since the `sysinfo.sh` script was unable to generate the `.tablet` file I wrote this manually following instructions and copying from files of similar devices, although I am unsure if the `ModelName=` field needs to be filled (I left it blank since I couldn't find that information) and don't know if the line `Styli=@isdv4-aes` is even necessary. Some of the files of other devices I looked at had it, some didn't.
Also I believed there was a problem in the file I discussed in #794, but closed the issue since I it is fixed by #793 