### PR TITLE
test/test_svg: don't fail if we don't have any classes on an element

### DIFF
--- a/test/test_svg.py
+++ b/test/test_svg.py
@@ -52,7 +52,7 @@ class SvgDevice:
         assert len(nodes) == 1, f"Expected one element with id {id}, have {len(nodes)}"
         node = nodes[0]
         for klass in classes or []:
-            assert klass in node.get("class").split(
+            assert klass in node.get("class", "").split(
                 " "
             ), f"Missing class '{klass}' for {id}. Have: {node.get('class')}"
 


### PR DESCRIPTION
Fixes "AttributeError: 'NoneType' object has no attribute 'split'"