### PR TITLE
data: add Huion Kamvas Pro 27 (GT2701)

### DIFF
--- a/data/huion-kamvas-pro-27-gt2701.tablet
+++ b/data/huion-kamvas-pro-27-gt2701.tablet
@@ -1,0 +1,25 @@
+# Huion
+# Kamvas Pro 27
+# GT2701
+
+# This tablet description file has been generated based on Huions website specifications.
+# If you own this tablet, please improve it.
+# sysinfo missing - if you own this device please provide it. See this link
+# for details: https://github.com/linuxwacom/libwacom/wiki/Adding-a-new-device
+
+[Device]
+Name=Kamvas Pro 27
+ModelName=GT2701
+DeviceMatch=usb|256c|006c;
+Width=597
+Height=336
+Styli=@generic-no-eraser;
+IntegratedIn=Display
+
+[Features]
+NumStrips=0
+NumRings=0
+Reversible=false
+Stylus=true
+Touch=true
+TouchSwitch=true


### PR DESCRIPTION
Based on Huion specifications
https://store.huion.com/au/products/kamvas-pro-27-144hz

The PID comes from
https://gitlab.freedesktop.org/libevdev/udev-hid-bpf/-/merge_requests/189/

Assisted-by: Claude:claude-opus-4-6