### PR TITLE
data: drop the firmware match for the Huion Kamvas 13 GS1333

### DIFF
--- a/data/huion-kamvas-13-gs1333.tablet
+++ b/data/huion-kamvas-13-gs1333.tablet
@@ -37,7 +37,7 @@
 [Device]
 Name=Huion Kamvas 13 (Gen 3)
 ModelName=GS1333
-DeviceMatch=usb|256c|2008||HUION_M22c;
+DeviceMatch=usb|256c|2008;
 Width=12
 Height=7
 Layout=huion-kamvas-13-gs1333.svg


### PR DESCRIPTION
This looks like a unique PID so we don't need the firmware match on top of the vid/pid match.

Closes #940

cc @higginsdragon - just fyi