### PR TITLE
test: add libc.so.6.1 as libc SONAME

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -67,8 +67,8 @@ class GlibC:
 
     @staticmethod
     def _cdll():
-        # BSD has 7, Linux has 6
-        for libc in ("libc.so.6", "libc.so.7"):
+        # BSD has 7, Linux has 6, Linux/alpha has 6.1
+        for libc in ("libc.so.6", "libc.so.7", "libc.so.6.1"):
             try:
                 return ctypes.CDLL(libc, use_errno=True)
             except OSError:


### PR DESCRIPTION
GNU libc on Linux/alpha and Linux/ia64 has `libc.so.6.1` as SONAME; hence, add it to the list of the libc to find.