### PR TITLE
Allow for a bustype of 0 on real devices

### DIFF
--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -137,6 +137,10 @@ get_bus_vid_pid (GUdevDevice  *device,
 	*product_id = (int)strtol (splitted_product[2], NULL, 16);
 
 	switch (bus_id) {
+	case 0:
+		*bus = WBUSTYPE_UNKNOWN;
+		retval = TRUE;
+		break;
 	case 3:
 		*bus = WBUSTYPE_USB;
 		retval = TRUE;


### PR DESCRIPTION
libwacom_new_for_path() is invoked on an actual device and those sometimes have a bustype of zero - especially where they're created as virtual device.

Since those devices exist we should handle them correctly even though the only thing we will reliably do here is provide the fallback device (if requested).

Closes #840