### PR TITLE
extended Lenovo Yoga X1 Gen5 Support

### DIFF
--- a/data/wacom-isdv4-5229.tablet
+++ b/data/wacom-isdv4-5229.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=ISDv4 5229
 ModelName=
-DeviceMatch=usb|056a|5229;usb|056a|522a
+DeviceMatch=usb|056a|5229;usb|056a|522a;usb|056a|522b
 Class=ISDV4
 Width=12
 Height=7


### PR DESCRIPTION
Hello everyone,

i have a Lenovo Yoga X1 Gen5, which has a display with integrated privacy function - think that might be the reason I have a different device id.

the way i implemented it makes it working correctly with the meson test, but creates following warning:

```
❯ libwacom-list-local-devices
failed to match 'usb|056a|5229' for product/vendor IDs. Skipping.
'usb|056a|5229' is an invalid DeviceMatch in '/usr/share/libwacom/wacom-isdv4-5229.tablet'
failed to match 'usb|056a|522a' for product/vendor IDs. Skipping.
'usb|056a|522a' is an invalid DeviceMatch in '/usr/share/libwacom/wacom-isdv4-5229.tablet'
failed to match 'usb|056a|522b' for product/vendor IDs. Skipping.
'usb|056a|522b' is an invalid DeviceMatch in '/usr/share/libwacom/wacom-isdv4-5229.tablet'

(libwacom-list-local-devices:18887): GLib-CRITICAL **: 16:08:56.547: g_array_free: assertion 'array' failed

(libwacom-list-local-devices:18887): GLib-CRITICAL **: 16:08:56.548: g_array_free: assertion 'array' failed
devices:
- name: 'ISDv4 5229'
  bus: 'usb'
  vid: '0x056a'
  pid: '0x522b'
  nodes: 
  - /dev/input/event5: 'Wacom Pen and multitouch sensor Pen'
  styli:
   - id: 0x1
     name: 'AES Pen'
     type: 'mobile'
     axes: ['x', 'y' , 'pressure']
     buttons: 1
     is_eraser: 'true'
     eraser_type: 'button'
   - id: 0x11
     name: 'AES Pen'
     type: 'mobile'


.....

```

edit: just checked again - there needs to be ```:``` as seperators to make it work without an error instead of ```|``` 

but then the build fails:

```
❯ meson compile -C builddir
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /usr/bin/ninja -C /home/.../dev/git/libwacom/builddir
ninja: Entering directory `/home/.../dev/git/libwacom/builddir'
[23/28] Generating hwdb with a custom command (wrapped by meson to capture output)
FAILED: 65-libwacom.hwdb 
/usr/bin/meson --internal exe --capture 65-libwacom.hwdb -- /usr/bin/python3 libwacom-update-db --buildsystem-mode /home/.../dev/git/libwacom/data
--- stderr ---
Failed to process match usb:056a:522a in /home/.../dev/git/libwacom/data/wacom-isdv4-5229.tablet
Traceback (most recent call last):
  File "/home/.../dev/git/libwacom/builddir/libwacom-update-db", line 218, in <module>
    db = TabletDatabase(ns.path)
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/.../dev/git/libwacom/builddir/libwacom-update-db", line 119, in __init__
    self.tablets = sorted(self._load(path))
                   ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/.../dev/git/libwacom/builddir/libwacom-update-db", line 137, in _load
    raise e
  File "/home/.../dev/git/libwacom/builddir/libwacom-update-db", line 134, in _load
    bus, vid, pid, *_ = match.split("|")
    ^^^^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected at least 3, got 1)

[28/28] Linking target test-stylus-validity
ninja: build stopped: subcommand failed.

``` 