### PR TITLE
Export libwacom_list_styli_from_database()

### DIFF
--- a/libwacom/libwacom-database.c
+++ b/libwacom/libwacom-database.c
@@ -1724,4 +1724,40 @@ error:
 	return NULL;
 }
 
+static gint
+stylus_compare_func(gconstpointer pa,
+		    gconstpointer pb)
+{
+	const WacomStylus *a = pa, *b = pb;
+
+	return wacom_stylus_id_sort(&a->id, &b->id);
+}
+
+LIBWACOM_EXPORT const WacomStylus **
+libwacom_list_styli_from_database(const WacomDeviceDatabase *db,
+				  WacomError *error)
+{
+	g_autoptr(GList) styli = NULL;
+	GList *cur;
+	const WacomStylus **list, **p;
+
+	if (!db) {
+		libwacom_error_set(error, WERROR_INVALID_DB, "db is NULL");
+		return NULL;
+	}
+
+	styli = g_hash_table_get_values(db->stylus_ht);
+	list = calloc(g_list_length(styli) + 1, sizeof(WacomStylus *));
+	if (!list) {
+		libwacom_error_set(error, WERROR_BAD_ALLOC, "Memory allocation failed");
+		return NULL;
+	}
+
+	styli = g_list_sort(styli, stylus_compare_func);
+	for (p = list, cur = styli; cur; cur = g_list_next(cur))
+		*p++ = (const WacomStylus *)cur->data;
+
+	return list;
+}
+
 /* vim: set noexpandtab tabstop=8 shiftwidth=8: */

--- a/libwacom/libwacom.h
+++ b/libwacom/libwacom.h
@@ -565,6 +565,24 @@ libwacom_list_devices_from_database(const WacomDeviceDatabase *db,
 				    WacomError *error);
 
 /**
+ * Returns the list of styli in the given database.
+ *
+ * @param db A device database
+ * @param error If not NULL, set to the error if any occurs
+ *
+ * @return A NULL terminated list of pointers to all the styli inside the
+ * database, sorted by vendor ID and tool ID.
+ * The content of the list is owned by the database and should not be
+ * modified or freed. Use free() to free the list.
+ *
+ * @since 2.19
+ * @ingroup styli
+ */
+const WacomStylus **
+libwacom_list_styli_from_database(const WacomDeviceDatabase *db,
+				  WacomError *error);
+
+/**
  * Print the description of this device to the given file.
  *
  * @param fd The file descriptor to print to

--- a/libwacom/libwacom.sym
+++ b/libwacom/libwacom.sym
@@ -108,4 +108,5 @@ LIBWACOM_2.19 {
     libwacom_database_unref;
     libwacom_get_height_mm;
     libwacom_get_width_mm;
+    libwacom_list_styli_from_database;
 } LIBWACOM_2.18;

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -165,6 +165,11 @@ class LibWacom:
             return_type=ctypes.POINTER(c_void_p),
         ),
         _Api(
+            name="libwacom_list_styli_from_database",
+            args=(c_void_p, c_void_p),
+            return_type=ctypes.POINTER(c_void_p),
+        ),
+        _Api(
             name="libwacom_print_device_description",
             args=(c_int, c_void_p),
             return_type=None,
@@ -904,7 +909,11 @@ class WacomDatabase:
             return lambda *args, **kwargs: func(self.db, *args, **kwargs)
 
         for api in lib._api_prototypes:
-            prefixes = ["new_from_", "list_devices_from_database"]
+            prefixes = [
+                "new_from_",
+                "list_devices_from_database",
+                "list_styli_from_database",
+            ]
             if any(api.basename.startswith(prefix) for prefix in prefixes):
                 func = getattr(lib, api.basename)
                 setattr(self, api.name, wrapper(func))
@@ -943,3 +952,12 @@ class WacomDatabase:
         ]
         GlibC.instance().free(devices)
         return devs
+
+    def list_styli(self) -> List[WacomStylus]:
+        styli = self.libwacom_list_styli_from_database(self.db, 0)
+        result = [
+            WacomStylus(s)
+            for s in itertools.takewhile(lambda ptr: ptr is not None, styli)
+        ]
+        GlibC.instance().free(styli)
+        return result

--- a/test/test_libwacom.py
+++ b/test/test_libwacom.py
@@ -823,6 +823,82 @@ def test_nonwacom_stylus_ids(tmp_path):
     assert sum(s.vendor_id == 0 and s.tool_id == 0xAFFFF for s in styli) == 1
 
 
+def test_list_styli_from_database(tmp_path):
+    styli = StylusFile.default()
+    styli.entries.append(
+        StylusEntry(
+            id="0x56a:0x802",
+            name="Wacom Pen",
+        )
+    )
+    styli.entries.append(
+        StylusEntry(
+            id="0x1234:0xabcd",
+            name="OtherVendor Pen",
+        )
+    )
+    styli.write_to_dir(tmp_path)
+    # Two tablets referencing the same styli to verify no duplicates
+    TabletFile(
+        name="Tablet A",
+        matches=["usb|1234|abcd"],
+        styli=["0x56a:0x802", "0x1234:0xabcd", "@generic-with-eraser"],
+    ).write_to(tmp_path / "tablet-a.tablet")
+    TabletFile(
+        name="Tablet B",
+        matches=["usb|5678|ef01"],
+        styli=["0x56a:0x802", "@generic-with-eraser"],
+    ).write_to(tmp_path / "tablet-b.tablet")
+
+    db = WacomDatabase(path=tmp_path)
+    all_styli = db.list_styli()
+    assert len(all_styli) > 0
+
+    # Every stylus should have valid vendor_id and tool_id
+    for s in all_styli:
+        assert isinstance(s, WacomStylus)
+
+    # Check that specific styli are present
+    ids = [(s.vendor_id, s.tool_id) for s in all_styli]
+    assert (0x56A, 0x802) in ids
+    assert (0x1234, 0xABCD) in ids
+    assert (0x0, 0xAFFFF) in ids
+    assert (0x0, 0xAFFFE) in ids
+
+    # No duplicates: should contain exactly 4 unique styli even though
+    # two tablets reference the same ones
+    assert len(ids) == len(set(ids))
+    assert len(all_styli) == 4
+
+    # Should be sorted by (vendor_id, tool_id)
+    assert ids == sorted(ids)
+
+
+def test_list_styli_from_database_matches_get_styli(tmp_path):
+    """Every stylus from get_styli should be present in list_styli."""
+    styli = StylusFile.default()
+    styli.entries.append(
+        StylusEntry(id="0x56a:0x802", name="Wacom Pen"),
+    )
+    styli.write_to_dir(tmp_path)
+    TabletFile(
+        name="Test Tablet",
+        matches=["usb|1234|abcd"],
+        styli=["0x56a:0x802", "@generic-with-eraser"],
+    ).write_to(tmp_path / "test.tablet")
+
+    db = WacomDatabase(path=tmp_path)
+    all_styli = db.list_styli()
+    all_ids = {(s.vendor_id, s.tool_id) for s in all_styli}
+
+    builder = WacomBuilder.create(usbid=(0x1234, 0xABCD))
+    device = db.new_from_builder(builder)
+    assert device is not None
+
+    for s in device.get_styli():
+        assert (s.vendor_id, s.tool_id) in all_ids
+
+
 def test_load_xdg_config_home(monkeypatch, tmp_path, custom_datadir):
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path.absolute()))
 


### PR DESCRIPTION
Complement libwacom_list_devices_from_database() with an equivalent function for styli. The returned list is sorted by vendor ID and tool ID.

Assisted-by: Claude:claude-opus-4-6

This is the alternative to #986, not sure yet which one to take.