### PR TITLE
Add Support for the ELAN-2514 04F3:29DF (HP Spectre x360 13-aw0020ng)

### DIFF
--- a/data/elan-2514.tablet
+++ b/data/elan-2514.tablet
@@ -4,6 +4,13 @@
 #
 # HP Spectre x360 Convertible 13-aw0xxx
 
+# i2c|04f3|29df
+#
+# HP Spectre x360 Convertible 13-aw0020ng
+#
+# sysinfo.aIzu1yVjI8
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/414
+
 # i2c|04f3|2af4
 #
 # HP Envy x360 Convertible 13-ay0xxx
@@ -47,7 +54,7 @@
 [Device]
 Name=ELAN 2514
 ModelName=
-DeviceMatch=i2c|04f3|29f5;i2c|04f3|2af4;i2c|04f3|2813;i2c|04f3|2817;i2c|04f3|2b0a;i2c|04f3|23f3;i2c|04f3|2718;i2c|04f3|2beb;i2c|04f3|23b9;i2c|04f3|29d4
+DeviceMatch=i2c|04f3|29f5;i2c|04f3|29df;i2c|04f3|2af4;i2c|04f3|2813;i2c|04f3|2817;i2c|04f3|2b0a;i2c|04f3|23f3;i2c|04f3|2718;i2c|04f3|2beb;i2c|04f3|23b9;i2c|04f3|29d4
 Class=ISDV4
 Width=12
 Height=7


### PR DESCRIPTION
Referring to this [sysinfo](https://github.com/linuxwacom/wacom-hid-descriptors/issues/414)