### PR TITLE
Add XP-Pen Deco02 support

### DIFF
--- a/data/layouts/xp-pen-deco02.svg
+++ b/data/layouts/xp-pen-deco02.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg
+   id="xp-pen-deco02"
+   width="10in"
+   height="5.6300001in"
+   style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
+   version="1.1"
+   viewBox="0 0 254 143.002"
+   xmlns="http://www.w3.org/2000/svg">
+   <title id="title">XP-Pen Deco 02</title>
+  <circle
+     id="ButtonF"
+     class="F Button"
+     cx="30.5"
+     cy="123.5"
+     r="4.5" />
+  <circle
+     id="ButtonE"
+     class="E Button"
+     cx="30.5"
+     cy="108.5"
+     r="4.5" />
+  <circle
+     id="ButtonD"
+     class="D Button"
+     cx="30.5"
+     cy="93.5"
+     r="4.5" />
+  <circle
+     id="RingCW"
+     class="RingCW Button"
+     cx="30.5"
+     cy="71"
+     r="10" />
+  <circle
+     id="RingCCW"
+     class="RingCCW Button"
+     cx="30.5"
+     cy="71"
+     r="10" />
+  <circle
+     id="ButtonC"
+     class="C Button"
+     cx="30.5"
+     cy="49.5"
+     r="4.5" />
+  <circle
+     id="ButtonB"
+     class="B Button"
+     cx="30.5"
+     cy="34.5"
+     r="4.5" />
+  <circle
+     id="ButtonA"
+     class="A Button"
+     cx="30.5"
+     cy="19.5"
+     r="4.5" />
+</svg>

--- a/data/xp-pen-deco02.tablet
+++ b/data/xp-pen-deco02.tablet
@@ -1,0 +1,55 @@
+# XP-Pen
+# Deco 02
+#
+# sysinfo.4ksH4T345j
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/506
+#
+# Button Map:
+# (A=1, B=2, C=3, ...)
+#
+#         *------------------------------------*
+#         |                                    |
+#  A      |                                    |
+#  B      |                                    |
+#  C      |                                    |
+#  (Dial) |              TABLET                |
+#  D      |                                    |
+#  E      |                                    |
+#  F      |                                    |
+#         |                                    |
+#         *------------------------------------*
+
+[Device]
+Name=XP-PEN DECO 02
+ModelName=
+DeviceMatch=usb|28bd|0803
+PairedIDs=
+Width=10
+Height=5.63
+IntegratedIn=
+Layout=xp-pen-deco02.svg
+# Only the discontinued P05 stylus is supported, which is single button only.
+# Until one-button configurations are supported, a two-button generic must be used.
+Styli=@generic-with-eraser
+
+[Features]
+Stylus=true
+Reversible=true
+Touch=false
+TouchSwitch=false
+NumRings=0
+NumDials=1
+NumStrips=0
+
+[Buttons]
+Top=A;B;C
+Bottom=D;E;F
+# This tablet sends KEYBOARD_KEY events, rather than button codes.
+# These are configurable, so not 100% sure it's appropriate for [Keys]?
+# This seems to be how it is defined for similar tablets, although not true here.
+EvdevCodes=BTN_0;BTN_1;BTN_2;BTN_3;BTN_4;BTN_5
+
+# A mode toggle is provided through the proprietary driver, but this is software-level.
+# F is selected as the default, but could theoretically be assigned to any button.
+Dial=F
+DialNumModes=4


### PR DESCRIPTION
Added support for the XP-Pen Deco 02.
Descriptors: [https://github.com/linuxwacom/wacom-hid-descriptors/issues/506](https://github.com/linuxwacom/wacom-hid-descriptors/issues/506)

Stylus support is only partial, due to the one-button nature of the only supported stylus.

Buttons may not be correct, as libinput only seems to offer KEYBOARD events, but this is the format that appears to be used by every other XP-Pen device currently in the repository. See lines 47-49 for further detail.

SVG is melting my brain a bit, so it's fairly minimal, but the tags should be correct even in the absence of labels.