### PR TITLE
Add Huion Inspiroy H610Pro v2

### DIFF
--- a/data/huion-inspiroy-h610pro-v2.tablet
+++ b/data/huion-inspiroy-h610pro-v2.tablet
@@ -1,0 +1,27 @@
+# Huion
+# Inspiroy H610Pro v2
+#
+# sysinfo.fcHjk6pvOB.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/630
+
+[Device]
+Name=HUION Inspiroy H610Pro v2
+ModelName=Inspiroy H610Pro v2
+DeviceMatch=usb|256c|006d||HUION_T184
+Width=10
+Height=6
+Layout=huion-h610-pro.svg
+Styli=@generic-no-eraser;
+IntegratedIn=
+
+[Features]
+NumStrips=0
+NumRings=0
+Reversible=true
+Stylus=true
+Touch=false
+TouchSwitch=false
+
+[Buttons]
+Left=A;B;C;D;E;F;G;H
+EvdevCodes=BTN_0;BTN_1;BTN_2;BTN_3;BTN_4;BTN_5;BTN_6;BTN_7


### PR DESCRIPTION
Associated udev rules.

/etc/udev/rules.d/99-huion-h610pro-v2.rules 
```
# Huion Inspiroy H610Pro v2: prevent touch strip and dial from appearing as tablets
SUBSYSTEM=="input", ATTRS{idVendor}=="256c", ATTRS{idProduct}=="006d", ATTR{device/name}=="HUION Huion Tablet Touch Strip", ENV{ID_INPUT_TABLET}=""
SUBSYSTEM=="input", ATTRS{idVendor}=="256c", ATTRS{idProduct}=="006d", ATTR{device/name}=="HUION Huion Tablet Dial", ENV{ID_INPUT_TABLET}=""
```