### PR TITLE
Adds missing identifiers for Huion Inspiroy H1060P (refs #901).

### DIFF
--- a/data/huion-h1060p.tablet
+++ b/data/huion-h1060p.tablet
@@ -6,7 +6,7 @@
 [Device]
 Name=HUION H1060P Tablet
 ModelName=
-DeviceMatch=usb|256c|006d|HUION Huion Tablet Pad;usb|256c|006d|HUION Huion Tablet Pen
+DeviceMatch=usb|256c|006d|HUION Huion Tablet Pad;usb|256c|006d|HUION Huion Tablet Pen;usb|256c|006d|HID 256c:006d;usb|256c|006d|HID 256c:006d Dial;usb|256c|006d|HID 256c:006d Touch Strip
 Width=10
 Height=6
 IntegratedIn=


### PR DESCRIPTION
This PR solves my issue #901 without breaking potentially correct behaviors for other users.