### PR TITLE
Support "AliasOf" keyword

### DIFF
--- a/data/wacom.stylus
+++ b/data/wacom.stylus
@@ -34,51 +34,26 @@ Type=Mobile
 
 [0x11]
 # Lenovo ; VID_NONE     | 0x0000 | BAT_CHRG
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x19]
 # Lenovo ; VID_LENOVO   | 0x60A8 | BAT_SWAP | BAT_HID
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x21]
 # HP     ; VID_NONE     | 0x0000 | BAT_SWAP
 # Huawei ; VID_NONE     | 0x0000 | BAT_SWAP
 # Lenovo ; VID_NONE     | 0x0000 | BAT_SWAP
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x31]
 # Dell   ; VID_BROADCOM | 0x81B9 | BAT_SWAP
 # HP     ; VID_CHICONY  | 0xB4A3 | BAT_SWAP | BAT_HID
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x39]
 # Huawei ; VID_HUAWEI   | 0x1091 | BAT_SWAP ("Huawei MatePen" / AF61)
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x49]
 # Wacom  ; VID_WACOM    | 0x035F | BAT_SWAP | BAT_GATT | BAT_SHARED | LONGPRESS ("Wacom Bamboo Ink" / CS321A)
@@ -91,145 +66,80 @@ Type=Mobile
 
 [0x71]
 # Wacom  ; VID_WACOM    | 0x035F | BAT_SWAP | BAT_GATT | BAT_SHARED | LONGPRESS ("Wacom Bamboo Ink" / CS321A1)
-Name=Bamboo Ink
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x49
 
 [0x221]
 # HP     ; VID_CHICONY  | 0xB4A3 | BAT_SWAP | BAT_HID
 # Lenovo ; VID_NONE     | 0x0000 | BAT_SWAP
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x231]
 # Dell   ; VID_BROADCOM | 0x81C6 | BAT_SWAP | LONGPRESS (Dell PN557W)
 # HP     ; VID_CHICONY  | 0xB4A3 | BAT_SWAP | BAT_HID
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x271]
 # Wacom  ; VID_NONE     | 0x0000 | BAT_SWAP ("Wacom Bamboo Ink" / CS323A)
-Name=Bamboo Ink
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x49
 
 [0x421]
 # HP     ; VID_NONE     | 0x0000 | BAT_SWAP
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x431]
 # Dell   ; VID_BROADCOM | 0x81B9 | BAT_SWAP
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x621]
 # Lenovo ; VID_NONE     | 0x0000 | BAT_SWAP
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x631]
 # Dell   ; VID_NONE     | 0x0000 | BAT_SWAP | LONGPRESS (Dell PN557W)
 # Dell   ; VID_NONE     | 0xf142541e | BAT_SWAP (Dell PN5122W)
 Name=Dell Active Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x8051]
 # Google ; VID_NONE     | 0x0000 | BAT_SWAP ("Google Pixelbook Pen" / C0B)
-Name=AES Pen
-Group=isdv4-aes
 Buttons=0
-EraserType=Button
 Axes=Tilt;Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x805B]
 # Dell   ; VID_BROADCOM | 0x81D5 | BAT_SWAP | BAT_GATT | BAT_SHARED | LONGPRESS (Dell PN579X)
 # Lenovo ; VID_LENOVO   | 0x60C5 | BAT_SWAP | BAT_GATT | BAT_SHARED
 # Toshiba; VID_NONE     | 0x0000 | BAT_SWAP
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
 Axes=Tilt;Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x806B]
 # HP     ; VID_CHICONY  | 0x1728 | BAT_CHRG | BAT_PROX | BAT_SHARED | LONGPRESS | PROX ("HP Rechargeable Active Pen" / HP Active Pen G2 / 4KL69AA)
 # Huawei ; VID_NONE     | 0x0000 | BAT_SWAP
 # Lenovo ; VID_LENOVO   | 0x60C2 | BAT_CHRG | BAT_GATT | BAT_SHARED
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
 Axes=Tilt;Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x807B]
 # Wacom  ; VID_WACOM    | 0x0397 | BAT_CHRG | BAT_GATT | BAT_SHARED | LONGPRESS ("Wacom Bamboo Ink Plus" / CS322A)
 Name=Bamboo Ink Plus
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
+AliasOf=0x49
 Axes=Tilt;Pressure
-Type=Mobile
 
 [0x826B]
 # HP     ; VID_CHICONY  | 0x1728 | BAT_CHRG | BAT_PROX | BAT_SHARED | LONGPRESS | PROX ("HP Active Pen G3" / L08263-003 / L57042-001)
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
 Axes=Tilt;Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x846B]
 # HP     ; VID_CHICONY  | 0x1850 | BAT_CHRG | BAT_GATT | BAT_SHARED | LONGPRESS | PROX ("HP Rechargeable Active Pen G3" / HP Active Pen G3 / 6SG43AA)
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
 Axes=Tilt;Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x219]
 # Lenovo ; VID_LENOVO     | 0x219 | BAT_SWAP
 Name=Lenovo Digital Pen 2
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 # Inking pen have no eraser
 [0x812]

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -47,6 +47,11 @@
 #define BUTTONS_GROUP "Buttons"
 #define KEYS_GROUP "Keys"
 
+typedef enum {
+        IGNORE_ALIASES  = 0,
+        ONLY_ALIASES    = 1,
+} AliasStatus;
+
 static WacomClass
 libwacom_class_string_to_enum(const char *class)
 {
@@ -105,6 +110,34 @@ type_from_str (const char *type)
 	return WSTYLUS_UNKNOWN;
 }
 
+static const char *
+str_from_type (WacomStylusType type)
+{
+	switch (type) {
+	case WSTYLUS_UNKNOWN:
+		return NULL;
+	case WSTYLUS_GENERAL:
+		return "General";
+	case WSTYLUS_INKING:
+		return "Inking";
+	case WSTYLUS_AIRBRUSH:
+		return "Airbrush";
+	case WSTYLUS_CLASSIC:
+		return "Classic";
+	case WSTYLUS_MARKER:
+		return "Marker";
+	case WSTYLUS_STROKE:
+		return "Stroke";
+	case WSTYLUS_PUCK:
+		return "Pick";
+	case WSTYLUS_3D:
+		return "3D";
+	case WSTYLUS_MOBILE:
+		return "Mobile";
+	}
+	return NULL;
+}
+
 static WacomEraserType
 eraser_type_from_str (const char *type)
 {
@@ -117,6 +150,22 @@ eraser_type_from_str (const char *type)
 	if (g_str_equal(type, "Button"))
 		return WACOM_ERASER_BUTTON;
 	return WACOM_ERASER_UNKNOWN;
+}
+
+static const char *
+eraser_str_from_type (WacomEraserType type)
+{
+	switch (type) {
+	case WACOM_ERASER_NONE:
+		return "None";
+	case WACOM_ERASER_INVERT:
+		return "Invert";
+	case WACOM_ERASER_BUTTON:
+		return "Button";
+	case WACOM_ERASER_UNKNOWN:
+		return NULL;
+	}
+	return NULL;
 }
 
 WacomBusType
@@ -279,8 +328,81 @@ parse_stylus_id(const char *str, WacomStylusId *id)
 	return ret;
 }
 
+static char *
+string_or_fallback (GKeyFile *keyfile, const char *group,
+		    const char *key, const char *fallback, GError *error)
+{
+	GError *local_error = NULL;
+	bool ret;
+
+	ret = g_key_file_has_key(keyfile, group, key, &local_error);
+	if (local_error) {
+		g_warning ("String fallback error: %s\n", local_error->message);
+		g_clear_error (&local_error);
+	}
+	if (ret)
+		return g_key_file_get_string(keyfile, group, key, &error);
+
+	return g_strdup(fallback);
+}
+
+static int
+int_or_fallback (GKeyFile *keyfile, const char *group,
+		 const char *key, int fallback, GError *error)
+{
+	GError *local_error = NULL;
+	bool ret;
+
+	ret = g_key_file_has_key(keyfile, group, key, &local_error);
+	if (local_error) {
+		g_warning ("int fallback error: %s\n", local_error->message);
+		g_clear_error (&local_error);
+	}
+
+	if (ret)
+		return g_key_file_get_integer(keyfile, group, key, &error);
+
+	return fallback;
+}
+
+static bool
+boolean_or_fallback (GKeyFile *keyfile, const char *group,
+		     const char *key, bool fallback, WacomStylus *stylus, GError *error)
+{
+	GError *local_error = NULL;
+	bool ret;
+
+	ret = g_key_file_has_key(keyfile, group, key, &local_error);
+	if (local_error) {
+		g_warning ("boolean fallback error: %s\n", local_error->message);
+		g_clear_error (&local_error);
+	}
+
+	if (ret)
+		return g_key_file_get_boolean(keyfile, group, key, &error);
+
+	return fallback;
+}
+
+static gchar **
+stylus_ids_as_hex(GArray *array)
+{
+	WacomStylusId *id;
+
+	if (array == NULL || array->len == 0)
+		return NULL;
+
+	GArray *a = g_array_new(true, false, array->len);
+	for (guint i = 0; i < array->len; i++) {
+		id = &g_array_index(array, WacomStylusId, i);
+		g_array_append_vals(a, g_strdup_printf("0x%08x", id->tool_id), 1);
+	}
+
+	return g_array_steal(a, NULL);
+}
+
 static void
-libwacom_parse_stylus_keyfile(WacomDeviceDatabase *db, const char *path)
+libwacom_parse_stylus_keyfile(WacomDeviceDatabase *db, const char *path, AliasStatus handle_aliases)
 {
 	GKeyFile *keyfile;
 	GError *error = NULL;
@@ -295,24 +417,59 @@ libwacom_parse_stylus_keyfile(WacomDeviceDatabase *db, const char *path)
 
 	groups = g_key_file_get_groups (keyfile, NULL);
 	for (i = 0; groups[i]; i++) {
-		WacomStylus *stylus;
+		WacomStylus *stylus = NULL, *aliased = NULL, empty = {0};
 		WacomStylusId id;
 		GError *error = NULL;
 		char *eraser_type, *type;
 		char **string_list;
+		int aliased_int;
 
 		if (!parse_stylus_id(groups[i], &id)) {
 			g_warning ("Failed to parse stylus ID '%s', ignoring entry", groups[i]);
 			continue;
 		}
+
+		char *aliasstr = g_key_file_get_string(keyfile, groups[i], "AliasOf", NULL);
+
+		if (handle_aliases == IGNORE_ALIASES && aliasstr) {
+			g_clear_pointer(&aliasstr, g_free);
+			continue;
+		}
+
+		if (handle_aliases == ONLY_ALIASES && !aliasstr) {
+			g_clear_pointer(&aliasstr, g_free);
+			continue;
+		}
+
+		if (handle_aliases == ONLY_ALIASES) {
+			WacomStylusId lookup;
+
+			if (!parse_stylus_id(groups[i], &lookup)) {
+				g_warning ("Failed to parse Aliased ID '%s', ignoring entry", groups[i]);
+				continue;
+			}
+			if (safe_atoi_base (aliasstr, &aliased_int, 16))
+				lookup.tool_id = aliased_int;
+
+			aliased = g_hash_table_lookup(db->stylus_ht, &lookup);
+			if (!aliased) {
+				g_warning ("Unkown Aliased ID 0x%08x %s\n", lookup.tool_id, aliasstr);
+				continue;
+			}
+		} else {
+			aliased = &empty;
+		}
+		g_clear_pointer(&aliasstr, g_free);
+
 		stylus = g_new0 (WacomStylus, 1);
 		stylus->refcnt = 1;
 		stylus->id = id;
-		stylus->name = g_key_file_get_string(keyfile, groups[i], "Name", NULL);
-		stylus->group = g_key_file_get_string(keyfile, groups[i], "Group", NULL);
+
+		stylus->name = string_or_fallback(keyfile, groups[i], "Name", aliased->name, NULL);
+		stylus->group = string_or_fallback(keyfile, groups[i], "Group", aliased->group, NULL);
 		stylus->paired_stylus_ids = g_array_new (FALSE, FALSE, sizeof(WacomStylusId));
 
-		eraser_type = g_key_file_get_string(keyfile, groups[i], "EraserType", NULL);
+		eraser_type = string_or_fallback(keyfile, groups[i], "EraserType", eraser_str_from_type(aliased->eraser_type), NULL);
 		stylus->eraser_type = eraser_type_from_str (eraser_type);
 		g_clear_pointer(&eraser_type, g_free);
 
@@ -320,7 +477,13 @@ libwacom_parse_stylus_keyfile(WacomDeviceDatabase *db, const char *path)
 		stylus->deprecated_paired_ids = g_array_new (FALSE, FALSE, sizeof(int));
 		stylus->paired_styli = g_array_new (FALSE, FALSE, sizeof(WacomStylus*));
 
-		string_list = g_key_file_get_string_list (keyfile, groups[i], "PairedStylusIds", NULL, NULL);
+		string_list = g_key_file_get_string_list(keyfile, groups[i], "PairedStylusIds", NULL, NULL);
+		if (handle_aliases == ONLY_ALIASES) {
+			if (string_list == NULL) {
+				string_list = stylus_ids_as_hex(aliased->paired_stylus_ids);
+			}
+		}
+
 		for (guint j = 0; string_list && string_list[j]; j++) {
 			WacomStylusId paired_id;
 			if (parse_stylus_id(string_list[j], &paired_id)) {
@@ -333,16 +496,15 @@ libwacom_parse_stylus_keyfile(WacomDeviceDatabase *db, const char *path)
 		}
 		g_clear_pointer(&string_list, g_strfreev);
 
-		stylus->has_lens = g_key_file_get_boolean(keyfile, groups[i], "HasLens", &error);
+		stylus->has_lens = boolean_or_fallback(keyfile, groups[i], "HasLens", aliased->has_lens, stylus, error);
 		if (error && error->code == G_KEY_FILE_ERROR_INVALID_VALUE)
 			g_warning ("Stylus %s (%s) %s\n", stylus->name, groups[i], error->message);
 		g_clear_error (&error);
-		stylus->has_wheel = g_key_file_get_boolean(keyfile, groups[i], "HasWheel", &error);
+		stylus->has_wheel = boolean_or_fallback(keyfile, groups[i], "HasWheel", aliased->has_wheel, stylus, error);
 		if (error && error->code == G_KEY_FILE_ERROR_INVALID_VALUE)
 			g_warning ("Stylus %s (%s) %s\n", stylus->name, groups[i], error->message);
 		g_clear_error (&error);
-
-		stylus->num_buttons = g_key_file_get_integer(keyfile, groups[i], "Buttons", &error);
+		stylus->num_buttons = int_or_fallback(keyfile, groups[i], "Buttons", aliased->num_buttons, error);
 		if (stylus->num_buttons == 0 && error != NULL) {
 			stylus->num_buttons = -1;
 			g_clear_error (&error);
@@ -350,30 +512,35 @@ libwacom_parse_stylus_keyfile(WacomDeviceDatabase *db, const char *path)
 
 		stylus->axes = WACOM_AXIS_TYPE_NONE;
 		string_list = g_key_file_get_string_list (keyfile, groups[i], "Axes", NULL, NULL);
-		for (guint j = 0; string_list && string_list[j]; j++) {
-			WacomAxisTypeFlags flag = WACOM_AXIS_TYPE_NONE;
-			if (g_str_equal(string_list[j], "Tilt")) {
-				flag = WACOM_AXIS_TYPE_TILT;
-			} else if (g_str_equal(string_list[j], "RotationZ")) {
-				flag = WACOM_AXIS_TYPE_ROTATION_Z;
-			} else if (g_str_equal(string_list[j], "Distance")) {
-				flag = WACOM_AXIS_TYPE_DISTANCE;
-			} else if (g_str_equal(string_list[j], "Pressure")) {
-				flag = WACOM_AXIS_TYPE_PRESSURE;
-			} else if (g_str_equal(string_list[j], "Slider")) {
-				flag = WACOM_AXIS_TYPE_SLIDER;
-			} else {
-				g_warning ("Invalid axis %s for stylus ID %s\n",
-					   string_list[j], groups[i]);
+
+		if (handle_aliases == ONLY_ALIASES && string_list == NULL) {
+			stylus->axes = aliased->axes;
+		} else {
+			for (guint j = 0; string_list && string_list[j]; j++) {
+				WacomAxisTypeFlags flag = WACOM_AXIS_TYPE_NONE;
+				if (g_str_equal(string_list[j], "Tilt")) {
+					flag = WACOM_AXIS_TYPE_TILT;
+				} else if (g_str_equal(string_list[j], "RotationZ")) {
+					flag = WACOM_AXIS_TYPE_ROTATION_Z;
+				} else if (g_str_equal(string_list[j], "Distance")) {
+					flag = WACOM_AXIS_TYPE_DISTANCE;
+				} else if (g_str_equal(string_list[j], "Pressure")) {
+					flag = WACOM_AXIS_TYPE_PRESSURE;
+				} else if (g_str_equal(string_list[j], "Slider")) {
+					flag = WACOM_AXIS_TYPE_SLIDER;
+				} else {
+					g_warning ("Invalid axis %s for stylus ID %s\n",
+						   string_list[j], groups[i]);
+				}
+				if (stylus->axes & flag)
+					g_warning ("Duplicate axis %s for stylus ID %s\n",
+						   string_list[j], groups[i]);
+				stylus->axes |= flag;
 			}
-			if (stylus->axes & flag)
-				g_warning ("Duplicate axis %s for stylus ID %s\n",
-					   string_list[j], groups[i]);
-			stylus->axes |= flag;
 		}
 		g_clear_pointer(&string_list, g_strfreev);
 
-		type = g_key_file_get_string(keyfile, groups[i], "Type", NULL);
+		type = string_or_fallback(keyfile, groups[i], "Type", str_from_type(aliased->type), NULL);
 		stylus->type = type_from_str (type);
 		g_clear_pointer(&type, g_free);
 
@@ -1082,7 +1249,7 @@ stylus_destroy(void *data)
 }
 
 static bool
-load_stylus_files(WacomDeviceDatabase *db, const char *datadir)
+load_stylus_files(WacomDeviceDatabase *db, const char *datadir, AliasStatus handle_aliases)
 {
 	DIR *dir;
 	struct dirent *file;
@@ -1093,12 +1260,11 @@ load_stylus_files(WacomDeviceDatabase *db, const char *datadir)
 
 	while ((file = readdir(dir))) {
 		char *path;
-
 		if (!is_stylus_file(file))
 			continue;
 
 		path = g_build_filename (datadir, file->d_name, NULL);
-		libwacom_parse_stylus_keyfile(db, path);
+		libwacom_parse_stylus_keyfile(db, path, handle_aliases);
 		g_free(path);
 	}
 
@@ -1142,7 +1308,12 @@ database_new_for_paths (char * const *datadirs)
 					       (GDestroyNotify) stylus_destroy);
 
 	for (datadir = datadirs; *datadir; datadir++) {
-		if (!load_stylus_files(db, *datadir))
+		if (!load_stylus_files(db, *datadir, IGNORE_ALIASES))
+			goto error;
+	}
+
+	for (datadir = datadirs; *datadir; datadir++) {
+		if (!load_stylus_files(db, *datadir, ONLY_ALIASES))
 			goto error;
 	}
 


### PR DESCRIPTION
Add a new keyword to libwacom.stylus so we can share the settings among those tools that of the same type: RFC: stylus tool id aliases.

https://github.com/linuxwacom/libwacom/issues/761