### PR TITLE
data: Extend support for Lenovo Yoga X1 Gen8

### DIFF
--- a/data/wacom-isdv4-5349.tablet
+++ b/data/wacom-isdv4-5349.tablet
@@ -9,7 +9,7 @@
 [Device]
 Name=Wacom ISDv4 5349
 ModelName=
-DeviceMatch=i2c|056a|5349
+DeviceMatch=i2c|056a|5349;i2c|056a|5345
 Class=ISDV4
 Width=12
 Height=7


### PR DESCRIPTION
here a different variant for the Lenovo Yoga X1 Gen8 display