### PR TITLE
Allow for datadirs to be colon-separated

### DIFF
--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -1132,10 +1132,10 @@ stylus_compare(WacomStylusId *a, WacomStylusId *b)
 }
 
 static WacomDeviceDatabase *
-database_new_for_paths (const char **datadirs)
+database_new_for_paths (char * const *datadirs)
 {
 	WacomDeviceDatabase *db;
-	const char **datadir;
+	char * const *datadir;
 
 	db = g_new0 (WacomDeviceDatabase, 1);
 	db->device_ht = g_hash_table_new_full (g_str_hash,
@@ -1174,17 +1174,21 @@ error:
 LIBWACOM_EXPORT WacomDeviceDatabase *
 libwacom_database_new_for_path (const char *datadir)
 {
-	const char *datadirs[] = {
-		datadir,
-		NULL,
-	};
-	return database_new_for_paths(datadirs);
+	WacomDeviceDatabase *db;
+	char **paths;
+
+	paths = g_strsplit(datadir, ":", 0);
+	db = database_new_for_paths(paths);
+
+	g_strfreev(paths);
+
+	return db;
 }
 
 LIBWACOM_EXPORT WacomDeviceDatabase *
 libwacom_database_new (void)
 {
-	const char *datadir[] = {
+	char *datadir[] = {
 		ETCDIR,
 		DATADIR,
 		NULL,

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -1132,10 +1132,9 @@ stylus_compare(WacomStylusId *a, WacomStylusId *b)
 }
 
 static WacomDeviceDatabase *
-database_new_for_paths (size_t npaths, const char **datadirs)
+database_new_for_paths (const char **datadirs)
 {
 	WacomDeviceDatabase *db;
-	size_t n;
 	const char **datadir;
 
 	db = g_new0 (WacomDeviceDatabase, 1);
@@ -1148,12 +1147,12 @@ database_new_for_paths (size_t npaths, const char **datadirs)
 					       (GDestroyNotify) g_free,
 					       (GDestroyNotify) stylus_destroy);
 
-	for (datadir = datadirs, n = npaths; n--; datadir++) {
+	for (datadir = datadirs; *datadir; datadir++) {
 		if (!load_stylus_files(db, *datadir))
 			goto error;
 	}
 
-	for (datadir = datadirs, n = npaths; n--; datadir++) {
+	for (datadir = datadirs; *datadir;  datadir++) {
 		if (!load_tablet_files(db, *datadir))
 			goto error;
 	}
@@ -1175,7 +1174,11 @@ error:
 LIBWACOM_EXPORT WacomDeviceDatabase *
 libwacom_database_new_for_path (const char *datadir)
 {
-	return database_new_for_paths(1, &datadir);
+	const char *datadirs[] = {
+		datadir,
+		NULL,
+	};
+	return database_new_for_paths(datadirs);
 }
 
 LIBWACOM_EXPORT WacomDeviceDatabase *
@@ -1184,9 +1187,10 @@ libwacom_database_new (void)
 	const char *datadir[] = {
 		ETCDIR,
 		DATADIR,
+		NULL,
 	};
 
-	return database_new_for_paths (2, datadir);
+	return database_new_for_paths(datadir);
 }
 
 LIBWACOM_EXPORT void

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -362,6 +362,8 @@ WacomDeviceDatabase* libwacom_database_new(void);
  * a layouts/ subdirectory for the svg files if any of the .tablet
  * files references an svg.
  *
+ * datadir may be a colon-separated list of directories.
+ *
  * @return A new database or NULL on error.
  *
  * @ingroup context

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -354,9 +354,13 @@ WacomDeviceDatabase* libwacom_database_new(void);
 
 /**
  * Loads the Tablet and Stylus databases, to be used
- * in libwacom_new_*() functions, from the prefix
- * path passes. This is only useful for diagnostics
+ * in libwacom_new_*() functions, from the datadir
+ * given in the argument. This is only useful for diagnostics
  * applications.
+ *
+ * The datadir must contain the libwacom .tablet files and optionally
+ * a layouts/ subdirectory for the svg files if any of the .tablet
+ * files references an svg.
  *
  * @return A new database or NULL on error.
  *


### PR DESCRIPTION
Useful for testing e.g. #788 with built-in tools like `debug-device`. The new file is in `/etc/libwacom` to make it system-wide accessible but `debug-device` only uses the git datadir by default.

This MR allows for:
```
./build/debug-device --database /etc/libwacom:$PWD/data /dev/input/event19
```
and other testing of databases distributed across multiple data dirs.