### PR TITLE
Add additional device match entries for Huion Kamvas 13

### DIFF
--- a/data/huion-kamvas-13.tablet
+++ b/data/huion-kamvas-13.tablet
@@ -24,7 +24,7 @@
 [Device]
 Name=Huion Kamvas 13
 ModelName=GS1331
-DeviceMatch=usb|256c|006d|HUION Huion Tablet_GS1331 Pad;usb|256c|006d|HUION Huion Tablet_GS1331 Pen;usb|256c|006d|Tablet Monitor;usb|256c|006d|Tablet Monitor Pad;usb|256c|006d|Tablet Monitor Pen
+DeviceMatch=usb|256c|006d|HUION Huion Tablet_GS1331 Pad;usb|256c|006d|HUION Huion Tablet_GS1331 Pen;usb|256c|006d|Tablet Monitor;usb|256c|006d|Tablet Monitor Pad;usb|256c|006d|Tablet Monitor Pen;usb|256c|006d|HUION Huion Tablet_GS1331 Touch Strip;usb|256c|006d|HUION Huion Tablet_GS1331;usb|256c|006d|HUION Huion Tablet_GS1331 Stylus;usb|256c|006d|HUION Huion Tablet_GS1331 Dial
 Width=12
 Height=7
 IntegratedIn=Display


### PR DESCRIPTION
Expanded the `DeviceMatch` to include new HUION Huion Tablet_GS1331 entries. 