### PR TITLE
Add Waltop Batteryless Tablet 172f:0505 aka Medion P82013 (MD 86457)

### DIFF
--- a/data/waltop-batteryless-tablet.tablet
+++ b/data/waltop-batteryless-tablet.tablet
@@ -1,0 +1,18 @@
+# Waltop
+# Batteryless Tablet
+#
+# sysinfo.XSrrkQpKdX.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/489
+
+[Device]
+Name=Waltop Batteryless Tablet
+ModelName=
+DeviceMatch=usb|172f|0505
+Class=Bamboo
+Width=8
+Height=5
+Styli=@generic-no-eraser
+
+[Features]
+Stylus=true
+Reversible=true


### PR DESCRIPTION
- Waltop Batteryless Tablet (`172f:0505`)
- Sold as "USB-Grafiktablett MEDION P82013 (MD 86457)" by Medion
- Sysinfo: https://github.com/linuxwacom/wacom-hid-descriptors/issues/489
- User Manual (German): https://download2.medion.com/downloads/anleitungen/bda_md86457_de-an.pdf
- Physical working area is 8×5″, reported by libinput as 200×125mm
- Resolution is stated as 4000 LPI
- Pressure sensitivity range is 0-2047, but the reported values seem to grow exponentially rather than linearly (see https://gitlab.freedesktop.org/libinput/libinput/-/issues/1146#note_2974640).

The tablet also reports stylus tilt levels, which I wasn’t sure how to note in the `.tablet` file.