### PR TITLE
Update wacom.stylus - added Lenovo Digital Pen 2

### DIFF
--- a/data/wacom.stylus
+++ b/data/wacom.stylus
@@ -222,6 +222,15 @@ EraserType=Button
 Axes=Tilt;Pressure
 Type=Mobile
 
+[0x219]
+# Lenovo ; VID_LENOVO     | 0x219 | BAT_SWAP
+Name=Lenovo Digital Pen 2
+Group=isdv4-aes
+Buttons=1
+EraserType=Button
+Axes=Pressure
+Type=Mobile
+
 # Inking pen have no eraser
 [0x812]
 # Intuos and Intuos2


### PR DESCRIPTION
I'm not sure if `BAT_HID` is required. Also as I have understood the lenovo digital pen 2 has tilt "detection", but not tilt "recognition", which I believe means it knows when it's tilted but not how much so I didn't put `Tilt` in the `Axes=` field, but I'm not 100% sure