### PR TITLE
Use g_autofree/g_autoptr and friends for automatic memory management 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,1 @@
+Checks: '-clang-analyzer-unix.Malloc'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,9 +62,9 @@ jobs:
 
   ###
   #
-  # scan-build
+  # clang-tidy
   #
-  scan-build:
+  clang-tidy:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -76,11 +76,13 @@ jobs:
         with:
           apt: $UBUNTU_PACKAGES
           pip: $PIP_PACKAGES
-      - name: scan-build
+      - name: clang-tidy
         uses: ./.github/actions/meson
         with:
           meson_skip_test: 1
-          ninja_args: scan-build
+          ninja_args: clang-tidy
+        env:
+          CC: clang
 
   ###
   #

--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -296,7 +296,7 @@ get_device_info (const char            *path,
 
 	retval = FALSE;
 	/* The integration flags from device info are unset by default */
-	*integration_flags = WACOM_DEVICE_INTEGRATED_UNSET;
+	*integration_flags = WACOM_DEVICE_INTEGRATED_UNSET; // NOLINT: core.EnumCastOutOfRange
 	*name = NULL;
 	*uniq = NULL;
 	bus_str = NULL;

--- a/libwacom/libwacomint.h
+++ b/libwacom/libwacomint.h
@@ -181,6 +181,9 @@ WacomBusType  bus_from_str (const char *str);
 const char   *bus_to_str   (WacomBusType bus);
 char *make_match_string(const char *name, const char *uniq, WacomBusType bus, int vendor_id, int product_id);
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(WacomMatch, libwacom_match_unref);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(WacomDevice, libwacom_unref);
+
 #endif /* _LIBWACOMINT_H_ */
 
 /* vim: set noexpandtab shiftwidth=8: */

--- a/run-full-test.sh
+++ b/run-full-test.sh
@@ -22,9 +22,9 @@ echo "####################################### running asan"
 meson configure $builddir  -Db_sanitize=address
 ninja -C $builddir test
 
-echo "####################################### running scan-build"
+echo "####################################### running clang-tidy"
 meson configure $builddir  -Db_sanitize=none
-ninja -C $builddir scan-build
+ninja -C $builddir clang-tidy
 
 echo "######## Success. Removing builddir #########"
 rm -rf "$buildir"

--- a/test/test-dbverify.c
+++ b/test/test-dbverify.c
@@ -52,7 +52,7 @@ rmtmpdir(const char *tmpdir)
 		return;
 
 	while ((file = readdir(dir))) {
-		char *path = NULL;
+		g_autofree char *path = NULL;
 
 		if (file->d_name[0] == '.')
 			continue;
@@ -60,7 +60,6 @@ rmtmpdir(const char *tmpdir)
 		g_assert(asprintf(&path, "%s/%s", tmpdir, file->d_name) != -1);
 		g_assert(path);
 		g_assert(remove(path) != -1);
-		free(path);
 	}
 
 	closedir(dir);
@@ -71,7 +70,7 @@ rmtmpdir(const char *tmpdir)
 static void
 find_matching(gconstpointer data)
 {
-	WacomDevice **devs_old, **devs_new;
+	g_autofree WacomDevice **devs_old, **devs_new;
 	WacomDevice **devices, **d;
 	WacomDevice *other;
 	gboolean found = FALSE;
@@ -106,16 +105,13 @@ find_matching(gconstpointer data)
 		}
 	}
 	g_assert_true(found);
-
-	free(devs_old);
-	free(devs_new);
 }
 
 static void
 test_database_size(void)
 {
 	int sz1, sz2;
-	WacomDevice **d1, **d2;
+	g_autofree WacomDevice **d1, **d2;
 
 	d1 = libwacom_list_devices_from_database(db_old, NULL);
 	d2 = libwacom_list_devices_from_database(db_new, NULL);
@@ -129,16 +125,14 @@ test_database_size(void)
 	for (WacomDevice **d = d2; *d; d++)
 		sz2++;
 	g_assert_cmpint(sz1, ==, sz2);
-
-	free(d1);
-	free(d2);
 }
 
 static int
 compare_databases(WacomDeviceDatabase *new)
 {
 	int i, rc;
-	WacomDevice **devs_new, **n;
+	g_autofree WacomDevice **devs_new;
+	WacomDevice **n;
 
 	g_test_add_func("/dbverify/database-sizes", test_database_size);
 
@@ -159,7 +153,6 @@ compare_databases(WacomDeviceDatabase *new)
 	}
 
 	rc = g_test_run();
-	free(devs_new);
 	return rc;
 }
 
@@ -177,9 +170,9 @@ duplicate_database(WacomDeviceDatabase *db, const char *dirname)
 	for (device = devices, i = 0; *device; device++, i++) {
 		int i;
 		int fd;
-		char *path = NULL;
+		g_autofree char *path = NULL;
 		int nstyli;
-		const WacomStylus **styli;
+		g_autofree const WacomStylus **styli = NULL;
 
 		g_assert(asprintf(&path, "%s/%s.tablet", dirname,
 				libwacom_get_match(*device)) != -1);
@@ -188,7 +181,6 @@ duplicate_database(WacomDeviceDatabase *db, const char *dirname)
 		g_assert(fd >= 0);
 		libwacom_print_device_description(fd, *device);
 		close(fd);
-		free(path);
 
 		if (!libwacom_has_stylus(*device))
 			continue;
@@ -197,15 +189,12 @@ duplicate_database(WacomDeviceDatabase *db, const char *dirname)
 		for (i = 0; i < nstyli; i++) {
 			int fd_stylus;
 			const WacomStylus *stylus = styli[i];
-
-			g_assert(asprintf(&path, "%s/%#x.stylus", dirname, libwacom_stylus_get_id(stylus)) != -1);
+			g_autofree char *path = g_strdup_printf("%s/%#x.stylus", dirname, libwacom_stylus_get_id(stylus));
 			fd_stylus = open(path, O_WRONLY|O_CREAT, S_IRWXU);
 			g_assert(fd_stylus >= 0);
 			libwacom_print_stylus_description(fd_stylus, stylus);
 			close(fd_stylus);
-			free(path);
 		}
-		free(styli);
 	}
 
 	free(devices);
@@ -232,7 +221,7 @@ load_database(void)
 int main(int argc, char **argv)
 {
 	WacomDeviceDatabase *db;
-	char *dirname;
+	g_autofree char *dirname;
 	int rc;
 
 	g_test_init(&argc, &argv, NULL);
@@ -253,7 +242,6 @@ int main(int argc, char **argv)
 	libwacom_database_destroy(db_old);
 
 	rmtmpdir(dirname);
-	g_free(dirname);
 
 	return rc;
 }

--- a/test/test-tablet-validity.c
+++ b/test/test-tablet-validity.c
@@ -257,7 +257,7 @@ test_styli(gconstpointer data)
 {
 	WacomDevice *device = (WacomDevice*)data;
 	int nstylus_ids, nstyli;
-	const WacomStylus **styli;
+	g_autofree const WacomStylus **styli = NULL;
 	const int *stylus_ids;
 
 #pragma GCC diagnostic push
@@ -280,9 +280,6 @@ test_styli(gconstpointer data)
 		}
 		g_assert_true(found);
 	}
-
-	g_free(styli);
-
 }
 
 static void
@@ -290,7 +287,7 @@ test_no_styli(gconstpointer data)
 {
 	WacomDevice *device = (WacomDevice*)data;
 	int nstylus_ids, nstyli;
-	const WacomStylus **styli;
+	g_autofree const WacomStylus **styli = NULL;
 	const int *stylus_ids;
 
 #pragma GCC diagnostic push
@@ -304,7 +301,6 @@ test_no_styli(gconstpointer data)
 	g_assert_nonnull(styli);
 	g_assert_null(stylus_ids);
 	g_assert_null(styli[0]); /* NULL-terminated list */
-	g_free(styli);
 
 }
 
@@ -313,7 +309,7 @@ test_realstylus(gconstpointer data)
 {
 	WacomDevice *device = (WacomDevice*)data;
 	int nstylus_ids, nstyli;
-	const WacomStylus **styli;
+	g_autofree const WacomStylus **styli = NULL;
 	const int *stylus_ids;
 
 #pragma GCC diagnostic push
@@ -332,9 +328,6 @@ test_realstylus(gconstpointer data)
 		g_assert_cmpint(libwacom_stylus_get_id(stylus), !=, WACOM_STYLUS_FALLBACK_ID);
 		g_assert_cmpint(libwacom_stylus_get_id(stylus), !=, WACOM_ERASER_FALLBACK_ID);
 	}
-
-
-	g_free(styli);
 }
 
 static void

--- a/tools/list-compatible-styli.c
+++ b/tools/list-compatible-styli.c
@@ -38,7 +38,7 @@
 static void
 print_device_info(const WacomDeviceDatabase *db, const WacomDevice *device)
 {
-	WacomStylus const **styli;
+	g_autofree WacomStylus const **styli = NULL;
 	int nstyli;
 
 	printf("- name: '%s'\n", libwacom_get_name(device));
@@ -62,7 +62,6 @@ print_device_info(const WacomDeviceDatabase *db, const WacomDevice *device)
 		       (int)(7 - strlen(id)), " ", id,
 		       libwacom_stylus_get_name(s));
 	}
-	g_free(styli);
 }
 
 int main(int argc, char **argv)

--- a/tools/list-devices.c
+++ b/tools/list-devices.c
@@ -100,20 +100,17 @@ static GOptionEntry opts[] = {
 int main(int argc, char **argv)
 {
 	WacomDeviceDatabase *db;
-	WacomDevice **list, **p;
-	GOptionContext *context;
-	GError *error = NULL;
+	g_autofree WacomDevice **list = NULL;
+	WacomDevice **p;
+	g_autoptr(GOptionContext) context = g_option_context_new(NULL);
+	g_autoptr(GError) error = NULL;
 
-	context = g_option_context_new (NULL);
 	g_option_context_add_main_entries (context, opts, NULL);
 	if (!g_option_context_parse (context, &argc, &argv, &error)) {
-		if (error != NULL) {
+		if (error != NULL)
 			fprintf (stderr, "%s\n", error->message);
-			g_error_free (error);
-		}
 		return EXIT_FAILURE;
 	}
-	g_option_context_free (context);
 
 #ifdef DATABASEPATH
 	db = libwacom_database_new_for_path(DATABASEPATH);
@@ -146,7 +143,6 @@ int main(int argc, char **argv)
 		print_device_info ((WacomDevice *) *p, WBUSTYPE_UNKNOWN, output_format);
 
 	libwacom_database_destroy (db);
-	free(list);
 
 	return 0;
 }


### PR DESCRIPTION
Closes #142 

`scan-build` prevented us from using these in the past since it would throw false positives for memleaks everywhere. We can instead run `clang-tidy` though which provides configuration[^1] via `.clang-tidy` where we can just disable that warning.

I've used the equivalent of `g_auto` in other projects and it makes code so much nicer that it's a huge win, even where there aren't lots of allocations.

Unfortunately that warning also disables double-free and use-after-free warnings but with consistent use of `g_auto` we should never have those anyway since we will never call free ourselves outside of dedicated cleanup functions. So I think that's a fair trade off.

side-note: `.clang-tidy` would also eventually allow us to enforce consistent coding style, see e.g. #868.

This patch isn't fully complete yet, it'd be nice to switch all instances to proper RAII (this isn't the 90s anymore, we can use decl after definitions too) but things take time.


[^1]: technically meson allows wrapping `scan-build` with a script that would allow the same but it appears more complicated to integrate.