### PR TITLE
Add support for Huion Inspiroy Frego S (L310).

### DIFF
--- a/data/huion-inspiroy-frego-s---l310.tablet
+++ b/data/huion-inspiroy-frego-s---l310.tablet
@@ -1,0 +1,35 @@
+# Huion
+# Inspiroy Frego S
+# L310
+#
+# usb:
+# sysinfo.VvlxvXAvsM.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/606
+#
+# sysinfo.eK4JstuomH.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/569
+#
+#
+# bluetooth:
+# sysinfo.jv4qEqVyOF.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/606
+#
+# sysinfo.qB5dPML29k.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/570
+
+[Device]
+Name=Huion Inspiroy Frego S
+ModelName=L310
+# The PID of bluetooth is conflict with Huion Keydial K20,
+# use the UNIQ "HUION_T23a" of this device.
+DeviceMatch=usb|256c|2011||HUION_T23a;bluetooth|256c|8251||HUION_T23a;
+# (Optional) Width 220mm.
+Width=9
+# (Optional) Height 165.7mm.
+Height=6
+IntegratedIn=
+Styli=@generic-no-eraser
+
+[Features]
+Reversible=true
+Stylus=true


### PR DESCRIPTION
I have this device. When connected via bluetooth, it is recognized as "Huion Keydial K20", which is not correct.

I found K20 and L310 are use the same VID:PID `256c:8251`. So I managed to get the UNIQ of L310 "HUION_T23a", using the [huion-switcher](https://github.com/whot/huion-switcher).

I use sysinfo captured by [issue#569](https://github.com/linuxwacom/wacom-hid-descriptors/issues/569), [issue#570](https://github.com/linuxwacom/wacom-hid-descriptors/issues/570) and [issue#606](https://github.com/linuxwacom/wacom-hid-descriptors/issues/606) as ref.

This tablet has no button on it, the pen has 2 buttons. I created a `.table` file to describe this device.