### PR TITLE
layouts: Add tablet and drawing area outlines

### DIFF
--- a/data/layouts/wacom-cintiq-12wx.svg
+++ b/data/layouts/wacom-cintiq-12wx.svg
@@ -342,4 +342,21 @@
        y="117"
        style="text-anchor:end;">Down</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="405"
+     height="270"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="271"
+     height="190"
+     x="67"
+     y="20" />
 </svg>

--- a/data/layouts/wacom-cintiq-13hd.svg
+++ b/data/layouts/wacom-cintiq-13hd.svg
@@ -231,4 +231,21 @@
       cx="34.0"
       r="1.0" />
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="380"
+     height="250"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="267"
+     height="156"
+     x="63"
+     y="47" />
 </svg>

--- a/data/layouts/wacom-cintiq-20wsx.svg
+++ b/data/layouts/wacom-cintiq-20wsx.svg
@@ -430,4 +430,21 @@
        y="303"
        style="text-anchor:end;">Down</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="547"
+     height="367"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="367"
+     height="237"
+     x="90"
+     y="65" />
 </svg>

--- a/data/layouts/wacom-cintiq-21ux.svg
+++ b/data/layouts/wacom-cintiq-21ux.svg
@@ -244,4 +244,21 @@
        y="197"
        style="text-anchor:end;">Down</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="561"
+     height="421"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="420"
+     height="321"
+     x="70"
+     y="50" />
 </svg>

--- a/data/layouts/wacom-cintiq-21ux2.svg
+++ b/data/layouts/wacom-cintiq-21ux2.svg
@@ -448,4 +448,21 @@
        y="345"
        style="text-anchor:end;">Down</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="560"
+     height="420"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="394"
+     height="301"
+     x="83"
+     y="60" />
 </svg>

--- a/data/layouts/wacom-cintiq-22hd.svg
+++ b/data/layouts/wacom-cintiq-22hd.svg
@@ -454,4 +454,21 @@
        y="330"
        style="text-anchor:end;">Down</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="650"
+     height="400"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="484"
+     height="280"
+     x="83"
+     y="60" />
 </svg>

--- a/data/layouts/wacom-cintiq-24hd.svg
+++ b/data/layouts/wacom-cintiq-24hd.svg
@@ -512,4 +512,21 @@
        class="Ring2CW Button"
        d="M 717 189 l 3 -1.5 l 0 1 a 7.5 7.5 0 0 0 5 -1 a 6.5 6.5 0 0 1 -5 2 l 0 1 z" />
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="770"
+     height="464"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="550"
+     height="340"
+     x="110"
+     y="62" />
 </svg>

--- a/data/layouts/wacom-cintiq-companion-2.svg
+++ b/data/layouts/wacom-cintiq-companion-2.svg
@@ -273,5 +273,21 @@
       y="200.5"
       x="26.0" />
   </g>
-
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="380"
+     height="250"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="267"
+     height="156"
+     x="63"
+     y="47" />
 </svg>

--- a/data/layouts/wacom-cintiq-companion-hybrid.svg
+++ b/data/layouts/wacom-cintiq-companion-hybrid.svg
@@ -231,4 +231,21 @@
       cx="34.0"
       r="1.0" />
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="380"
+     height="250"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="267"
+     height="156"
+     x="63"
+     y="47" />
 </svg>

--- a/data/layouts/wacom-cintiq-companion.svg
+++ b/data/layouts/wacom-cintiq-companion.svg
@@ -231,4 +231,21 @@
       cx="34.0"
       r="1.0" />
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="380"
+     height="250"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="267"
+     height="156"
+     x="63"
+     y="47" />
 </svg>

--- a/data/layouts/wacom-cintiq-pro-16-2.svg
+++ b/data/layouts/wacom-cintiq-pro-16-2.svg
@@ -178,4 +178,21 @@
        y="87"
        style="text-anchor:end;">H</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="410"
+     height="264"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="358"
+     height="204"
+     x="26"
+     y="30" />
 </svg>

--- a/data/layouts/wacom-cintiq-pro-17.svg
+++ b/data/layouts/wacom-cintiq-pro-17.svg
@@ -178,4 +178,21 @@
        y="87"
        style="text-anchor:end;">H</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="410"
+     height="264"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="358"
+     height="191"
+     x="26"
+     y="37" />
 </svg>

--- a/data/layouts/wacom-cintiq-pro-22.svg
+++ b/data/layouts/wacom-cintiq-pro-22.svg
@@ -178,4 +178,21 @@
        y="87"
        style="text-anchor:end;">H</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="410"
+     height="264"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="358"
+     height="199"
+     x="26"
+     y="33" />
 </svg>

--- a/data/layouts/wacom-cintiq-pro-27.svg
+++ b/data/layouts/wacom-cintiq-pro-27.svg
@@ -178,4 +178,21 @@
        y="87"
        style="text-anchor:end;">H</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="410"
+     height="264"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="358"
+     height="194"
+     x="26"
+     y="35" />
 </svg>

--- a/data/layouts/wacom-intuos-m-p.svg
+++ b/data/layouts/wacom-intuos-m-p.svg
@@ -2,7 +2,7 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <!--
  -->
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="intuos-m-p" width="275" height="222">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="intuos-m-p" width="275" height="201">
   <title id="title">Wacom Intuos Pen Medium (CTL-680)</title>
   <g>
     <path id="ButtonA" class="A Button" d="M 2,10.5 a 12.75,8.5 0 0 1 12.75,-8.5 l 23.75,0 l 0,19 l -36.5,0 z"/>
@@ -31,4 +31,21 @@
     <path id="LeaderD" class="D Leader" d="M 233,31.5 l -20,0"/>
     <text id="LabelD" class="D Label" x="211" y="31.5" style="text-anchor:end;">D</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="275"
+     height="201"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="235"
+     height="130"
+     x="20"
+     y="51" />
 </svg>

--- a/data/layouts/wacom-intuos-m-p2.svg
+++ b/data/layouts/wacom-intuos-m-p2.svg
@@ -2,7 +2,7 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <!--
  -->
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="intuos-s-pt" width="281" height="212">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="intuos-s-pt" width="281" height="195">
   <title id="title">Wacom Intuos Pen Medium (CTL-690)</title>
     <g>
       <path id="ButtonA" class="A Button" d="m 13.0,25.25 12.25,-12.25 -4.75,-4.75 C 12.75,0.5 0.25,12.5 8.25,20.75 Z" />
@@ -24,4 +24,21 @@
       <path id="LeaderD" class="D Leader" d="M 233,31.5 l -20,0"/>
       <text id="LabelD" class="D Label" x="211" y="31.5" style="text-anchor:end;">D</text>
     </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="281"
+     height="195"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="241"
+     height="134"
+     x="20"
+     y="41" />
 </svg>

--- a/data/layouts/wacom-intuos-m-p3.svg
+++ b/data/layouts/wacom-intuos-m-p3.svg
@@ -2,7 +2,7 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <!--
  -->
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="intuos-m-p3" width="275" height="222">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="intuos-m-p3" width="275" height="181">
   <title id="title">Wacom Intuos Pen Medium (CTL-6100)</title>
   <g>
     <path id="ButtonA" class="A Button" d="M 42,10.5 a 12.75,8.5 0 0 1 12.75,-8.5 l 23.75,0 l 0,19 l -23.75,0 a 12.75,8.5 0 0 1 -12.75,-8.5 l 0,-2"/>
@@ -28,4 +28,21 @@
     <text id="LabelD" class="D Label" x="212.5" y="38" style="text-anchor:end;">D</text>
   </g>
 
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="275"
+     height="181"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="235"
+     height="130"
+     x="20"
+     y="31" />
 </svg>

--- a/data/layouts/wacom-intuos-m-pt.svg
+++ b/data/layouts/wacom-intuos-m-pt.svg
@@ -2,7 +2,7 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <!--
  -->
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="intuos-m-pt" width="275" height="222">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="intuos-m-pt" width="275" height="201">
   <title id="title">Wacom Intuos PT Medium (CTH-680)</title>
   <g>
     <path id="ButtonA" class="A Button" d="M 2,10.5 a 12.75,8.5 0 0 1 12.75,-8.5 l 23.75,0 l 0,19 l -36.5,0 z"/>
@@ -31,4 +31,21 @@
     <path id="LeaderD" class="D Leader" d="M 233,31.5 l -20,0"/>
     <text id="LabelD" class="D Label" x="211" y="31.5" style="text-anchor:end;">D</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="275"
+     height="201"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="235"
+     height="130"
+     x="20"
+     y="51" />
 </svg>

--- a/data/layouts/wacom-intuos-m-pt2.svg
+++ b/data/layouts/wacom-intuos-m-pt2.svg
@@ -2,7 +2,7 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <!--
  -->
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="intuos-s-pt" width="281" height="212">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" id="intuos-s-pt" width="281" height="195">
   <title id="title">Wacom Intuos PT Medium (CTH-690)</title>
     <g>
       <path id="ButtonA" class="A Button" d="m 13.0,25.25 12.25,-12.25 -4.75,-4.75 C 12.75,0.5 0.25,12.5 8.25,20.75 Z" />
@@ -24,4 +24,21 @@
       <path id="LeaderD" class="D Leader" d="M 233,31.5 l -20,0"/>
       <text id="LabelD" class="D Label" x="211" y="31.5" style="text-anchor:end;">D</text>
     </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="281"
+     height="195"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="241"
+     height="134"
+     x="20"
+     y="41" />
 </svg>

--- a/data/layouts/wacom-intuos-pro-2-l.svg
+++ b/data/layouts/wacom-intuos-pro-2-l.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
-   style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
+   style="color:#000000;font-size:8px;fill:none;stroke:#7f7f7f;stroke-width:0.25"
    id="intuos-pro-2-l"
-   width="380"
-   height="250"
-   inkscape:version="0.47 r22583"
-   sodipodi:docname="intuos-pro-2-l.svg">
+   width="435.05508"
+   height="268.56357"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   sodipodi:docname="wacom-intuos-pro-2-l.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <metadata
      id="metadata66">
     <rdf:RDF>
@@ -30,10 +30,10 @@
      id="defs64">
     <inkscape:perspective
        sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 125 : 1"
+       inkscape:vp_x="0 : 135.56357 : 1"
        inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="380 : 125 : 1"
-       inkscape:persp3d-origin="190 : 83.333333 : 1"
+       inkscape:vp_z="380 : 135.56357 : 1"
+       inkscape:persp3d-origin="190 : 93.896898 : 1"
        id="perspective68" />
   </defs>
   <sodipodi:namedview
@@ -45,41 +45,43 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1600"
-     inkscape:window-height="1124"
+     inkscape:window-width="3072"
+     inkscape:window-height="1629"
      id="namedview62"
      showgrid="false"
-     inkscape:zoom="3.776"
-     inkscape:cx="190"
-     inkscape:cy="122.3517"
+     inkscape:zoom="1.888"
+     inkscape:cx="99.576271"
+     inkscape:cy="109.11017"
      inkscape:window-x="0"
-     inkscape:window-y="25"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="intuos-pro-2-l" />
+     inkscape:current-layer="intuos-pro-2-l"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
   <title
      id="title">Wacom Intuos Pro 2 L</title>
   <g
-     id="GroupA">
+     id="GroupA"
+     transform="translate(0.25,4.25)">
     <path
-       d="M 24 42    c 0 -2 2 -2 2 -2    l 16 0    c 2 0 2 2 2 2   l 0 10    l -20 0    l -0 -10"
+       d="m 24,42 c 0,-2 2,-2 2,-2 h 16 c 2,0 2,2 2,2 V 52 H 24 V 42"
        class="A Button"
        id="ButtonA" />
     <path
        id="LeaderA"
        class="A Leader"
-       d="M 46 46 L 50 46" />
+       d="m 46,46 h 4" />
     <text
        id="LabelA"
        class="A Label"
        x="52"
        y="46"
-       style="text-anchor:start;">
-      A
-    </text>
+       style="line-height:0%;text-anchor:start">A</text>
   </g>
   <g
      id="g9"
-     transform="translate(0,-1.5889831)">
+     transform="translate(0.25,2.6610169)">
     <rect
        id="ButtonB"
        class="B Button"
@@ -98,17 +100,17 @@
     <path
        id="LeaderB"
        class="B Leader"
-       d="m 46,60 4,0" />
+       d="m 46,60 h 4" />
     <text
        id="LabelB"
        class="B Label"
        x="52"
        y="60"
-       style="text-anchor:start">B</text>
+       style="line-height:0%;text-anchor:start">B</text>
   </g>
   <g
      id="g15"
-     transform="translate(0,-3.1779661)">
+     transform="translate(0.25,1.0720339)">
     <rect
        id="ButtonC"
        class="C Button"
@@ -116,66 +118,61 @@
        y="68"
        width="20"
        height="12" />
-    <circle
-       id="DotC1"
-       cx="34"
-       cy="74"
-       r="0.75"
-       d="m 34.75,74 c 0,0.414214 -0.335786,0.75 -0.75,0.75 -0.414214,0 -0.75,-0.335786 -0.75,-0.75 0,-0.414214 0.335786,-0.75 0.75,-0.75 0.414214,0 0.75,0.335786 0.75,0.75 z"
-       sodipodi:cx="34"
-       sodipodi:cy="74"
-       sodipodi:rx="0.75"
-       sodipodi:ry="0.75" />
+     <circle
+        id="DotC1"
+        cx="34"
+        cy="74"
+        r="0.75" />
     <path
        id="LeaderC"
        class="C Leader"
-       d="m 46,74 4,0" />
+       d="m 46,74 h 4" />
     <text
        id="LabelC"
        class="C Label"
        x="52"
        y="74"
-       style="text-anchor:start">C</text>
+       style="line-height:0%;text-anchor:start">C</text>
   </g>
   <g
      id="g21"
-     transform="translate(0,-4.7669492)">
+     transform="translate(0.25,-0.5169492)">
     <path
-       d="m 24,82 20,0 0,10 c 0,2 -2,2 -2,2 l -16,0 c -2,0 -2,-2 -2,-2 l 0,-10"
+       d="m 24,82 h 20 v 10 c 0,2 -2,2 -2,2 H 26 c -2,0 -2,-2 -2,-2 V 82"
        class="D Button"
        id="ButtonD" />
     <path
        id="LeaderD"
        class="D Leader"
-       d="m 46,88 4,0" />
+       d="m 46,88 h 4" />
     <text
        id="LabelD"
        class="D Label"
        x="52"
        y="88"
-       style="text-anchor:start">D</text>
+       style="line-height:0%;text-anchor:start">D</text>
   </g>
   <g
      id="g26"
-     transform="translate(-0.26483051,-7.4152542)">
+     transform="translate(-0.01483051,-3.1652542)">
     <path
-       d="M 24 156                  c 0 -2 2 -2 2 -2                  l 16 0                  c 2 0 2 2 2 2                 l 0 10                  l -20 0                  l -0 -10"
+       d="m 24,156 c 0,-2 2,-2 2,-2 h 16 c 2,0 2,2 2,2 v 10 H 24 v -10"
        class="E Button"
        id="ButtonE" />
     <path
        id="LeaderE"
        class="E Leader"
-       d="m 46,162 4,0" />
+       d="m 46,162 h 4" />
     <text
        id="LabelE"
        class="E Label"
        x="52"
        y="162"
-       style="text-anchor:start">E</text>
+       style="line-height:0%;text-anchor:start">E</text>
   </g>
   <g
      id="g31"
-     transform="translate(-0.26483051,-11.122881)">
+     transform="translate(-0.01483051,-6.872881)">
     <rect
        id="ButtonF"
        class="F Button"
@@ -183,30 +180,25 @@
        y="170"
        width="20"
        height="12" />
-    <circle
-       id="DotF1"
-       cx="34"
-       cy="176"
-       r="0.75"
-       d="m 34.75,176 c 0,0.41421 -0.335786,0.75 -0.75,0.75 -0.414214,0 -0.75,-0.33579 -0.75,-0.75 0,-0.41421 0.335786,-0.75 0.75,-0.75 0.414214,0 0.75,0.33579 0.75,0.75 z"
-       sodipodi:cx="34"
-       sodipodi:cy="176"
-       sodipodi:rx="0.75"
-       sodipodi:ry="0.75" />
+     <circle
+        id="DotF1"
+        cx="34"
+        cy="176"
+        r="0.75" />
     <path
        id="LeaderF"
        class="F Leader"
-       d="m 46,176 4,0" />
+       d="m 46,176 h 4" />
     <text
        id="LabelF"
        class="F Label"
        x="52"
        y="176"
-       style="text-anchor:start">F</text>
+       style="line-height:0%;text-anchor:start">F</text>
   </g>
   <g
      id="g37"
-     transform="translate(-0.26483051,-12.711865)">
+     transform="translate(-0.01483051,-8.461865)">
     <rect
        id="ButtonG"
        class="G Button"
@@ -225,99 +217,107 @@
     <path
        id="LeaderG"
        class="G Leader"
-       d="m 46,190 4,0" />
+       d="m 46,190 h 4" />
     <text
        id="LabelG"
        class="G Label"
        x="52"
        y="190"
-       style="text-anchor:start">G</text>
+       style="line-height:0%;text-anchor:start">G</text>
   </g>
   <g
      id="g43"
-     transform="translate(-0.26483051,-14.830508)">
+     transform="translate(-0.01483051,-10.580508)">
     <path
-       d="m 24,198 20,0 0,10 c 0,2 -2,2 -2,2 l -16,0 c -2,0 -2,-2 -2,-2 l 0,-10"
+       d="m 24,198 h 20 v 10 c 0,2 -2,2 -2,2 H 26 c -2,0 -2,-2 -2,-2 v -10"
        class="H Button"
        id="ButtonH" />
     <path
        id="LeaderH"
        class="H Leader"
-       d="m 46,204 4,0" />
+       d="m 46,204 h 4" />
     <text
        id="LabelH"
        class="H Label"
        x="52"
        y="204"
-       style="text-anchor:start">H</text>
+       style="line-height:0%;text-anchor:start">H</text>
   </g>
   <g
      id="g48"
-     transform="translate(-0.52966102,-6.0911017)">
-    <circle
-       id="Ring"
-       class="Ring TouchRing"
-       cx="34"
-       cy="125"
-       r="19.5"
-       d="m 53.5,125 c 0,10.76955 -8.730447,19.5 -19.5,19.5 -10.769553,0 -19.5,-8.73045 -19.5,-19.5 0,-10.76955 8.730447,-19.5 19.5,-19.5 10.769553,0 19.5,8.73045 19.5,19.5 z"
-       sodipodi:cx="34"
-       sodipodi:cy="125"
-       sodipodi:rx="19.5"
-       sodipodi:ry="19.5" />
+     transform="translate(-0.27966102,-1.8411017)">
+     <circle
+        id="Ring"
+        class="Ring TouchRing"
+        cx="34"
+        cy="125"
+        r="19.5" />
     <path
        id="LeaderRingCCW"
        class="RingCCW Ring Leader"
-       d="m 34,105 0,-2 26,0" />
+       d="m 34,105 v -2 h 26" />
     <text
        id="LabelRingCCW"
        class="RingCCW Ring Label"
        x="62"
        y="103"
-       style="text-anchor:start">CCW</text>
+       style="line-height:0%;text-anchor:start">CCW</text>
     <path
        id="RingCCW"
        class="RingCCW Button"
-       d="m 31,111 3,-1.5 0,1 a 7.5,7.5 0 0 1 5,1.5 6.5,6.5 0 0 0 -5,-0.5 l 0,1 z" />
+       d="m 31,111 3,-1.5 v 1 a 7.5,7.5 0 0 1 5,1.5 6.5,6.5 0 0 0 -5,-0.5 v 1 z" />
     <path
        id="LeaderRingCW"
        class="RingCW Ring Leader"
-       d="m 34,145 0,2 26,0" />
+       d="m 34,145 v 2 h 26" />
     <text
        id="LabelRingCW"
        class="RingCW Ring Label"
        x="62"
        y="147"
-       style="text-anchor:start">CW</text>
+       style="line-height:0%;text-anchor:start">CW</text>
     <path
        id="RingCW"
        class="RingCW Button"
-       d="m 31,139 3,-1.5 0,1 a 7.5,7.5 0 0 0 5,-1 6.5,6.5 0 0 1 -5,2 l 0,1 z" />
+       d="m 31,139 3,-1.5 v 1 a 7.5,7.5 0 0 0 5,-1 6.5,6.5 0 0 1 -5,2 v 1 z" />
   </g>
   <g
      id="g57"
-     transform="translate(-0.52966107,-6.0911017)">
-    <circle
-       id="ButtonI"
-       class="I ModeSwitch Button"
-       cx="34"
-       cy="125"
-       r="9.5"
-       d="m 43.5,125 c 0,5.24671 -4.253295,9.5 -9.5,9.5 -5.246705,0 -9.5,-4.25329 -9.5,-9.5 0,-5.24671 4.253295,-9.5 9.5,-9.5 5.246705,0 9.5,4.25329 9.5,9.5 z"
-       sodipodi:cx="34"
-       sodipodi:cy="125"
-       sodipodi:rx="9.5"
-       sodipodi:ry="9.5" />
+     transform="translate(-0.27966107,-1.8411017)">
+     <circle
+        id="ButtonI"
+        class="I ModeSwitch Button"
+        cx="34"
+        cy="125"
+        r="9.5" />
     <path
        id="LeaderI"
        class="I ModeSwitch Leader"
-       d="m 56,125 4,0" />
+       d="m 56,125 h 4" />
     <text
        id="LabelI"
        class="I ModeSwitch Label"
        x="62"
        y="125"
-       style="text-anchor:start">I</text>
+       style="line-height:0%;text-anchor:start">I</text>
   </g>
-
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="434.55508"
+     height="268.06357"
+     x="0.25"
+     y="0.25"
+     ry="2.9007006"
+     inkscape:label="#Outline" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="327.91104"
+     height="214.54662"
+     x="63.779659"
+     y="24.88983"
+     inkscape:label="#DrawingArea" />
 </svg>

--- a/data/layouts/wacom-intuos-pro-2-m.svg
+++ b/data/layouts/wacom-intuos-pro-2-m.svg
@@ -319,5 +319,23 @@
        y="125"
        style="text-anchor:start">I</text>
   </g>
-
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="380"
+     height="250"
+     x="0"
+     y="0"
+     ry="2.9007006"
+     inkscape:label="#Outline" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="267"
+     height="170"
+     x="63"
+     y="40"
+     inkscape:label="#DrawingArea" />
 </svg>

--- a/data/layouts/wacom-intuos-pro-2-s.svg
+++ b/data/layouts/wacom-intuos-pro-2-s.svg
@@ -257,5 +257,23 @@
        y="110"
        style="text-anchor:start">G</text>
   </g>
-
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="380"
+     height="250"
+     x="0"
+     y="0"
+     ry="2.9007006"
+     inkscape:label="#Outline" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="267"
+     height="170"
+     x="63"
+     y="40"
+     inkscape:label="#DrawingArea" />
 </svg>

--- a/data/layouts/wacom-intuos-pro-3-l.svg
+++ b/data/layouts/wacom-intuos-pro-3-l.svg
@@ -9,7 +9,7 @@
    id="intuos-pro-l-ptk870"
    style="fill:none;stroke:#7f7f7f;stroke-width:0.25;font-size:6;font-family:monospace"
    sodipodi:docname="wacom-intuos-pro-3-l.svg"
-   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -29,13 +29,13 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
-     showgrid="true"
+     showgrid="false"
      showguides="true"
-     inkscape:zoom="4.3000698"
-     inkscape:cx="712.31402"
-     inkscape:cy="69.76631"
+     inkscape:zoom="0.76015213"
+     inkscape:cx="810.3641"
+     inkscape:cy="440.70126"
      inkscape:window-width="3072"
-     inkscape:window-height="1659"
+     inkscape:window-height="1629"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -98,7 +98,7 @@
        opacity="0.14901961"
        empspacing="5"
        enabled="true"
-       visible="true" />
+       visible="false" />
   </sodipodi:namedview>
   <title
      id="title">Wacom Intuos Pro L (PTK870)</title>
@@ -337,4 +337,24 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="377"
+     height="251.99998"
+     x="0"
+     y="0"
+     ry="2.9007006"
+     inkscape:label="#Outline" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="377"
+     height="219.28177"
+     x="0"
+     y="32.718235"
+     ry="2"
+     inkscape:label="#DrawingArea" />
 </svg>

--- a/data/layouts/wacom-intuos-pro-3-m.svg
+++ b/data/layouts/wacom-intuos-pro-3-m.svg
@@ -9,7 +9,7 @@
    id="intuos-pro-m-ptk670"
    style="fill:none;stroke:#7f7f7f;stroke-width:0.25;font-size:6;font-family:monospace"
    sodipodi:docname="wacom-intuos-pro-3-m.svg"
-   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -29,16 +29,16 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
-     inkscape:zoom="1.8688618"
-     inkscape:cx="660.83003"
-     inkscape:cy="-44.412059"
+     inkscape:zoom="0.9344309"
+     inkscape:cx="689.18954"
+     inkscape:cy="481.57654"
      inkscape:window-width="3072"
-     inkscape:window-height="1659"
+     inkscape:window-height="1629"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
      inkscape:current-layer="intuos-pro-m-ptk670"
-     showgrid="true"
+     showgrid="false"
      showguides="true">
     <sodipodi:guide
        position="170.99112,187.66268"
@@ -63,7 +63,7 @@
        opacity="0.14901961"
        empspacing="5"
        enabled="true"
-       visible="true" />
+       visible="false" />
   </sodipodi:namedview>
   <title
      id="title">Wacom Intuos Pro M (PTK670)</title>
@@ -337,4 +337,23 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <rect
+     style="font-size:6px;font-family:monospace;fill:none;stroke:#7f7f7f;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="291"
+     height="205"
+     x="0"
+     y="0"
+     ry="2.9007006"
+     inkscape:label="#Outline" />
+  <rect
+     style="font-size:6px;font-family:monospace;fill:none;stroke:#7f7f7f;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="291"
+     height="173.69473"
+     x="0"
+     y="31.305264"
+     inkscape:label="#DrawingArea" />
 </svg>

--- a/data/layouts/wacom-intuos-pro-3-s.svg
+++ b/data/layouts/wacom-intuos-pro-3-s.svg
@@ -8,8 +8,33 @@
    version="1.1"
    id="intuos-pro-s-ptk470"
    style="fill:none;stroke:#7f7f7f;stroke-width:0.25;font-size:6;font-family:monospace"
+   sodipodi:docname="wacom-intuos-pro-3-s.svg"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="0.81995651"
+     inkscape:cx="690.28051"
+     inkscape:cy="519.53975"
+     inkscape:window-width="3072"
+     inkscape:window-height="1629"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="intuos-pro-s-ptk470" />
   <title
      id="title">Wacom Intuos Pro S (PTK470)</title>
   <g
@@ -132,4 +157,23 @@
        y="25.45682"
        style="text-anchor:start;">CW</text>
   </g>
+  <rect
+     style="font-size:6px;font-family:monospace;display:inline;fill:none;stroke:#7f7f7f;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="215"
+     height="162"
+     x="0"
+     y="0"
+     ry="2.9007006"
+     inkscape:label="#Outline" />
+  <rect
+     style="font-size:6px;font-family:monospace;display:inline;fill:none;stroke:#7f7f7f;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="215"
+     height="129.54449"
+     x="0"
+     y="32.455513"
+     inkscape:label="#DrawingArea" />
 </svg>

--- a/data/layouts/wacom-intuos4-12x19.svg
+++ b/data/layouts/wacom-intuos4-12x19.svg
@@ -234,4 +234,21 @@
        y="230"
        style="text-anchor:start;">A</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="623"
+     height="462"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="510"
+     height="322"
+     x="63"
+     y="70" />
 </svg>

--- a/data/layouts/wacom-intuos4-4x6.svg
+++ b/data/layouts/wacom-intuos4-4x6.svg
@@ -192,4 +192,21 @@
        y="104"
        style="text-anchor:start;">A</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="309"
+     height="208"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="196"
+     height="132"
+     x="63"
+     y="38" />
 </svg>

--- a/data/layouts/wacom-intuos4-6x9-wl.svg
+++ b/data/layouts/wacom-intuos4-6x9-wl.svg
@@ -238,4 +238,21 @@
        y="127"
        style="text-anchor:start;">A</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="363"
+     height="254"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="252"
+     height="158"
+     x="61"
+     y="48" />
 </svg>

--- a/data/layouts/wacom-intuos4-6x9.svg
+++ b/data/layouts/wacom-intuos4-6x9.svg
@@ -238,4 +238,21 @@
        y="126.5"
        style="text-anchor:start;">A</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="370"
+     height="253"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="259"
+     height="172"
+     x="61"
+     y="41" />
 </svg>

--- a/data/layouts/wacom-intuos4-8x13.svg
+++ b/data/layouts/wacom-intuos4-8x13.svg
@@ -234,4 +234,21 @@
        y="159"
        style="text-anchor:start;">A</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="474"
+     height="320"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="361"
+     height="222"
+     x="63"
+     y="49" />
 </svg>

--- a/data/layouts/wacom-intuos5-l.svg
+++ b/data/layouts/wacom-intuos5-l.svg
@@ -260,4 +260,21 @@
        y="159"
        style="text-anchor:start;">A</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="487"
+     height="318"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="374"
+     height="230"
+     x="63"
+     y="44" />
 </svg>

--- a/data/layouts/wacom-intuos5-m.svg
+++ b/data/layouts/wacom-intuos5-m.svg
@@ -260,4 +260,21 @@
        y="125"
        style="text-anchor:start;">A</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="380"
+     height="250"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="267"
+     height="177"
+     x="63"
+     y="37" />
 </svg>

--- a/data/layouts/wacom-intuos5-s.svg
+++ b/data/layouts/wacom-intuos5-s.svg
@@ -208,4 +208,21 @@
        y="104"
        style="text-anchor:start;">A</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="320"
+     height="208"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="207"
+     height="139"
+     x="63"
+     y="35" />
 </svg>

--- a/data/layouts/xp-pen-deco-mw.svg
+++ b/data/layouts/xp-pen-deco-mw.svg
@@ -5,7 +5,7 @@
     version="1.1"
     style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8"
     id="xp-pen-deco-l"
-    width="355"
+    width="455"
     height="250">
   <title id="title">XP-Pen Deco L</title>
   <g>
@@ -178,4 +178,21 @@
        y="212"
        style="text-anchor:start">H</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="455"
+     height="250"
+     x="0"
+     y="0"
+     ry="2.9007006" />
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="368"
+     height="230"
+     x="77"
+     y="10" />
 </svg>

--- a/data/layouts/xp-pen-deco-pro-mw.svg
+++ b/data/layouts/xp-pen-deco-pro-mw.svg
@@ -1,8 +1,17 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
    "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg id="xp-pen-deco-pro" width="623.0" height="462.0" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" version="1.1" xmlns="http://www.w3.org/2000/svg">
+<svg id="xp-pen-deco-pro-mw" width="623.0" height="362.0" viewBox="0 50 623 362" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" version="1.1" xmlns="http://www.w3.org/2000/svg">
   <title id="title">XP-PEN Deco Pro MW</title>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="623"
+     height="362"
+     x="0"
+     y="50"
+     ry="2.9007006" />
   <g>
     <rect id="ButtonH" class="H Button" x="45.0" y="308.0" width="19.5" height="19.5" />
     <path id="LeaderH" class="H Leader" d="M 90.0 324.5 65.0 324.5" />
@@ -50,6 +59,14 @@
   <g>
     <rect id="ButtonA" class="A Button" x="20.0" y="120.0" width="19.5" height="19.5" />
     <path id="LeaderA" class="A Leader" d="m 30.0 120.0 v -5.0 h 45.0 v 8.0 h 15.0" />
-    <text id="LabelA" class="A Label" x="95.0" y="126.0" style="text-anchor:start;">A</text>
+     <text id="LabelA" class="A Label" x="95.0" y="126.0" style="text-anchor:start;">A</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="458"
+     height="249"
+     x="145"
+     y="107" />
 </svg>

--- a/data/layouts/xp-pen-deco-pro-sw.svg
+++ b/data/layouts/xp-pen-deco-pro-sw.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg id="xp-pen-deco-pro-sw" width="623.0" height="302.0" viewBox="0 80 623 302" style="color:#000000;stroke:#7f7f7f;fill:none;stroke-width:.25;font-size:8" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <title id="title">XP-PEN Deco Pro SW</title>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="623"
+     height="302"
+     x="0"
+     y="80"
+     ry="2.9007006" />
+  <g>
+    <rect id="ButtonH" class="H Button" x="45.0" y="308.0" width="19.5" height="19.5" />
+    <path id="LeaderH" class="H Leader" d="M 90.0 324.5 65.0 324.5" />
+    <text id="LabelH" class="H Label" x="94.5" y="328.0" style="text-anchor:start;">H</text>
+  </g>
+  <g>
+    <rect id="ButtonG" class="G Button" x="20.0" y="308.0" width="19.5" height="19.5" />
+    <path id="LeaderG" class="G Leader" d="M 90.0 310.0 H 75.0 v 23.0 l -45.0 0.0 v -5.0" />
+    <text id="LabelG" class="G Label" x="94.5" y="313.0" style="text-anchor:start;">G</text>
+  </g>
+  <g>
+    <rect id="ButtonF" class="F Button" x="45.0" y="278.0" width="19.5" height="29.5" />
+    <path id="LeaderF" class="F Leader" d="M 65.0 295.0 90.0 295.0" />
+    <text id="LabelF" class="F Label" x="95.0" y="298.5" style="text-anchor:start;">F</text>
+  </g>
+  <g>
+    <rect id="ButtonE" class="E Button" x="20.0" y="278.0" width="19.5" height="29.5" />
+    <path id="LeaderE" class="E Leader" d="M 90.0 281.0 H 75.0 l 0.0 -8.0 -45.0 0.0 0.0 5.0" />
+    <text id="LabelE" class="E Label" x="95.0" y="284.0" style="text-anchor:start;">E</text>
+  </g>
+  <g>
+    <circle id="Dial" class="Dial TouchDial" cx="39.5" cy="224.5" r="25.0" />
+    <path id="LeaderDialCCW" class="DialCCW Dial Leader" d="M 40.5 198.0 V 193.5 h 49.5" />
+    <path id="DialCCW" class="DialCCW Button" d="m 35.553343,206.65045 3.821656,-1.91083 v 1.27389 a 9.5541398,9.5541399 0 0 1 6.369426,1.91083 8.2802545,8.2802546 0 0 0 -6.369426,-0.63694 v 1.27388 z" />
+    <path id="LeaderDialCW" class="DialCW Dial Leader" d="m 40.5 250.5 v 4.5 H 90.0" />
+    <path id="DialCW" class="DialCW Button" d="m 35.553343,242.31924 3.821656,-1.91082 v 1.27387 a 9.5541398,9.5541399 0 0 0 6.369426,-1.27387 8.2802545,8.2802546 0 0 1 -6.369426,2.54777 v 1.27388 z" />
+    <text id="LabelDialCCW" class="DialCCW Dial Label" x="94.5" y="196.0" style="text-anchor:start;">CCW</text>
+    <text id="LabelDialCW" class="DialCW Dial Label" x="94.5" y="258.0" style="text-anchor:start;">CW</text>
+  </g>
+  <g>
+    <rect id="ButtonD" class="D Button" x="45.0" y="140.0" width="19.5" height="29.5" />
+    <path id="LeaderD" class="D Leader" d="M 65.0 167.0 H 90.0" />
+    <text id="LabelD" class="D Label" x="94.5" y="170.0" style="text-anchor:start;">D</text>
+  </g>
+  <g>
+    <rect id="ButtonC" class="C Button" x="20.0" y="140.0" width="19.5" height="29.5" />
+    <path id="LeaderC" class="C Leader" d="m 30.0 170.0 v 5.0 h 45.0 v -23.0 l 15.0 0.0" />
+    <text id="LabelC" class="C Label" x="95.0" y="155.0" style="text-anchor:start;">C</text>
+  </g>
+  <g>
+    <rect id="ButtonB" class="B Button" x="45.0" y="120.0" width="19.5" height="19.5" />
+    <path id="LeaderB" class="B Leader" d="M 65.0 137.5 H 90.0" />
+    <text id="LabelB" class="B Label" x="95.0" y="140.5" style="text-anchor:start;">B</text>
+  </g>
+  <g>
+    <rect id="ButtonA" class="A Button" x="20.0" y="120.0" width="19.5" height="19.5" />
+    <path id="LeaderA" class="A Leader" d="m 30.0 120.0 v -5.0 h 45.0 v 8.0 h 15.0" />
+     <text id="LabelA" class="A Label" x="95.0" y="126.0" style="text-anchor:start;">A</text>
+  </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="DrawingArea"
+     id="DrawingArea"
+     width="458"
+     height="254"
+     x="145"
+     y="104" />
+</svg>

--- a/data/layouts/xp-pen-innovator-16.svg
+++ b/data/layouts/xp-pen-innovator-16.svg
@@ -263,14 +263,24 @@
        y="321"
        style="text-anchor:start;">H</text>
   </g>
+  <rect
+     style="fill:none;stroke-width:0.5;stroke-linecap:round;stroke-dasharray:none"
+     class="Outline"
+     id="Outline"
+     width="640"
+     height="350"
+     x="0"
+     y="0"
+     ry="2.9007006" />
   <g
      id="g34">
-    <rect
-       id="Screen"
-       x="110"
-       y="15"
-       width="520"
-       height="320" />
+     <rect
+        class="DrawingArea"
+     id="DrawingArea"
+        x="110"
+        y="15"
+        width="520"
+        height="320" />
     <rect
        id="DotB"
        x="51.5"

--- a/data/xp-pen-deco-pro-mw.tablet
+++ b/data/xp-pen-deco-pro-mw.tablet
@@ -27,7 +27,7 @@ PairedIDs=
 Width=279
 Height=152
 IntegratedIn=
-Layout=xp-pen-deco-pro-s-m-sw-mw.svg
+Layout=xp-pen-deco-pro-mw.svg
 Styli=@generic-no-eraser
 
 [Features]

--- a/data/xp-pen-deco-pro-sw.tablet
+++ b/data/xp-pen-deco-pro-sw.tablet
@@ -27,7 +27,7 @@ PairedIDs=
 Width=229
 Height=127
 IntegratedIn=
-Layout=xp-pen-deco-pro-s-m-sw-mw.svg
+Layout=xp-pen-deco-pro-sw.svg
 Styli=@generic-no-eraser
 
 [Features]


### PR DESCRIPTION
This is currently incomplete but covers the recent wacom intuos/cintiq tablets and some xp-pen tablets. 

This adds an approximation of an outline (SVG: `id="Outline" class="Outline"`) and a drawing area (SVG: `id="DrawingArea" class="DrawingArea"`). The goal of both of those is to make the SVG more useful, right now we focus on just the buttons/rings/..., roughly placed where they should be relative to the screen but without any other information about the tablet.

This stems directly from the GNOME Settings OSD approach for configuring these buttons but it's insufficient if we ever want to use it in some other setting. Hence - let's add something that makes this an abstraction of the tablet so we can at least visualize it.

We have over 200 layout files so I'm not going for perfect accuracy here. Some devices are decades old and unlikely to be in use, really we only need to care about tablets from the last few years. And I'll leave proportion-perfect drawings to those that have those tablets and care about this.

For backwards compatibility we should probably make both invisible by default but since afaik only GNOME Settings uses that... meh?