### PR TITLE
Add support for ISDv4 526b (Lenovo ThinkBook 14s Yoga ITL)

### DIFF
--- a/data/wacom-isdv4-526b.tablet
+++ b/data/wacom-isdv4-526b.tablet
@@ -1,0 +1,21 @@
+# Lenovo ThinkBook 14s Yoga ITL
+# Sensor Type: AES
+# Features: Touch (Integrated), Tilt
+# HW Resolution: 30931 x 17399 (2540 x 2540 lpi)
+#
+# Manually created; copied from wacom-isdv4-526a; Tarball: sysinfo.EKNM3yvMma.tar.gz
+# https://github.com/linuxwacom/wacom-hid-descriptors/issues/640
+
+[Device]
+Name=ISDv4 526b
+ModelName=
+DeviceMatch=i2c|056a|526b
+Class=ISDV4
+Width=305
+Height=178
+IntegratedIn=Display;System
+Styli=@isdv4-aes;
+
+[Features]
+Stylus=true
+Touch=true


### PR DESCRIPTION
Another variant of the wacom 526 integrated tablet;
we now have 526a, 526b, and 526c with the same .tablet files