### PR TITLE
CI: add merge_group trigger to workflow files

### DIFF
--- a/.github/workflows/check-for-sysinfo.yml
+++ b/.github/workflows/check-for-sysinfo.yml
@@ -1,6 +1,6 @@
 name: "Check for sysinfo in data files"
 
-on: [ pull_request ]
+on: [ pull_request, merge_group ]
 
 permissions:
   contents: read

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,6 +1,6 @@
 name: "FreeBSD build and test"
 
-on: [ push, pull_request ]
+on: [ push, pull_request, merge_group ]
 
 permissions:
   contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: "Build and test"
 
-on: [ push, pull_request ]
+on: [ push, pull_request, merge_group ]
 
 permissions:
   contents: read

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,6 +1,6 @@
 name: "Coding style"
 
-on: [ push, pull_request ]
+on: [ push, pull_request, merge_group ]
 
 permissions:
   contents: read


### PR DESCRIPTION
Add the merge_group event trigger to all CI workflows that gate merges: main.yml, freebsd.yml, style.yml, and check-for-sysinfo.yml.

This ensures the CI runs (and must pass) when a PR enters the merge queue, preventing broken commits from being merged.

Assisted-by: Claude:claude-opus-4-6