### PR TITLE
Special-case the generic pens for libwacom_get_supported_styli

### DIFF
--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -1600,6 +1600,14 @@ libwacom_stylus_get_for_id (const WacomDeviceDatabase *db, int tool_id)
 		.tool_id = tool_id,
 	};
 
+	switch (tool_id) {
+	case GENERIC_PEN_WITH_ERASER:
+	case GENERIC_ERASER:
+	case GENERIC_PEN_NO_ERASER:
+		id.vid = 0;
+		break;
+
+	}
 	return libwacom_stylus_get_for_stylus_id (db, &id);
 }
 

--- a/libwacom/libwacomint.h
+++ b/libwacom/libwacomint.h
@@ -42,6 +42,12 @@
 #define WACOM_DEVICE_INTEGRATED_UNSET (WACOM_DEVICE_INTEGRATED_NONE - 1U)
 #define WACOM_VENDOR_ID 0x056a
 
+enum GenericStylus {
+	GENERIC_PEN_WITH_ERASER = 0xfffff,
+        GENERIC_ERASER = 0xffffe,
+        GENERIC_PEN_NO_ERASER = 0xffffd,
+};
+
 enum WacomFeature {
 	FEATURE_STYLUS		= (1 << 0),
 	FEATURE_TOUCH		= (1 << 1),

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -196,8 +196,8 @@ class LibWacom:
         _Api(name="libwacom_get_num_keys", args=(c_void_p,), return_type=c_int),
         _Api(
             name="libwacom_get_supported_styli",
-            args=(c_void_p, c_void_p),
-            return_type=c_void_p,
+            args=(c_void_p, ctypes.POINTER(c_int)),
+            return_type=ctypes.POINTER(c_int),
         ),
         _Api(
             name="libwacom_get_styli",
@@ -558,6 +558,11 @@ class WacomEraserType(enum.IntEnum):
 
 
 class WacomStylus:
+    class Generic(enum.IntEnum):
+        PEN_WITH_ERASER = 0xFFFFF
+        ERASER = 0xFFFFE
+        PEN_NO_ERASER = 0xFFFFD
+
     def __init__(self, stylus):
         self.stylus = stylus
         lib = LibWacom.instance()


### PR DESCRIPTION
The three generic pens have a vendor-id of 0 so let's special case those for the now-deprecated API.