### PR TITLE
tools: add Keyboard and Mouse hwdb exclusions for Wacom devices too

### DIFF
--- a/tools/libwacom-update-db.py
+++ b/tools/libwacom-update-db.py
@@ -90,9 +90,8 @@ class HWDBFile:
         # to accept those.
         # Let's add a generic exclusion rule for anything we know of with a
         # Keyboard device name.
-        if int(vid, 16) != 0x56A:
-            entries["* Keyboard"] = ["ID_INPUT_TABLET=0", "ID_INPUT_TABLET_PAD=0"]
-            entries["* Mouse"] = ["ID_INPUT_TABLET=0", "ID_INPUT_TABLET_PAD=0"]
+        entries["* Keyboard"] = ["ID_INPUT_TABLET=0", "ID_INPUT_TABLET_PAD=0"]
+        entries["* Mouse"] = ["ID_INPUT_TABLET=0", "ID_INPUT_TABLET_PAD=0"]
 
         lines = [f"# {tablet.name}"]
         for name, props in entries.items():


### PR DESCRIPTION
We already had this in place for non-Wacom devices, let's include Wacom devices too because some of those

Closes: #927