### PR TITLE
Add support for Dell Inspiron 14 7445 2-in-1

### DIFF
--- a/data/wacom-isdv4-42ab.tablet
+++ b/data/wacom-isdv4-42ab.tablet
@@ -1,0 +1,21 @@
+# Dell Inspiron 7445 14 2-in-1
+# Sensor Type: AES
+# Features: Touch (Intergrated), Tilt
+#
+# sysinfo.BRJPJZKkp3.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/532
+#
+
+[Device]
+Name=Dell Inc. Inspiron 14 7445 2-in-1
+ModelName=
+DeviceMatch=i2c|04f3|42ab
+Class=ISDV4
+Width=12
+Height=7
+IntegratedIn=Display;System
+Styli=@isdv4-aes;
+
+[Features]
+Stylus=true
+Touch=true


### PR DESCRIPTION
The pull request allows listing support of Dell Inc. Inspiron 14 7445 2-in-1 in the libwacom database as tested on Gnome Settings -> Graphics Tablets.