### PR TITLE
Add support for Wacom HID 53fd Pen and Lenovo Yoga Pen

### DIFF
--- a/data/lenovo.stylus
+++ b/data/lenovo.stylus
@@ -24,3 +24,12 @@ Buttons=1
 EraserType=Button
 Axes=Tilt;Pressure
 Type=Mobile
+
+[0x56a:0x8113]
+# Lenovo ; VID_LENOVO     | 0x8113 | BAT_CHRG
+Name=Lenovo Yoga Pen GX81S07448
+Group=isdv4-aes
+Buttons=1
+EraserType=Button
+Axes=Tilt;Pressure
+Type=Mobile

--- a/data/wacom-hid-53fd-pen.tablet
+++ b/data/wacom-hid-53fd-pen.tablet
@@ -1,0 +1,17 @@
+# Wacom
+# Wacom HID 53FD Pen
+#
+# sysinfo.Ul3NVe7Qo3
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/616
+
+[Device]
+Name=Wacom HID 53FD Pen
+ModelName=
+DeviceMatch=i2c|056a|53fd
+IntegratedIn=Display;System
+Styli=@isdv4-aes
+
+[Features]
+Stylus=true
+Reversible=false
+Touch=true


### PR DESCRIPTION
Added support for Wacom HID 53fd Pen with Data/wacom-hid-53fd-pen.tablet    
Added support for Lenovo Yoga Pen in Data/lenovo.stylus

Meson tests are all ok. They also caught an uppercase hex which I corrected.

After creating these, I found that  #949 uses the same tablet and pen, but is not the same laptop model as mine. I have decided to still make this pull request since the other has not been merged for almost half a year and I believe my PR adheres better to the project's conventions. 