### PR TITLE
test: do not allow empty Layout= lines

### DIFF
--- a/test/test_data_files.py
+++ b/test/test_data_files.py
@@ -75,6 +75,7 @@ def test_svg_exists(tabletfile):
 
     try:
         svg = config["Device"]["Layout"]
+        assert svg != "", "Empty Layout= line not permitted"
         assert (layoutsdir() / svg).exists()
 
     except KeyError:


### PR DESCRIPTION
The clean_svg.py script has a problem with those, see #818, but either way there's little to be gained from them anyway.