### PR TITLE
meson.build: bump minimum version for format strings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('libwacom', 'c',
 	version: '2.16.1',
 	license: 'HPND',
 	default_options: [ 'c_std=gnu99', 'warning_level=2' ],
-	meson_version: '>= 0.57.0')
+	meson_version: '>= 0.58.0')
 
 dir_bin      = get_option('prefix') / get_option('bindir')
 dir_data     = get_option('prefix') / get_option('datadir') / 'libwacom'


### PR DESCRIPTION
Fixes:

   WARNING: Project specifies a minimum meson_version '>= 0.57.0'
    but uses features which were added in newer versions: