### PR TITLE
Add Support for Wacom HID 5214 (Lenovo IdeaPad Flex 5 14ARE05 rev.81X2)

### DIFF
--- a/data/wacom-isdv4-5214.tablet
+++ b/data/wacom-isdv4-5214.tablet
@@ -1,7 +1,7 @@
 # Lenovo IdeaPad Flex 5 14ARE05
 # Sensor Type: AES
 # Features: Touch (Integrated), Tilt
-# 
+#
 # Derived from wacom-isdv4-5215.tablet as the sysinfo script didn't generate a file
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/421
 

--- a/data/wacom-isdv4-5214.tablet
+++ b/data/wacom-isdv4-5214.tablet
@@ -1,0 +1,20 @@
+# Lenovo IdeaPad Flex 5 14ARE05
+# Sensor Type: AES
+# Features: Touch (Integrated), Tilt
+# 
+# Derived from wacom-isdv4-5215.tablet as the sysinfo script didn't generate a file
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/421
+
+[Device]
+Name=ISDv4 5214
+ModelName=
+DeviceMatch=i2c|056a|5214
+Class=ISDV4
+Width=12
+Height=7
+IntegratedIn=Display;System
+Styli=@isdv4-aes;
+
+[Features]
+Stylus=true
+Touch=true


### PR DESCRIPTION
Hi everyone,

My Flex 5 seems to have an id that's not in the database.
The sysinfo script didn't generate a tablet file so I edited it from wacom-isdv4-5215.tablet.

It seems to work fine on my unit in Ubuntu 24.10 and it passed the meson test.
[testlog.txt](https://github.com/user-attachments/files/17535127/testlog.txt)
