### PR TITLE
Add support for Lenovo 2-in-1 IdeaPad 5 Wacom HID 53BB Pen

### DIFF
--- a/data/wacom-hid-53bb-pen.tablet
+++ b/data/wacom-hid-53bb-pen.tablet
@@ -17,4 +17,3 @@ Styli=@isdv4-aes;
 Stylus=true
 Touch=true
 Buttons=2
-

--- a/data/wacom-hid-53bb-pen.tablet
+++ b/data/wacom-hid-53bb-pen.tablet
@@ -1,0 +1,20 @@
+# Lenovo IdeaPad 5-14AHP9
+# Pen: Wacom HID 53BB Pen
+# Screen: Touchscreen 14", 1920x2000
+# Features: Stylus (2 buttons), Touchscreen
+
+[Device]
+Name=Wacom HID 53BB Pen
+ModelName=IdeaPad 5-14AHP9
+DeviceMatch=i2c|056a|53bb
+Class=ISDV4
+Width=14
+Height=7.5
+IntegratedIn=Display;System
+Styli=@isdv4-aes;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=2
+


### PR DESCRIPTION
this PR adds a .tablet file for the Wacom HID 53BB Pen found in the Lenovo 2-in-1 IdeaPad 5. 

I have a Lenovo 2-in-1 IdeaPad 5 and gnome identified the device as unknown and displayed the warning:
"Wacom HID 53BB Pen: this device is unknown and may present wrong capabilities." 

The pen has 2 buttons, but only 1 was recognized by the system. Using the device's real characteristics, I created a custom .tablet entry to properly describe it.