### PR TITLE
Support "AliasOf" keyword 

### DIFF
--- a/data/wacom.stylus
+++ b/data/wacom.stylus
@@ -34,51 +34,26 @@ Type=Mobile
 
 [0x56a:0x11]
 # Lenovo ; VID_NONE     | 0x0000 | BAT_CHRG
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x56a:0x19]
 # Lenovo ; VID_LENOVO   | 0x60A8 | BAT_SWAP | BAT_HID
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x56a:0x21]
 # HP     ; VID_NONE     | 0x0000 | BAT_SWAP
 # Huawei ; VID_NONE     | 0x0000 | BAT_SWAP
 # Lenovo ; VID_NONE     | 0x0000 | BAT_SWAP
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x56a:0x31]
 # Dell   ; VID_BROADCOM | 0x81B9 | BAT_SWAP
 # HP     ; VID_CHICONY  | 0xB4A3 | BAT_SWAP | BAT_HID
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x56a:0x39]
 # Huawei ; VID_HUAWEI   | 0x1091 | BAT_SWAP ("Huawei MatePen" / AF61)
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x56a:0x49]
 # Wacom  ; VID_WACOM    | 0x035F | BAT_SWAP | BAT_GATT | BAT_SHARED | LONGPRESS ("Wacom Bamboo Ink" / CS321A)
@@ -91,145 +66,80 @@ Type=Mobile
 
 [0x56a:0x71]
 # Wacom  ; VID_WACOM    | 0x035F | BAT_SWAP | BAT_GATT | BAT_SHARED | LONGPRESS ("Wacom Bamboo Ink" / CS321A1)
-Name=Bamboo Ink
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x49
 
 [0x56a:0x221]
 # HP     ; VID_CHICONY  | 0xB4A3 | BAT_SWAP | BAT_HID
 # Lenovo ; VID_NONE     | 0x0000 | BAT_SWAP
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x56a:0x231]
 # Dell   ; VID_BROADCOM | 0x81C6 | BAT_SWAP | LONGPRESS (Dell PN557W)
 # HP     ; VID_CHICONY  | 0xB4A3 | BAT_SWAP | BAT_HID
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x56a:0x271]
 # Wacom  ; VID_NONE     | 0x0000 | BAT_SWAP ("Wacom Bamboo Ink" / CS323A)
-Name=Bamboo Ink
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x49
 
 [0x56a:0x421]
 # HP     ; VID_NONE     | 0x0000 | BAT_SWAP
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x56a:0x431]
 # Dell   ; VID_BROADCOM | 0x81B9 | BAT_SWAP
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x56a:0x621]
 # Lenovo ; VID_NONE     | 0x0000 | BAT_SWAP
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x56a:0x631]
 # Dell   ; VID_NONE     | 0x0000 | BAT_SWAP | LONGPRESS (Dell PN557W)
 # Dell   ; VID_NONE     | 0xf142541e | BAT_SWAP (Dell PN5122W)
 Name=Dell Active Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x56a:0x8051]
 # Google ; VID_NONE     | 0x0000 | BAT_SWAP ("Google Pixelbook Pen" / C0B)
-Name=AES Pen
-Group=isdv4-aes
 Buttons=0
-EraserType=Button
 Axes=Tilt;Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x56a:0x805B]
 # Dell   ; VID_BROADCOM | 0x81D5 | BAT_SWAP | BAT_GATT | BAT_SHARED | LONGPRESS (Dell PN579X)
 # Lenovo ; VID_LENOVO   | 0x60C5 | BAT_SWAP | BAT_GATT | BAT_SHARED
 # Toshiba; VID_NONE     | 0x0000 | BAT_SWAP
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
 Axes=Tilt;Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x56a:0x806B]
 # HP     ; VID_CHICONY  | 0x1728 | BAT_CHRG | BAT_PROX | BAT_SHARED | LONGPRESS | PROX ("HP Rechargeable Active Pen" / HP Active Pen G2 / 4KL69AA)
 # Huawei ; VID_NONE     | 0x0000 | BAT_SWAP
 # Lenovo ; VID_LENOVO   | 0x60C2 | BAT_CHRG | BAT_GATT | BAT_SHARED
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
 Axes=Tilt;Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x56a:0x807B]
 # Wacom  ; VID_WACOM    | 0x0397 | BAT_CHRG | BAT_GATT | BAT_SHARED | LONGPRESS ("Wacom Bamboo Ink Plus" / CS322A)
 Name=Bamboo Ink Plus
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
+AliasOf=0x49
 Axes=Tilt;Pressure
-Type=Mobile
 
 [0x56a:0x826B]
 # HP     ; VID_CHICONY  | 0x1728 | BAT_CHRG | BAT_PROX | BAT_SHARED | LONGPRESS | PROX ("HP Active Pen G3" / L08263-003 / L57042-001)
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
 Axes=Tilt;Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x56a:0x846B]
 # HP     ; VID_CHICONY  | 0x1850 | BAT_CHRG | BAT_GATT | BAT_SHARED | LONGPRESS | PROX ("HP Rechargeable Active Pen G3" / HP Active Pen G3 / 6SG43AA)
-Name=AES Pen
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
 Axes=Tilt;Pressure
-Type=Mobile
+AliasOf=0x1
 
 [0x56a:0x219]
 # Lenovo ; VID_LENOVO     | 0x219 | BAT_SWAP
 Name=Lenovo Digital Pen 2
-Group=isdv4-aes
-Buttons=1
-EraserType=Button
-Axes=Pressure
-Type=Mobile
+AliasOf=0x1
 
 # Inking pen have no eraser
 [0x56a:0x812]

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -309,6 +309,10 @@ typedef enum {
 	WACOM_STATUS_LED_DIAL2		= 5,
 } WacomStatusLEDs;
 
+typedef enum {
+	IGNORE_ALIASES	= 0,
+	ONLY_ALIASES	= 1,
+} AliasStatus;
 /**
  * @ingroup devices
  *


### PR DESCRIPTION
Add a new keyword to libwacom.stylus so we can share the settings among those tools that of the same type.

This supersedes #844 and has the various missing bits:
- style changes and memleak fixes
- better error path handling through `g_set_error()`
- support for full stylus ids (`vid:pid` format)
- test case added so we can make sure the overrides actually works

Closes #761

Closes #884