### PR TITLE
Add Lenovo Slim Pen

### DIFF
--- a/data/lenovo.stylus
+++ b/data/lenovo.stylus
@@ -15,3 +15,12 @@ Buttons=1
 EraserType=Button
 Axes=Tilt;Pressure
 Type=Mobile
+
+[0x80a3]
+# Lenovo ; VID_LENOVO     | 0x80a3 | BAT_CHRG
+Name=Lenovo Slim Pen
+Group=isdv4-aes
+Buttons=1
+EraserType=Button
+Axes=Tilt;Pressure
+Type=Mobile


### PR DESCRIPTION
Please add the Lenovo Slim Pen to the database.

It is shipped with the Laptop [Lenovo ThinkPad X1 2-in-1 Gen 9](https://github.com/linuxwacom/wacom-hid-descriptors/tree/master/Lenovo%20ThinkPad%20X1%202-in-1%20Gen%209).

After adding the configuration, I was able to configure the pen using the Gnome Control Center.
I'm not sure whether it is supposed to, but the pen does not appear in the Power section.