### PR TITLE
Fix segfault after running list-local-devices

### DIFF
--- a/tools/list-local-devices.c
+++ b/tools/list-local-devices.c
@@ -264,8 +264,6 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-	g_option_context_free (context);
-
 	if (database_path) {
 		db = libwacom_database_new_for_path(database_path);
 		g_free (database_path);


### PR DESCRIPTION
The regression was caused by ac375537f2592307f6056dbd01f8321eef8af1f6.

The command appears do what it needs to do, it simply segfaults after everything was executed.