### PR TITLE
Add support for getting the target mode for a modeswitch button

### DIFF
--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -1589,6 +1589,18 @@ libwacom_get_button_evdev_code(const WacomDevice *device, char button)
 	return b ? b->code : 0;
 }
 
+LIBWACOM_EXPORT WacomModeSwitch
+libwacom_get_button_modeswitch_mode(const WacomDevice *device, char button)
+{
+	WacomButton *b = g_hash_table_lookup(device->buttons,
+					     GINT_TO_POINTER(button));
+
+	if (!b || (b->flags & WACOM_BUTTON_MODESWITCH) == 0)
+		return WACOM_MODE_SWITCH_NEXT;
+
+	return b->mode;
+}
+
 static const WacomStylus *
 libwacom_stylus_get_for_stylus_id (const WacomDeviceDatabase *db,
 				   const WacomStylusId *id)

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -310,6 +310,27 @@ typedef enum {
 } WacomStatusLEDs;
 
 /**
+ * @ingroup devices
+ *
+ * Defines the mode a button with @ref WACOM_BUTTON_RING_MODESWITCH,
+ * @ref WACOM_BUTTON_RING2_MODESWITCH, @ref WACOM_BUTTON_TOUCHSTRIP_MODESWITCH,
+ * @ref WACOM_BUTTON_TOUCHSTRIP2_MODESWITCH, @ref WACOM_BUTTON_DIAL_MODESWITCH
+ * or @ref WACOM_BUTTON_DIAL2_MODESWITCH switches to.
+ *
+ * Positive values in this enum are used to signify the mode number. A tablet may
+ * support more than the 4 modes defined here, callers should use the numerical
+ * value of this enum to determine the mode number.
+ */
+typedef enum {
+	WACOM_MODE_SWITCH_NEXT = -1,
+	WACOM_MODE_SWITCH_0 = 0,
+	WACOM_MODE_SWITCH_1 = 1,
+	WACOM_MODE_SWITCH_2 = 2,
+	WACOM_MODE_SWITCH_3 = 3,
+	/* further modes are numerical only */
+} WacomModeSwitch;
+
+/**
  * Allocate a new structure for error reporting.
  *
  * @return A newly allocated error structure or NULL if the allocation
@@ -861,6 +882,24 @@ WacomButtonFlags libwacom_get_button_flag(const WacomDevice *device,
  */
 int libwacom_get_button_evdev_code(const WacomDevice *device,
 				   char               button);
+
+/**
+ * @param device The tablet to query
+ * @param button The ID of the button to check for, between 'A' and 'Z'
+ *
+ * This function may only be called for buttons with one of the
+ * @ref WACOM_BUTTON_MODESWITCH flags set. For all other buttons, it returns
+ * @ref WACOM_MODE_SWITCH_NEXT.
+ *
+ * @return the target mode for this button. Values zero and above signal the
+ * number of the target mode, negative values are enumerated in the @WacomModeSwitch
+ * enum.
+ *
+ * @ingroup devices
+ * @since 2.15
+ */
+WacomModeSwitch libwacom_get_button_modeswitch_mode(const WacomDevice *device,
+						    char button);
 
 /**
  * Get the WacomStylus for the given tool ID.

--- a/libwacom/libwacom.sym
+++ b/libwacom/libwacom.sym
@@ -94,3 +94,7 @@ LIBWACOM_2.14 {
     libwacom_stylus_get_paired_styli;
     libwacom_stylus_get_vendor_id;
 } LIBWACOM_2.12;
+
+LIBWACOM_2.15 {
+    libwacom_get_button_modeswitch_mode;
+} LIBWACOM_2.14;

--- a/libwacom/libwacomint.h
+++ b/libwacom/libwacomint.h
@@ -80,6 +80,7 @@ struct _WacomMatch {
 typedef struct _WacomButton {
 	WacomButtonFlags flags;
 	int code;
+	WacomModeSwitch mode;
 } WacomButton;
 
 typedef struct _WacomKeycode {

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -240,6 +240,11 @@ class LibWacom:
             return_type=c_int,
         ),
         _Api(
+            name="libwacom_get_button_modeswitch_mode",
+            args=(c_void_p, c_char),
+            return_type=c_int,
+        ),
+        _Api(
             name="libwacom_stylus_get_for_id",
             args=(c_void_p, c_int),
             return_type=c_void_p,
@@ -396,6 +401,11 @@ class LibWacom:
         _Enum(name="WACOM_STATUS_LED_TOUCHSTRIP2", value=4),
         _Enum(name="WACOM_STATUS_LED_DIAL", value=1),
         _Enum(name="WACOM_STATUS_LED_DIAL2", value=2),
+        _Enum(name="WACOM_MODE_SWITCH_NEXT", value=-1),
+        _Enum(name="WACOM_MODE_SWITCH_0", value=0),
+        _Enum(name="WACOM_MODE_SWITCH_1", value=1),
+        _Enum(name="WACOM_MODE_SWITCH_2", value=2),
+        _Enum(name="WACOM_MODE_SWITCH_3", value=3),
     ]
 
 
@@ -667,6 +677,13 @@ class WacomDevice:
                 WacomDevice.ButtonFlags.DIAL2_MODESWITCH,
             ]
 
+    class ModeSwitch(enum.IntEnum):
+        NEXT = -1
+        MODE_0 = 0
+        MODE_1 = 1
+        MODE_2 = 2
+        MODE_3 = 3
+
     def __init__(self, device, destroy=True):
         self.device = device
         self._destroy_on_del = destroy
@@ -811,6 +828,10 @@ class WacomDevice:
 
     def button_evdev_code(self, button: str) -> int:
         return self.get_button_evdev_code(button.encode("utf-8"))
+
+    def button_modeswitch_mode(self, button: str) -> ModeSwitch:
+        mode = self.get_button_modeswitch_mode(button.encode("utf-8"))
+        return WacomDevice.ModeSwitch(mode)
 
     def button_led_group(self, button: str) -> List[ButtonFlags]:
         return self.get_button_led_group(button.encode("utf-8"))

--- a/test/test_libwacom.py
+++ b/test/test_libwacom.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 import ctypes
 import logging
 import pytest
+import string
 
 from . import (
     WacomBuilder,
@@ -226,6 +227,11 @@ def test_cintiq24hdt(db):
     assert match.product_id == 0xF6
     assert match.bustype == device.BUSTYPE_USB
 
+    modes = {"A": 0, "B": 1, "C": 2, "I": 0, "J": 1, "K": 2}
+    for btn in string.ascii_uppercase[: device.num_buttons]:
+        expected_mode = modes.get(btn, WacomDevice.ModeSwitch.NEXT)
+        assert device.button_modeswitch_mode(btn) == expected_mode
+
 
 def test_cintiq13hd(db):
     libevdev = pytest.importorskip("libevdev")
@@ -248,6 +254,9 @@ def test_cintiqpro13(db):
     device = db.new_from_name("Wacom Cintiq Pro 13")
     assert device is not None
     assert device.num_keys == 5
+
+    for btn in string.ascii_uppercase[: device.num_buttons]:
+        assert device.button_modeswitch_mode(btn) == WacomDevice.ModeSwitch.NEXT
 
 
 def test_dell_canvas(db):
@@ -281,6 +290,16 @@ def test_isdv4_4800(db):
     assert device.vendor_id == 0x56A
     assert device.product_id == 0x4800
     assert device.num_buttons == 0
+
+
+def test_mobilestudio_pro_modeswitch(db):
+    device = db.new_from_name("Wacom MobileStudio Pro 13")
+    assert device is not None
+
+    modes = {"H": 0, "I": 1, "J": 2, "K": 3}
+    for btn in string.ascii_uppercase[: device.num_buttons]:
+        expected_mode = modes.get(btn, WacomDevice.ModeSwitch.NEXT)
+        assert device.button_modeswitch_mode(btn) == expected_mode
 
 
 @pytest.mark.parametrize(

--- a/tools/debug-device.c
+++ b/tools/debug-device.c
@@ -50,7 +50,7 @@ static int indent = 0;
 #define pop() indent -= 2
 
 #define ip(fmt_, ...) \
-	printf("%-*s" fmt_, indent, "", __VA_ARGS__);
+	printf("%-*s" fmt_, indent, "", __VA_ARGS__)
 /* Usage: p("function_name", "return value is %d", a) */
 #define p(f_, fmt_, ...) \
 	printf("%-*s%-*s -> " fmt_ "\n", indent, "", (46 - indent), f_, __VA_ARGS__)
@@ -61,11 +61,11 @@ static int indent = 0;
 
 /* Usage: func(myfunc, "%d", argval, "return value is %d", a) */
 #define func_arg(f_, arg_fmt_, arg_val_, fmt_, ...) \
-	{ \
+	do { \
 		char buf_[256]; \
 		snprintf(buf_, sizeof(buf_), #f_"(" arg_fmt_ ")", arg_val_); \
 		p(buf_, fmt_, __VA_ARGS__); \
-	}
+	} while(0)
 
 #define strfunc(f_, dev_) \
 	func(f_, "\"%s\"", f_(dev_))

--- a/tools/debug-device.c
+++ b/tools/debug-device.c
@@ -233,6 +233,20 @@ handle_device(WacomDeviceDatabase *db, const char *path)
 				 flags & WACOM_BUTTON_DIAL2_MODESWITCH ? "DIAL2_MODESWITCH|" : "",
 				 flags & WACOM_BUTTON_OLED ? "OLED " : "");
 		}
+
+		for (int i = 0; i < libwacom_get_num_buttons(device); i++ ) {
+			char b = 'A' + i;
+			WacomModeSwitch mode;
+
+			if ((libwacom_get_button_flag(device, b) & WACOM_BUTTON_MODESWITCH) == 0)
+				continue;
+
+			mode = libwacom_get_button_modeswitch_mode(device, b);
+			if (mode == WACOM_MODE_SWITCH_NEXT)
+				func_arg(libwacom_get_button_modeswitch_mode, "%c", b, "%s", "MODE_SWITCH_NEXT");
+			else
+				func_arg(libwacom_get_button_modeswitch_mode, "%c", b, "%d", (int)mode);
+		}
 	}
 
 	{


### PR DESCRIPTION
Add libwacom_get_button_modeswitch_mode() to return the target mode for a given button. On the vast majority of devices this will be "next" but the Wacom Mobile Studio and the Cintiq 24HD have multiple mode switch buttons that correspond to the respective mode (i.e. button N should switch to mode M).

This is already effectively encoded in our tablet database so we can simply use the order of buttons in that file to assign the modes.

Closes #854