### PR TITLE
Support for XP-Pen Deco Pro S

### DIFF
--- a/data/xp-pen-deco-pro-s.tablet
+++ b/data/xp-pen-deco-pro-s.tablet
@@ -1,0 +1,27 @@
+# XP-Pen
+# Deco Pro S
+#
+# sysinfo.YgZdvbyG6s
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/300
+
+[Device]
+Name=UGTABLET Deco Pro S
+ModelName=
+DeviceMatch=usb|28bd|0909
+PairedIDs=
+Width=9
+Height=5
+IntegratedIn=
+Layout=xp-pen-deco-pro-s-m-sw-mw.svg
+Styli=@generic-no-eraser
+
+[Features]
+Stylus=true
+Reversible=true
+Touch=false
+NumRings=0
+NumStrips=0
+
+[Buttons]
+Left=A;B;C;D;E;F;G;H
+EvdevCodes=BTN_0;BTN_1;BTN_2;BTN_3;BTN_4;BTN_5;BTN_6;BTN_7


### PR DESCRIPTION
Pull request adds support for XP-Pen Deco Pro S tablet. This model is virtually identical to the XP-Pen Deco Pro SW tablet, just without the Bluetooth connectivity.