### PR TITLE
Add libwacom_stylus_is_generic() to detect generic styli

### DIFF
--- a/data/wacom.stylus
+++ b/data/wacom.stylus
@@ -6,6 +6,7 @@ PairedStylusIds=0x0:0xffffe;
 Buttons=2
 Axes=Tilt;Pressure;Distance;
 Type=General
+IsGenericStylus=true
 
 [0x0:0xffffe]
 Name=General Pen Eraser
@@ -15,6 +16,7 @@ EraserType=Invert
 Buttons=2
 Axes=Tilt;Pressure;Distance;
 Type=General
+IsGenericStylus=true
 
 [0x0:0xffffd]
 Name=General Pen with no Eraser
@@ -22,6 +24,7 @@ Group=generic-no-eraser
 Buttons=2
 Axes=Pressure;
 Type=General
+IsGenericStylus=true
 
 [0x56a:0x1]
 # Lenovo ; VID_NONE     | 0x0000 | BAT_SWAP

--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -571,6 +571,18 @@ libwacom_parse_stylus_keyfile(WacomDeviceDatabase *db,
 				  groups[i],
 				  error->message);
 		g_clear_error(&error);
+		stylus->is_generic_stylus = boolean_or_fallback(
+			keyfile,
+			groups[i],
+			"IsGenericStylus",
+			aliased ? aliased->is_generic_stylus : FALSE,
+			error);
+		if (error && error->code == G_KEY_FILE_ERROR_INVALID_VALUE)
+			g_warning("Stylus %s (%s) %s\n",
+				  stylus->name,
+				  groups[i],
+				  error->message);
+		g_clear_error(&error);
 		stylus->num_buttons =
 			int_or_fallback(keyfile,
 					groups[i],

--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -1814,6 +1814,12 @@ libwacom_stylus_is_eraser(const WacomStylus *stylus)
 }
 
 LIBWACOM_EXPORT int
+libwacom_stylus_is_generic(const WacomStylus *stylus)
+{
+	return stylus->is_generic_stylus;
+}
+
+LIBWACOM_EXPORT int
 libwacom_stylus_has_lens(const WacomStylus *stylus)
 {
 	return stylus->has_lens;

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -1106,6 +1106,24 @@ int
 libwacom_stylus_is_eraser(const WacomStylus *stylus);
 
 /**
+ * Check if the given stylus is a generic stylus.
+ *
+ * Generic styli are styli that cannot be uniquely identified by their
+ * tool ID. Instead a tool ID is assigned by libwacom but these styli
+ * cannot be differentiated at runtime. A device may support multiple
+ * generic styli but there is no information which stylus is in use
+ * at any time.
+ *
+ * @param stylus The stylus to query
+ * @return Non-zero if the stylus is a generic stylus, zero otherwise
+ *
+ * @since 2.18
+ * @ingroup styli
+ */
+int
+libwacom_stylus_is_generic(const WacomStylus *stylus);
+
+/**
  * @param stylus The stylus to query
  * @return Whether the stylus has a lens
  *

--- a/libwacom/libwacom.sym
+++ b/libwacom/libwacom.sym
@@ -98,3 +98,7 @@ LIBWACOM_2.14 {
 LIBWACOM_2.15 {
     libwacom_get_button_modeswitch_mode;
 } LIBWACOM_2.14;
+
+LIBWACOM_2.18 {
+    libwacom_stylus_is_generic;
+} LIBWACOM_2.15;

--- a/libwacom/libwacomint.h
+++ b/libwacom/libwacomint.h
@@ -143,6 +143,7 @@ struct _WacomStylus {
 	char *group;
 	int num_buttons;
 	gboolean has_eraser;
+	gboolean is_generic_stylus;
 	GArray *paired_styli;          /* [WacomStylus*, ...] */
 	GArray *deprecated_paired_ids; /* [int, ...] */
 	GArray *paired_stylus_ids;     /* [WacomStylusId, ...], NULL once parsing is

--- a/test/test-stylus-validity.c
+++ b/test/test-stylus-validity.c
@@ -257,6 +257,22 @@ test_name(gconstpointer data)
 }
 
 static void
+test_generic(gconstpointer data)
+{
+	const WacomStylus *stylus = data;
+
+	g_assert_true(libwacom_stylus_is_generic(stylus));
+}
+
+static void
+test_not_generic(gconstpointer data)
+{
+	const WacomStylus *stylus = data;
+
+	g_assert_false(libwacom_stylus_is_generic(stylus));
+}
+
+static void
 test_buttons(gconstpointer data)
 {
 	const WacomStylus *stylus = data;
@@ -352,7 +368,15 @@ static void
 setup_emr_tests(const WacomStylus *stylus)
 {
 	switch (libwacom_stylus_get_id(stylus)) {
-	case 0xffffd:
+	case 0xfffff: /* GENERIC_PEN_WITH_ERASER */
+	case 0xffffe: /* GENERIC_ERASER */
+		add_test(stylus, test_generic);
+		add_test(stylus, test_pressure);
+		add_test(stylus, test_distance);
+		add_test(stylus, test_tilt);
+		break;
+	case 0xffffd: /* GENERIC_PEN_NO_ERASER */
+		add_test(stylus, test_generic);
 		add_test(stylus, test_pressure);
 		add_test(stylus, test_no_distance);
 		add_test(stylus, test_no_tilt);
@@ -360,6 +384,7 @@ setup_emr_tests(const WacomStylus *stylus)
 	case 0x006:
 	case 0x096:
 	case 0x097:
+		add_test(stylus, test_not_generic);
 		add_test(stylus, test_no_pressure);
 		add_test(stylus, test_distance);
 		add_test(stylus, test_no_tilt);
@@ -368,6 +393,7 @@ setup_emr_tests(const WacomStylus *stylus)
 	case 0x017:
 	case 0x094:
 	case 0x806:
+		add_test(stylus, test_not_generic);
 		add_test(stylus, test_no_pressure);
 		add_test(stylus, test_distance);
 		add_test(stylus, test_tilt);
@@ -375,11 +401,13 @@ setup_emr_tests(const WacomStylus *stylus)
 	case 0x021:
 	case 0x8e2:
 	case 0x862:
+		add_test(stylus, test_not_generic);
 		add_test(stylus, test_pressure);
 		add_test(stylus, test_distance);
 		add_test(stylus, test_no_tilt);
 		break;
 	default:
+		add_test(stylus, test_not_generic);
 		add_test(stylus, test_pressure);
 		add_test(stylus, test_tilt);
 		add_test(stylus, test_distance);


### PR DESCRIPTION
Huion devices now support and ship with a multitude of styli that are support different features and buttons. We need to add more generic (read: unidentifiable) styli to libwacom but this may require callers to differentiate the UI depending on the stylus.

This function allows detection of generic styli.

Closes: #953