### PR TITLE
data: support gaomon m5v2

### DIFF
--- a/data/gaomon-m5v2.tablet
+++ b/data/gaomon-m5v2.tablet
@@ -1,0 +1,29 @@
+# GAOMON
+# S620
+
+# sysinfo.e08ugqN1CI
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/590
+
+[Device]
+Name=M5 V2
+ModelName=
+DeviceMatch=usb|256c|200e
+Class=Bamboo
+Width=9
+Height=6
+IntegratedIn=
+Layout=gaomon-m5v2.svg
+Styli=@generic-no-eraser
+
+[Features]
+Stylus=true
+Reversible=true
+Touch=false
+TouchSwitch=false
+NumRings=0
+NumDials=0
+NumStrips=0
+
+[Buttons]
+Left=A;B;C;D;E;F;G;H
+EvdevCodes=BTN_0;BTN_1;BTN_2;BTN_3;BTN_4;BTN_5;BTN_6;BTN_7

--- a/data/layouts/gaomon-m5v2.svg
+++ b/data/layouts/gaomon-m5v2.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" standalone="no" ?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+    "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    version="1.1"
+    style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
+    id="gaomon-m5v2"
+    width="732"
+    height="500"
+>
+  <title id="title">M5 V2</title>
+  <rect x="116" y="76" width="564" height="348" />
+  <g>
+    <rect id="ButtonA" class="A Button" x="32" y="61" width="35" height="35" />
+    <text
+            id="LabelA"
+            class="A Label"
+            x="47.5"
+            y="80.5"
+            style="text-anchor:start;"
+        >A</text>
+    <path style="display:none" d="M 0,0" id="LeaderA" class="Leader A" />
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="32" y="110" width="35" height="35" />
+    <text
+            id="LabelB"
+            class="B Label"
+            x="47.5"
+            y="129.5"
+            style="text-anchor:start;"
+        >B</text>
+    <path style="display:none" d="M 0,0" id="LeaderB" class="Leader B" />
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="32" y="159" width="35" height="35" />
+    <text
+            id="LabelC"
+            class="C Label"
+            x="47.5"
+            y="178.5"
+            style="text-anchor:start;"
+        >C</text>
+    <path style="display:none" d="M 0,0" id="LeaderC" class="Leader C" />
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="32" y="208" width="35" height="35" />
+    <text
+            id="LabelD"
+            class="D Label"
+            x="47.5"
+            y="227.5"
+            style="text-anchor:start;"
+        >D</text>
+    <path style="display:none" d="M 0,0" id="LeaderD" class="Leader D" />
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="32" y="257" width="35" height="35" />
+    <text
+            id="LabelE"
+            class="E Label"
+            x="47.5"
+            y="276.5"
+            style="text-anchor:start;"
+        >E</text>
+    <path style="display:none" d="M 0,0" id="LeaderE" class="Leader E" />
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="32" y="306" width="35" height="35" />
+    <text
+            id="LabelF"
+            class="F Label"
+            x="47.5"
+            y="325.5"
+            style="text-anchor:start;"
+        >F</text>
+    <path style="display:none" d="M 0,0" id="LeaderF" class="Leader F" />
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="32" y="355" width="35" height="35" />
+    <text
+            id="LabelG"
+            class="G Label"
+            x="47.5"
+            y="374.5"
+            style="text-anchor:start;"
+        >G</text>
+    <path style="display:none" d="M 0,0" id="LeaderG" class="Leader G" />
+  </g>
+  <g>
+    <rect id="ButtonH" class="H Button" x="32" y="405" width="35" height="35" />
+    <text
+            id="LabelH"
+            class="H Label"
+            x="47.5"
+            y="424.5"
+            style="text-anchor:start;"
+        >H</text>
+    <path style="display:none" d="M 0,0" id="LeaderH" class="Leader H" />
+  </g>
+</svg>


### PR DESCRIPTION
<!--
Please read https://github.com/linuxwacom/libwacom/wiki/Adding-a-new-device

In most cases you should file a pull request instead of this issue.
Pull requests are usually quickly reviewed and merged.

Filing this issue means support for your tablet is likely to get delayed for a
long time.
-->


- **Device name**: GAOMON M5 V2 <!-- e.g. Wacom Intuos Pro Small -->
- **Device model identifier**: M5 V2 <!-- e.g. CTH-680 -->
- **libwacom version**:

- [x] I understand that libwacom does **not** affect whether the device works (see [Troubleshooting](https://github.com/linuxwacom/libwacom/wiki/Troubleshooting#my-tablet-doesnt-work))

- [x] **udevadm info output**: 
[udevadm-info.tar.gz](https://github.com/user-attachments/files/25157800/udevadm-info.tar.gz) <!-- as attachment! -->
- [x] sysinfo issue in [wacom-hid-descriptors](https://github.com/linuxwacom/wacom-hid-descriptors): https://github.com/linuxwacom/wacom-hid-descriptors/issues/590


TODO:

> Can't remap button.

<img width="2560" height="1408" alt="Screenshot From 2026-02-08 15-52-53" src="https://github.com/user-attachments/assets/d210501b-d5b4-46ad-9478-fe7b79864a84" />

```console
$ libwacom-list-local-devices
devices:
  - name: 'M5 V2'
    bus: 'usb'
    vid: 0x256c
    pid: 0x200e
    nodes:
      - /dev/input/event4: 'GAOMON M5 V2 Pen'
      - /dev/input/event3: 'GAOMON M5 V2 Pen'
    styli:
      - id: 0xffffd
        vid: 0x0000
        name: 'General Pen with no Eraser'
        type: 'general'
        axes: ['x', 'y' , 'pressure']
        buttons: 2
        erasers: []

$ uname -r
6.18.8-200.fc43.x86_64

$ tree ~/.config/libwacom/
/home/yshngg/.config/libwacom/
├── gaomon-m5v2.tablet
└── layouts
    └── gaomon-m5v2.svg

2 directories, 2 files
```

