### PR TITLE
Initial config for Framework 12 touchscreen

### DIFF
--- a/data/framework-laptop12.tablet
+++ b/data/framework-laptop12.tablet
@@ -1,0 +1,19 @@
+# Framework Laptop 12
+#
+# sysinfo.9HcjU7I6uJ.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/475
+[Device]
+Name=Framework Laptop 12
+# VID belongs to Ilitek, the touch IC vendor
+# PID is reserved for this Framework Laptop 12
+DeviceMatch=i2c|222a|5539
+# Dimensions of the touch area in inches
+# Actually 10.5x6.6in, rounding up
+Width=11
+Height=7
+IntegratedIn=Display;System;
+Styli=@generic-no-eraser;
+
+[Features]
+Stylus=true
+Touch=true


### PR DESCRIPTION
To validate:

```
> sudo cp data/framework-laptop12.tablet /usr/share/libwacom/
> sudo libwacom-list-local-devices
devices:
  - name: 'Framework Laptop 12'
    bus: 'i2c'
    vid: 0x222a
    pid: 0x5539
    nodes:
      - /dev/input/event9: 'ILIT2901:00 222A:5539 Stylus'
    styli:
      - id: 0xffffd
        vid: 0x0000
        name: 'General Pen with no Eraser'
        type: 'general'
        axes: ['x', 'y' , 'pressure']
        buttons: 2
        erasers: []
```