### PR TITLE
Added support for ELAN-2514 variant 04f3:2f9d (HP Envy x360 15-ew0xxx)

### DIFF
--- a/data/elan-2513.tablet
+++ b/data/elan-2513.tablet
@@ -1,12 +1,19 @@
-# ELAN touchscreen/pen sensor present in the HP Pavilion x360 Convertible 14-dh0xxx
+# ELAN touchscreen/pen sensor
 
+# HP Pavilion x360 Convertible 14-dh0xxx
+# i2c|04f3|2b5f
 # sysinfo.6IzIUhfUYF
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/163#issue-936701718
+
+# HP Spectre x360 Convertible 15-ew0xxx
+# i2c|04f3|2f9d
+# sysinfo.yZGgFYGbVa
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/419#issue-2594972408
 
 [Device]
 Name=ELAN 2513
 ModelName=
-DeviceMatch=i2c|04f3|2b5f
+DeviceMatch=i2c|04f3|2b5f;i2c|04f3|2f9d
 Class=ISDV4
 Width=12
 Height=7


### PR DESCRIPTION
Referring to [this sysinfo](https://github.com/linuxwacom/wacom-hid-descriptors/issues/419)