### PR TITLE
xp-pen-deco-fun-l should have generic-with-eraser styli

### DIFF
--- a/data/xp-pen-deco-fun-l.tablet
+++ b/data/xp-pen-deco-fun-l.tablet
@@ -13,7 +13,7 @@ Class=Bamboo
 Width=10
 Height=6
 IntegratedIn=
-Styli=@generic-no-eraser
+Styli=@generic-with-eraser
 
 [Features]
 Stylus=true


### PR DESCRIPTION
The pen that comes with the XP Pen Deco Fun series (XP-Pen P01 Stylus) does not have a back eraser. Instead, its upper button is hardwired to act as an eraser toggle. This is not software-configurable as far as I can tell.

This change fixes the crashes I have been having with my tablet in all GTK apps.
(When I hold the pen near the tablet, press upper button, then pull the pen up, GTK apps will crash. I think this indicates a deeper problem with GTK input handling, but setting "generic-with-eraser" workarounds that (and is the correct thing to do anyway).)