### PR TITLE
Added uniq identifier to Huion Kamvas Pro 13 (GT-133)

### DIFF
--- a/data/huion-kamvas-pro-13.tablet
+++ b/data/huion-kamvas-pro-13.tablet
@@ -37,7 +37,7 @@
 [Device]
 Name=Huion Kamvas Pro 13
 ModelName=GT-133
-DeviceMatch=usb|256c|006e|Tablet Monitor Pen;usb|256c|006e|Tablet Monitor Pad;
+DeviceMatch=usb|256c|006d||HUION_M182;usb|256c|006e|Tablet Monitor Pen;usb|256c|006e|Tablet Monitor Pad;
 Width=12
 Height=7
 Layout=huion-kamvas-pro-13.svg


### PR DESCRIPTION
Later Huion Kamvas Pro 13 (GT-133) models have the productId 006d (of course) so I added the uniq identifier to the .tablet file. Tested working on my local system.

A word of note: For some reason `udevadm info` (v258) did not show a UNIQ attribtue, but `udevadm info -a` returned `ATTRS{uniq}=="HUION_M182_190116"`

The wiki might need to be updated to reflect this, not sure which version caused the change.