### PR TITLE
Add support for Lenovo IdeaPad 5 14AHP9 83DR (Wacom HID 53BB)

### DIFF
--- a/data/wacom-hid-53bb-pen.tablet
+++ b/data/wacom-hid-53bb-pen.tablet
@@ -1,0 +1,21 @@
+# Lenovo IdeaPad 5-14AHP9
+# Pen: Wacom HID 53BB Pen
+# Screen: Touchscreen 14", 1920x1200
+# Features: Stylus (1 button, eraser-invert), Touchscreen
+#
+# sysinfo.WlvlvxLwpX.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/636
+
+[Device]
+Name=Wacom HID 53BB Pen
+Class=ISDV4
+DeviceMatch=i2c|056a|53bb
+Width=300
+Height=190
+IntegratedIn=Display;System
+Styli=@isdv4-aes;
+
+[Features]
+Stylus=true
+Touch=true
+Buttons=0


### PR DESCRIPTION
Added support for the Wacom HID 53BB in the Lenovo IdeaPad 5 2-in-1 14AHP9
Pretty sure its the same device as the one from https://github.com/linuxwacom/libwacom/pull/950
It seems there were quite a couple mistakes on the pr by @sperdev54 so i verified everything with my own hardware