### PR TITLE
data: add USB PID 006d to Huion HS610

### DIFF
--- a/data/huion-hs610.tablet
+++ b/data/huion-hs610.tablet
@@ -5,7 +5,7 @@
 [Device]
 Name=Huion HS610
 ModelName=HS610
-DeviceMatch=usb|256c|0064||HUION_T194
+DeviceMatch=usb|256c|0064||HUION_T194;usb|256c|006d||HUION_T194
 Width=254
 Height=152
 Layout=huion-hs610.svg


### PR DESCRIPTION
Some HS610 units enumerate as `256c:006d` rather than `256c:0064`. On those units the existing match misses, and the device falls through to `huion-h1060p.tablet`'s generic-name match `usb|256c|006d|HUION Huion Tablet Pen` — so an HS610 is reported as an H1060P, with the wrong pad layout.

This is the fix already identified by @BigBoyBarney in #914 and confirmed working there; it just never got opened as a PR.

### Measured on an affected unit

Kernel 7.1.3, libwacom 2.19.0, Fedora 44.

```
$ lsusb | grep 256c
Bus 003 Device 032: ID 256c:006d HUION Huion Tablet
```

All four nodes report the same firmware family, so only the PID differs:

```
input84 event23 name='HUION Huion Tablet Pen'        uniq='HUION_T194_190307'
input85 event24 name='HUION Huion Tablet Pad'        uniq='HUION_T194_190307'
input86 event25 name='HUION Huion Tablet Touch Ring' uniq='HUION_T194_190307'
input87 event26 name='HUION Huion Tablet Dial'       uniq='HUION_T194_190307'
```

### Before

```
$ libwacom-list-local-devices
/dev/input/event26 (usb:256c:006d - "HUION Huion Tablet Dial") is a tablet but not supported by libwacom
/dev/input/event25 (usb:256c:006d - "HUION Huion Tablet Touch Ring") is a tablet but not supported by libwacom
devices:
  - name: 'HUION H1060P Tablet'
```

### After

```
$ libwacom-list-local-devices
devices:
  - name: 'Huion HS610'
    bus: 'usb'
    vid: 0x256c
    pid: 0x006d
    nodes:
      - /dev/input/event26: 'HUION Huion Tablet Dial'
      - /dev/input/event25: 'HUION Huion Tablet Touch Ring'
      - /dev/input/event24: 'HUION Huion Tablet Pad'
      - /dev/input/event23: 'HUION Huion Tablet Pen'
```

The `0064` match is retained, since units reporting that PID presumably exist.

Note this only addresses model identification and pad button mapping. Per @whot's comment in #914, the ring still won't work, because uclogic splits pad/ring/dial across separate event nodes and libinput expects them on one — that needs udev-hid-bpf and is out of scope here.

Closes #914