### PR TITLE
Allow for generic pens to be in the legacy paired IDs

### DIFF
--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -552,7 +552,8 @@ libwacom_parse_stylus_keyfile(WacomDeviceDatabase *db,
 			if (parse_stylus_id(paired_id_list[j], &paired_id)) {
 				g_array_append_val(stylus->paired_stylus_ids,
 						   paired_id);
-				if (paired_id.vid == WACOM_VENDOR_ID)
+				if (paired_id.vid == 0 ||
+				    paired_id.vid == WACOM_VENDOR_ID)
 					g_array_append_val(
 						stylus->deprecated_paired_ids,
 						paired_id.tool_id);


### PR DESCRIPTION
Otherwise we cannot associate a generic stylus with its eraser and vice versa and have an implicit dependency on the tool ID ordering within the libwacom_get_supported_styli() array.

For example, GNOME Settings correctly searches for a non-eraser paired IDs and only if that fails that uses the first tool ID.

Fixes: 884d4230d1b7 ("Support styli from vendors other than Wacom")