### PR TITLE
Another attempt to add XP-Pen Deco MW with 3 modes

### DIFF
--- a/data/xp-pen-deco-mw.tablet
+++ b/data/xp-pen-deco-mw.tablet
@@ -3,11 +3,18 @@
 #
 # sysinfo.VOAFvy7j7z.tar.gz
 # https://github.com/linuxwacom/wacom-hid-descriptors/issues/291
+# sysinfo.xEHXYQ3D0h.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/566
+# sysinfo.dwWr0dkJW2.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/567
+# sysinfo.znrBdxmBWS.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/568
+
 
 [Device]
 Name=XP-Pen Deco MW
 ModelName=Deco_MW
-DeviceMatch=usb|28bd|0936
+DeviceMatch=usb|28bd|0936;bluetooth|28bd|0936;
 Width=8
 Height=5
 Layout=xp-pen-deco-mw.svg


### PR DESCRIPTION
Another attempt to add support for XP-Pen Deco MW with its USB/Bluetooth/Dongle modes. The device is mostly functional currently, but it still lacks a side button and possibly other features. 

Since my current device is from a later production run, I've collected the sysinfo again, just in case.

The git-update.sh script failed to generate a .tablet file with the following message:

WARNING: Multiple pen devices found.
NOTE: Unable to parse HID data. Skipping creation of libwacom tablet definition.

I modified the existing xp-pen-deco-mw.tablet file from libwacom's data directory.

I have no idea what I'm doing here. I was unable to find information about how to manually create a .tablet file from scratch. Please guide me through what I need to do to make the side buttons on this device to finally work. 

I have a few other devices at hand that partially works but with different degrees of missing features, mostly missing a side button. Hopefully with your help I can get those devices working as well.