### PR TITLE
Add a generic 3 button + eraser pen

### DIFF
--- a/data/huion-kamvas-13-gs1333.tablet
+++ b/data/huion-kamvas-13-gs1333.tablet
@@ -42,7 +42,7 @@ Width=305
 Height=178
 Layout=huion-kamvas-13-gs1333.svg
 IntegratedIn=Display
-Styli=@generic-no-eraser;
+Styli=@generic-3btn-with-eraser;
 
 [Features]
 Stylus=true

--- a/data/huion-kamvas-16-gs1563.tablet
+++ b/data/huion-kamvas-16-gs1563.tablet
@@ -44,7 +44,7 @@ Width=356
 Height=203
 Layout=huion-kamvas-16-gs1563.svg
 IntegratedIn=Display
-Styli=@generic-no-eraser;
+Styli=@generic-3btn-with-eraser;
 
 [Features]
 Stylus=true

--- a/data/huion-kamvas-pro-19-gt1902.tablet
+++ b/data/huion-kamvas-pro-19-gt1902.tablet
@@ -18,7 +18,7 @@ DeviceMatch=usb|256c|006b||HUION_M220;
 # HUION_MAGIC_BYTES="1303803f01b8b300ff3fd81303000000080040"
 Width=406
 Height=229
-Styli=@generic-no-eraser;
+Styli=@generic-3btn-with-eraser;
 IntegratedIn=Display
 
 [Features]

--- a/data/huion-kamvas-pro-27-gt2701.tablet
+++ b/data/huion-kamvas-pro-27-gt2701.tablet
@@ -13,7 +13,7 @@ ModelName=GT2701
 DeviceMatch=usb|256c|006c;
 Width=597
 Height=336
-Styli=@generic-no-eraser;
+Styli=@generic-3btn-with-eraser;
 IntegratedIn=Display
 
 [Features]

--- a/data/wacom.example
+++ b/data/wacom.example
@@ -127,6 +127,8 @@ Layout=wacom-bamboo-16fg-m-pt.svg
 # Styli=@generic-with-eraser
 # If the stylus does not have an eraser:
 # Styli=@generic-no-eraser
+# If the stylus has 3 buttons and an eraser (e.g. Huion PW600):
+# Styli=@generic-3btn-with-eraser
 #
 # For Wacom devices this is needed only for the professional series devices,
 # i.e. Intuos Pro and Cintiq.

--- a/data/wacom.stylus
+++ b/data/wacom.stylus
@@ -26,6 +26,26 @@ Axes=Pressure;
 Type=General
 IsGenericStylus=true
 
+# Used by e.g. Huion devices
+[0x0:0xffffb]
+Name=General 3 Button Pen
+Group=generic-3btn-with-eraser
+PairedStylusIds=0x0:0xffffc;
+Buttons=3
+Axes=Tilt;Pressure;Distance;
+Type=General
+IsGenericStylus=true
+
+[0x0:0xffffc]
+Name=General 3 Button Pen Eraser
+Group=generic-3btn-with-eraser
+PairedStylusIds=0x0:0xffffb;
+EraserType=Invert
+Buttons=3
+Axes=Tilt;Pressure;Distance;
+Type=General
+IsGenericStylus=true
+
 [0x56a:0x1]
 # Lenovo ; VID_NONE     | 0x0000 | BAT_SWAP
 Name=AES Pen

--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -1766,6 +1766,8 @@ libwacom_stylus_get_for_id(const WacomDeviceDatabase *db,
 	case GENERIC_PEN_WITH_ERASER:
 	case GENERIC_ERASER:
 	case GENERIC_PEN_NO_ERASER:
+	case GENERIC_PEN_3BTN_WITH_ERASER:
+	case GENERIC_ERASER_3BTN:
 		id.vid = 0;
 		break;
 	}

--- a/libwacom/libwacomint.h
+++ b/libwacom/libwacomint.h
@@ -47,6 +47,8 @@ enum GenericStylus {
 	GENERIC_PEN_WITH_ERASER = 0xfffff,
 	GENERIC_ERASER = 0xffffe,
 	GENERIC_PEN_NO_ERASER = 0xffffd,
+	GENERIC_ERASER_3BTN = 0xffffc,
+	GENERIC_PEN_3BTN_WITH_ERASER = 0xffffb,
 };
 
 enum WacomFeature {

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -583,6 +583,8 @@ class WacomStylus:
         PEN_WITH_ERASER = 0xFFFFF
         ERASER = 0xFFFFE
         PEN_NO_ERASER = 0xFFFFD
+        ERASER_3BTN = 0xFFFFC
+        PEN_3BTN_WITH_ERASER = 0xFFFFB
 
     def __init__(self, stylus):
         self.stylus = stylus

--- a/test/test-stylus-validity.c
+++ b/test/test-stylus-validity.c
@@ -381,6 +381,13 @@ setup_emr_tests(const WacomStylus *stylus)
 		add_test(stylus, test_no_distance);
 		add_test(stylus, test_no_tilt);
 		break;
+	case 0xffffc: /* GENERIC_ERASER_3BTN */
+	case 0xffffb: /* GENERIC_PEN_3BTN_WITH_ERASER */
+		add_test(stylus, test_generic);
+		add_test(stylus, test_pressure);
+		add_test(stylus, test_distance);
+		add_test(stylus, test_tilt);
+		break;
 	case 0x006:
 	case 0x096:
 	case 0x097:

--- a/test/test_libwacom.py
+++ b/test/test_libwacom.py
@@ -333,6 +333,13 @@ def test_mobilestudio_pro_modeswitch(db):
                 WacomStylus.Generic.PEN_NO_ERASER,
             ],
         ],
+        [
+            (0x256C, 0x006C),
+            [
+                WacomStylus.Generic.PEN_3BTN_WITH_ERASER,
+                WacomStylus.Generic.ERASER_3BTN,
+            ],
+        ],
     ],
 )
 def test_generic_pens(db, usbid, expected):


### PR DESCRIPTION
This sits on top of #983 

This covers the Huion PW600 device which is the most flexible device
that huion devices can support - it's a three-button pen with a tail-end
eraser. But so far we cannot know which pen is being used so we need to
implement this as a generic pen and hope that it doesn't confuse the
user too much.

The order (and fake tool ID) of pen and eraser shouldn't matter but we
give the pen a lower tool ID than the eraser. This means during typical
listing the pen comes first which helps implementations that don't
correctly check whether the tool is an eraser ~~(e.g. GNOME Settings
as of GNOME 50).~~ *edit: this is #985*

The tablets switch to the new pen are the ones listed on Huion's website [^1]: 
> Compatible with Kamvas Pro 19 and Kamvas Pro 27, Kamvas 16 (Gen 3) and Kamvas 13 (Gen 3)

This produces false positives if a user doesn't have that tool - we
still cannot identify Huion pens at runtime. But better to have
configuration for buttons that don't exist than lacking configurations
for buttons that do exist.

[^1]: https://store.huion.com/au/products/battery-free-pen-pw600
