### PR TITLE
Export libwacom_stylus_lookup()

### DIFF
--- a/libwacom/libwacom.c
+++ b/libwacom/libwacom.c
@@ -1754,6 +1754,19 @@ libwacom_stylus_get_for_stylus_id(const WacomDeviceDatabase *db,
 }
 
 LIBWACOM_EXPORT const WacomStylus *
+libwacom_stylus_lookup(const WacomDeviceDatabase *db,
+		       int vendor_id,
+		       int tool_id)
+{
+	WacomStylusId id = {
+		.vid = vendor_id,
+		.tool_id = tool_id,
+	};
+
+	return libwacom_stylus_get_for_stylus_id(db, &id);
+}
+
+LIBWACOM_EXPORT const WacomStylus *
 libwacom_stylus_get_for_id(const WacomDeviceDatabase *db,
 			   int tool_id)
 {

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -1050,13 +1050,29 @@ libwacom_get_button_modeswitch_mode(const WacomDevice *device,
  * @return A WacomStylus representing the stylus. Do not free.
  *
  * @ingroup styli
- * @deprecated 2.14 Use libwacom_get_styli() and
+ * @deprecated 2.14 Use libwacom_get_styli() or libwacom_stylus_lookup() and
  * libwacom_stylus_get_paired_styli() to obtain the WacomStylus directly
  */
 LIBWACOM_DEPRECATED
 const WacomStylus *
 libwacom_stylus_get_for_id(const WacomDeviceDatabase *db,
 			   int id);
+
+/**
+ * Get the WacomStylus for the given vendor/tool ID pair.
+ *
+ * @param db A Tablet and Stylus database.
+ * @param vendor_id The Vendor ID for this stylus
+ * @param tool_id The Tool ID for this stylus
+ * @return A WacomStylus representing the stylus. Do not free.
+ *
+ * @since 2.19
+ * @ingroup styli
+ */
+const WacomStylus *
+libwacom_stylus_lookup(const WacomDeviceDatabase *db,
+		       int vendor_id,
+		       int tool_id);
 
 /**
  * @param stylus The stylus to query

--- a/libwacom/libwacom.sym
+++ b/libwacom/libwacom.sym
@@ -108,4 +108,5 @@ LIBWACOM_2.19 {
     libwacom_database_unref;
     libwacom_get_height_mm;
     libwacom_get_width_mm;
+    libwacom_stylus_lookup;
 } LIBWACOM_2.18;

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -251,6 +251,11 @@ class LibWacom:
             args=(c_void_p, c_int),
             return_type=c_void_p,
         ),
+        _Api(
+            name="libwacom_stylus_lookup",
+            args=(c_void_p, c_int, c_int),
+            return_type=c_void_p,
+        ),
         _Api(name="libwacom_stylus_get_id", args=(c_void_p,), return_type=c_int),
         _Api(name="libwacom_stylus_get_vendor_id", args=(c_void_p,), return_type=c_int),
         _Api(name="libwacom_stylus_get_name", args=(c_void_p,), return_type=c_char_p),
@@ -934,6 +939,11 @@ class WacomDatabase:
     ) -> Optional[WacomDevice]:
         device = self.libwacom_new_from_builder(builder.builder, fallback.value, 0)
         return WacomDevice(device) if device else None
+
+    def stylus_lookup(self, vendor_id: int, tool_id: int) -> Optional[WacomStylus]:
+        lib = LibWacom.instance()
+        stylus = lib.stylus_lookup(self.db, vendor_id, tool_id)
+        return WacomStylus(stylus) if stylus else None
 
     def list_devices(self) -> List[WacomDevice]:
         devices = self.libwacom_list_devices_from_database(self.db, 0)

--- a/test/test_libwacom.py
+++ b/test/test_libwacom.py
@@ -823,6 +823,104 @@ def test_nonwacom_stylus_ids(tmp_path):
     assert sum(s.vendor_id == 0 and s.tool_id == 0xAFFFF for s in styli) == 1
 
 
+@pytest.mark.parametrize(
+    "vid, tool_id, name",
+    [
+        (0x56A, 0x802, "Wacom Pen"),
+        (0x1234, 0xABCD, "OtherVendor Pen"),
+    ],
+)
+def test_stylus_lookup(tmp_path, vid, tool_id, name):
+    styli = StylusFile.default()
+    styli.entries.append(
+        StylusEntry(
+            id=f"{vid:#x}:{tool_id:#x}",
+            name=name,
+        )
+    )
+    styli.write_to_dir(tmp_path)
+    TabletFile(name="Test Tablet", matches=["usb|1234|abcd"]).write_to(
+        tmp_path / "test.tablet"
+    )
+
+    db = WacomDatabase(path=tmp_path)
+    stylus = db.stylus_lookup(vid, tool_id)
+    assert stylus is not None
+    assert stylus.vendor_id == vid
+    assert stylus.tool_id == tool_id
+    assert stylus.name == name
+
+
+@pytest.mark.parametrize(
+    "lookup_vid, lookup_tool_id",
+    [
+        pytest.param(0x9999, 0x9999, id="unknown"),
+        pytest.param(0x1234, 0x802, id="wrong-vendor"),
+        pytest.param(0x56A, 0x9999, id="wrong-tool-id"),
+    ],
+)
+def test_stylus_lookup_not_found(tmp_path, lookup_vid, lookup_tool_id):
+    styli = StylusFile.default()
+    styli.entries.append(
+        StylusEntry(
+            id="0x56a:0x802",
+            name="Wacom Pen",
+        )
+    )
+    styli.write_to_dir(tmp_path)
+    TabletFile(name="Test Tablet", matches=["usb|1234|abcd"]).write_to(
+        tmp_path / "test.tablet"
+    )
+
+    db = WacomDatabase(path=tmp_path)
+    stylus = db.stylus_lookup(lookup_vid, lookup_tool_id)
+    assert stylus is None
+
+
+def test_stylus_lookup_generic(tmp_path):
+    styli = StylusFile.default()
+    styli.write_to_dir(tmp_path)
+    TabletFile(name="Test Tablet", matches=["usb|1234|abcd"]).write_to(
+        tmp_path / "test.tablet"
+    )
+
+    db = WacomDatabase(path=tmp_path)
+    stylus = db.stylus_lookup(0x0, 0xAFFFF)
+    assert stylus is not None
+    assert stylus.vendor_id == 0x0
+    assert stylus.tool_id == 0xAFFFF
+    assert stylus.name == "General Pen"
+
+
+def test_stylus_lookup_matches_get_styli(tmp_path):
+    styli = StylusFile.default()
+    s = StylusEntry(
+        id="0x1234:0xabcd",
+        name="Custom Pen",
+        group="custom",
+    )
+    styli.entries.append(s)
+    styli.write_to_dir(tmp_path)
+
+    TabletFile(
+        name="Custom Tablet",
+        matches=["usb|5555|aaaa"],
+        styli=[s.id, "@generic-with-eraser"],
+    ).write_to(tmp_path / "custom.tablet")
+
+    db = WacomDatabase(path=tmp_path)
+    builder = WacomBuilder.create(usbid=(0x5555, 0xAAAA))
+    device = db.new_from_builder(builder)
+    assert device is not None
+
+    for s in device.get_styli():
+        looked_up = db.stylus_lookup(s.vendor_id, s.tool_id)
+        assert looked_up is not None
+        assert looked_up.vendor_id == s.vendor_id
+        assert looked_up.tool_id == s.tool_id
+        assert looked_up.name == s.name
+
+
 def test_load_xdg_config_home(monkeypatch, tmp_path, custom_datadir):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path.absolute()))
 


### PR DESCRIPTION
This is the vendor ID-enabled version of the deprecated libwacom_stylus_get_for_id().

libwacom_get_styli() is insufficient for GNOME Settings and libinput - both need to be able to find a stylus definition without having a WacomDevice as reference (in libinput that's an implementation detail that could probably be changed but GNOME Settings loads stylus definitions even when the stylus is not currently in proximity and thus truly has no device to be used as reference).

Assisted-by: Claude:claude-opus-4-6