### PR TITLE
Support $XDG_CONFIG_HOME/libwacom as additional path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,6 +115,9 @@ jobs:
           - sudo mv /usr/share/libwacom/wacom-intuos*.tablet /etc/libwacom
           - sudo mv /usr/share/libwacom/*.tablet /etc/libwacom
           - sudo mv /usr/share/libwacom/*.stylus /etc/libwacom
+          - sudo mv /usr/share/libwacom/*.tablet $HOME/.config/libwacom
+          - sudo mv /usr/share/libwacom/*.stylus $HOME/.config/libwacom
+          - sudo mv /usr/share/libwacom/wacom-*.tablet $HOME/.config/libwacom && sudo mv /usr/share/libwacom/huion-*.tablet /etc/libwacom
           # split the wacom.stylus file into to two files to check for
           # accumlated loading
           - sudo csplit data/wacom.stylus '/^\[0x822\]/' && sudo mv xx00 /etc/libwacom/first.stylus && sudo mv xx01 /usr/share/libwacom/wacom.stylus
@@ -141,6 +144,7 @@ jobs:
       - name: list devices with database in /usr
         run: libwacom-list-devices --format=datafile > devicelist.default.txt
       - run: sudo mkdir /etc/libwacom
+      - run: sudo mkdir $HOME/.config/libwacom
       - name: split the databases between /usr/share and /etc
         run: ${{matrix.command}}
       - name: list devices with database in /etc and /usr

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -1192,13 +1192,28 @@ libwacom_database_new_for_path (const char *datadir)
 LIBWACOM_EXPORT WacomDeviceDatabase *
 libwacom_database_new (void)
 {
+	WacomDeviceDatabase *db;
+	char *xdgdir = NULL;
+	char *xdg_config_home = g_strdup(g_getenv("XDG_CONFIG_HOME"));
+
+	if (!xdg_config_home)
+		xdg_config_home = g_strdup_printf("%s/.config/", g_get_home_dir());
+
+	xdgdir = g_strdup_printf("%s/libwacom", xdg_config_home);
+
 	char *datadir[] = {
+		xdgdir,
 		ETCDIR,
 		DATADIR,
 		NULL,
 	};
 
-	return database_new_for_paths(datadir);
+	db = database_new_for_paths(datadir);
+
+	free(xdgdir);
+	free(xdg_config_home);
+
+	return db;
 }
 
 LIBWACOM_EXPORT void

--- a/tools/show-stylus.py
+++ b/tools/show-stylus.py
@@ -22,6 +22,7 @@
 
 import argparse
 import configparser
+import os
 import sys
 from pathlib import Path
 
@@ -35,6 +36,10 @@ except ModuleNotFoundError as e:
         "modules and re-run this tool."
     )
     sys.exit(1)
+
+
+def xdg_dir():
+    return Path(os.getenv("XDG_CONFIG_HOME", Path.home() / ".config")) / "libwacom"
 
 
 class Ansi:
@@ -133,7 +138,7 @@ def record_events(ns):
 def load_data_files():
     lookup_paths = (
         ("./data/",),
-        ("@DATADIR@", "@ETCDIR@"),
+        ("@DATADIR@", "@ETCDIR@", xdg_dir()),
         ("/usr/share/libwacom/", "/etc/libwacom/"),
     )
     stylusfiles = []


### PR DESCRIPTION
This completes the traditional triplet of $XDG_CONFIG_HOME, /etc, and
/usr/share for configuration files.

Having custom .tablet files in $XDG_CONFIG_HOME makes it easier for
immutable systems and also for backups that only back up the user home
directory.