### PR TITLE
Create isdv4-53db.tablet

### DIFF
--- a/data/isdv4-53db.tablet
+++ b/data/isdv4-53db.tablet
@@ -1,0 +1,19 @@
+# Wacom HID 53DB Pen & Touch
+# Combined Sensor panel found in Lenovo IdeaPad 5 2-in-1 14IRH9
+#
+# evemu-describe string:
+# I: 0018 056a 53db 0100
+
+[Device]
+Name=Wacom HID 53DB Pen
+DeviceMatch=i2c:056a:53db;
+Class=ISDV4
+Width=301
+Height=188
+IntegratedIn=Display;System
+Styli=@isdv4-aes;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
Adds a tablet definition file for the integrated Wacom HID 53DB 
digitizer panel found on the Lenovo IdeaPad 5 2-in-1 14IRH9 laptop.

Specs verified locally using evemu-describe tracking tools.